### PR TITLE
Fix reversed getLength and getText examples

### DIFF
--- a/docs/editor/api.md
+++ b/docs/editor/api.md
@@ -63,7 +63,7 @@ Retrieves the string contents of the editor.
 **Examples**
 
 {% highlight javascript %}
-var length = editor.getLength();
+var length = editor.getText(0, 10);
 {% endhighlight %}
 
 
@@ -82,7 +82,7 @@ Retrieves the length of the editor contents.
 **Examples**
 
 {% highlight javascript %}
-var text = editor.getText(0, 10);
+var text = editor.getLength();
 {% endhighlight %}
 
 


### PR DESCRIPTION
Title says it all. The getLength and getText api examples are swapped, this is to correct that.
