### PR TITLE
Add a Markup Editor toolbar button

### DIFF
--- a/src/modules/markup-tooltip.coffee
+++ b/src/modules/markup-tooltip.coffee
@@ -1,0 +1,62 @@
+_       = require('lodash')
+DOM     = require('../dom')
+Tooltip = require('./tooltip')
+
+class MarkupTooltip extends Tooltip
+  @DEFAULTS:
+    styles:
+      '.markup-tooltip-container':
+        'margin': '25px'
+        'padding': '10px'
+        'width': '500px'
+      '.markup-tooltip-container:after':
+        'clear': 'both'
+        'content': '""'
+        'display': 'table'
+      '.markup-tooltip-container .input':
+        'font-family': 'Courier New'
+        'font-weight': 'bold'
+        'height': '250px'
+        'box-sizing': 'border-box'
+        'width': '100%'
+      '.markup-tooltip-container a':
+        'border': '1px solid black'
+        'box-sizing': 'border-box'
+        'display': 'inline-block'
+        'float': 'left'
+        'padding': '5px'
+        'text-align': 'center'
+        'width': '50%'
+    template:
+     '<div class="markup-editor">
+        <textarea class="input"></textarea>
+      </div>
+      <a href="javascript:;" class="cancel">Cancel</a>
+      <a href="javascript:;" class="update">Insert</a>'
+
+  constructor: (@quill, @options) ->
+    @options.styles = _.defaults(@options.styles, Tooltip.DEFAULTS.styles)
+    @options = _.defaults(@options, Tooltip.DEFAULTS)
+    super(@quill, @options)
+    @textbox = @container.querySelector('.input')
+    DOM.addClass(@container, 'markup-tooltip-container')
+    this.initListeners()
+
+  initListeners: ->
+    DOM.addEventListener(@container.querySelector('.update'), 'click', _.bind(this.updateMarkup, this))
+    DOM.addEventListener(@container.querySelector('.cancel'), 'click', _.bind(this.hide, this))
+    # this.initTextbox(@textbox, this.updateMarkup, this.hide)
+    @quill.onModuleLoad('toolbar', (toolbar) =>
+      toolbar.initFormat('markup', _.bind(this._onToolbar, this))
+    )
+
+  updateMarkup: ->
+    @quill.setHTML(@textbox.value, Quill.sources.SILENT)
+    this.hide()
+
+  _onToolbar: (range, value) ->
+    @textbox.value = @quill.getHTML();
+    this.show()
+    @textbox.focus()
+
+module.exports = MarkupTooltip

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -8,10 +8,10 @@ class Toolbar
     container: null
 
   @formats:
-    BUTTON  : { 'bold', 'image', 'italic', 'link', 'strike', 'underline' }
+    BUTTON  : { 'bold', 'image', 'italic', 'link', 'markup', 'strike', 'underline' }
     LINE    : { 'align' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOOLTIP : { 'image', 'link' }
+    TOOLTIP : { 'image', 'link', 'markup' }
 
   constructor: (@quill, @options) ->
     throw new Error('container required for toolbar', @options) unless @options.container?

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -13,6 +13,7 @@ Modules =
   ImageTooltip  : require('./modules/image-tooltip')
   Keyboard      : require('./modules/keyboard')
   LinkTooltip   : require('./modules/link-tooltip')
+  MarkupTooltip : require('./modules/markup-tooltip')
   MultiCursor   : require('./modules/multi-cursor')
   PasteManager  : require('./modules/paste-manager')
   Toolbar       : require('./modules/toolbar')

--- a/test/quill.coffee
+++ b/test/quill.coffee
@@ -23,6 +23,7 @@ Quill.Module =
   Keyboard      : require('../src/modules/keyboard')
   ImageTooltip  : require('../src/modules/image-tooltip')
   LinkTooltip   : require('../src/modules/link-tooltip')
+  MarkupTooltip : require('../src/modules/markup-tooltip')
   MultiCursor   : require('../src/modules/multi-cursor')
   PasteManager  : require('../src/modules/paste-manager')
   Toolbar       : require('../src/modules/toolbar')


### PR DESCRIPTION
Hope this falls in-line with the types of features you're looking to implement. Editing raw HTML has been a invaluable feature for editors I've used in the past and is a requirement for me to use quill.

There are a couple problems I'm currently blocked on:
- I was unable to figure out how to get a icon for the toolbar
- I didn't see any obvious unit tests for custom `Tooltip` objects.
  Let me know if you have any recommendations on how to approach these two issues.

Also, I think it would be helpful to include something along the lines of [behave.js](https://github.com/jakiestfu/Behave.js). I didn't want to introduce that dependency, so the markup is currently unformatted.
