### PR TITLE
Support for batch formatting to improve speed

### DIFF
--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -122,7 +122,8 @@ class Quill extends EventEmitter2
       endLength: Number.MAX_VALUE
 
     for params in paramArray
-      [start, end, formats, source] = this._buildParams.apply(this, params)
+      # apply cannot be used due to quirks in IE 9
+      [start, end, formats, source] = this._buildParams(params[0], params[1], params[2], params[3], params[4])
       return unless end > start
       formats = _.reduce(formats, (formats, value, name) =>
         format = @editor.doc.formats[name]


### PR DESCRIPTION
Hello,

I noticed that massive formatting of text tends to get rather slow when the text gets a little bit longer.
Small example: When formatting every word in a 2000-character text it takes approx. 2000 ms.

I added a batchFormatText method which takes an array of the parameters which get usually passed to formatText. For every element a delta is computed. These deltas get merged into one object which will be applied.
It is rather hacky since I tinker with the **proto** attribute. And I think I handled the startLength and endLength properties wrong (what's the purpose of those?). But it seems to work and the tests pass (at least locally).

To cut a long story short: The performance gain is a factor of 4 (2000-character take 500 ms, now). It is still rather slow but better than nothing. Maybe somebody gets inspired by this and has further ideas on how to improve the performance.

Thanks
