### PR TITLE
Add `browserify.transform` field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "browserify": {
     "transform": ["coffeeify"]
   },
+  "main": "index.coffee",
   "devDependencies": {
     "async": "~0.6.2",
     "coffeeify": "~0.6.0",


### PR DESCRIPTION
So that `quill` can be browserified from the command-line after a simple `npm install quilljs` command.

See: http://stackoverflow.com/a/16113666/376773

So now a user can `npm install quilljs`, and then given a file `t.js` do something like this:

``` js
var Quill = require('quilljs');

var editor = new Quill('#editor');
editor.addModule('toolbar', { container: '#toolbar' });
```

And then ultimately compile it via browserify like this:

``` bash
$ browserify --extension=".coffee" t.js > bundle.js
```
