### PR TITLE
fix for changing links in tooltip #113

### DIFF
--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -59,7 +59,7 @@ class LinkTooltip extends Tooltip
         anchor = this._findAnchor(@range)
         anchor.href = url if anchor?
       else
-        @quill.formatText(@range, 'link', url, 'user') if @range?
+        @quill.formatText(@range, 'link', url, 'user')
     this.setMode(url, false)
 
   setMode: (url, edit = false) ->


### PR DESCRIPTION
Fixes cross browser bug in #113. Allows links to be changed using the tooltip.
