### PR TITLE
Option to use iframe or not

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -8,8 +8,8 @@ Tandem     = require('tandem-core')
 
 
 class Editor
-  constructor: (@iframeContainer, @quill, @options = {}) ->
-    @renderer = new Renderer(@iframeContainer, @options)
+  constructor: (@container, @quill, @options = {}) ->
+    @renderer = new Renderer(@container, @options)
     @root = @renderer.root
     @doc = new Document(@root, @options)
     @delta = @doc.toDelta()
@@ -47,7 +47,7 @@ class Editor
       @quill.emit(@quill.constructor.events.TEXT_CHANGE, localDelta, 'user')
 
   checkUpdate: (source = 'user') ->
-    return clearInterval(@timer) if !@renderer.iframe.parentNode? or !@root.parentNode?
+    return clearInterval(@timer) if @renderer.detached()
     delta = this._update()
     if delta
       oldDelta = @delta

--- a/src/core/renderer.coffee
+++ b/src/core/renderer.coffee
@@ -70,11 +70,21 @@ class Renderer
     iframeDoc.body.appendChild(root)
     return [root, iframe]
 
+  @buildRoot: (container) ->
+    root = container.ownerDocument.createElement('div')
+    container.appendChild(root)
+    return root
+
   constructor: (@container, @options = {}) ->
     @container.innerHTML = ''
-    [@root, @iframe] = Renderer.buildFrame(@container)
+
+    if @options.useIFrame
+      [@root, @iframe] = Renderer.buildFrame(@container)
+      @iframe.setAttribute('name', @options.id)
+    else
+      @root = Renderer.buildRoot(@container)
+
     @root.setAttribute('id', @options.id)
-    @iframe.setAttribute('name', @options.id)
     dom(@root).addClass('editor-container')
     dom(@container).addClass('ql-container')
     dom(@container).on('focus', =>
@@ -89,6 +99,9 @@ class Renderer
     this.addStyles(DEFAULT_STYLES)
     # Ensure user specified styles are added after modules'
     _.defer(_.bind(this.addStyles, this, @options.styles)) if @options.styles?
+
+  detached: ->
+    (@iframe and !@iframe.parentNode?) or !@root.parentNode
 
   addContainer: (className, before = false) ->
     refNode = if before then @root else null

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -24,6 +24,7 @@ class Quill extends EventEmitter2
     pollInterval: 100
     readOnly: false
     theme: 'default'
+    useIFrame: true
 
   @events:
     MODULE_INIT      : 'module-init'

--- a/test/unit/core/quill.coffee
+++ b/test/unit/core/quill.coffee
@@ -13,7 +13,7 @@ describe('Quill', ->
     it('string container', ->
       @container.innerHTML = '<div id="target"></div>'
       quill = new Quill('#target')
-      expect(quill.editor.iframeContainer).toEqual(@container.firstChild)
+      expect(quill.editor.container).toEqual(@container.firstChild)
     )
 
     it('invalid container', ->

--- a/test/unit/core/renderer.coffee
+++ b/test/unit/core/renderer.coffee
@@ -24,8 +24,21 @@ describe('Renderer', ->
     expect(root.innerHTML).toEqual('')
   )
 
+  it('buildRoot()', ->
+    root = Quill.Renderer.buildRoot(@container)
+    expect(@container.querySelectorAll('iframe').length).toEqual(0)
+    expect(@container.firstChild).toEqual(root)
+    expect(root.innerHTML).toEqual('')
+  )
+
   it('constructor', ->
     renderer = new Quill.Renderer(@container)
+    expect(@container.querySelectorAll('iframe').length).toEqual(0)
+    expect(renderer.root.id).not.toBe(null)
+  )
+
+  it('constructor with useIFrame', ->
+    renderer = new Quill.Renderer(@container, useIFrame: true)
     expect(@container.querySelectorAll('iframe').length).toEqual(1)
     expect(renderer.root.id).not.toBe(null)
   )
@@ -39,6 +52,20 @@ describe('Renderer', ->
       expect(renderer.root.firstChild.offsetHeight).toEqual(25)
       done()
     )
+  )
+
+  it('detached() with iframe', ->
+    renderer = new Quill.Renderer(@container, useIFrame: true)
+    expect(renderer.detached()).toBe(false)
+    renderer.iframe.parentNode.removeChild(renderer.iframe)
+    expect(renderer.detached()).toBe(true)
+  )
+
+  it('detached() without iframe', ->
+    renderer = new Quill.Renderer(@container)
+    expect(renderer.detached()).toBe(false)
+    renderer.root.parentNode.removeChild(renderer.root)
+    expect(renderer.detached()).toBe(true)
   )
 
   it('addStyles() object', (done) ->


### PR DESCRIPTION
This basically addresses https://github.com/quilljs/quill/issues/179.

Two things are pending for this PR to be ready:
1. We need to figure out what to do with the default styles. I think a css file would be better than creating style tags, especially when you don't want to use an iframe, and those styles will conflict with the ones in your page.
   Where I'm using this, I'm making the `addStyles` method a noop, and moved all the defaults to a .css file which I can then customize or override.
2. I can't find a way to run the e2e tests. When I run `grunt test:e2e`, the tests start to run but I get a `NoSuchFrameError` when protractor attempts to switch between frames. This is also happening to me in `develop` branch. Any ideas?
