### PR TITLE
Fix removing format for line formats without parentTag

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -145,8 +145,9 @@ class Format
       node.removeAttribute('class') unless node.getAttribute('class')  # Some browsers leave empty style attribute
     if _.isString(@config.tag)
       if this.isType(Format.types.LINE)
-        dom(node).splitAncestors(node.parentNode.parentNode) if node.previousSibling?
-        dom(node.nextSibling).splitAncestors(node.parentNode.parentNode) if node.nextSibling?
+        if @config.parentTag
+          dom(node).splitAncestors(node.parentNode.parentNode) if node.previousSibling?
+          dom(node.nextSibling).splitAncestors(node.parentNode.parentNode) if node.nextSibling?
         node = dom(node).switchTag(dom.DEFAULT_BLOCK_TAG)
       else
         node = dom(node).switchTag(dom.DEFAULT_INLINE_TAG)

--- a/test/unit/core/format.coffee
+++ b/test/unit/core/format.coffee
@@ -196,4 +196,12 @@ describe('Format', ->
     format.remove(li)
     expect(@container).toEqualHTML('<ul><li>One</li></ul><div>Two</div><ul><li>Three</li></ul>')
   )
+
+  it('headers', ->
+    @container.innerHTML = '<div>One</div><h1>Two</h1><div>Three</div>'
+    format = new Quill.Format(document, type: Quill.Format.types.LINE, tag: 'H1')
+    line = @container.childNodes[1]
+    format.remove(line)
+    expect(@container).toEqualHTML('<div>One</div><div>Two</div><div>Three</div>')
+  )
 )


### PR DESCRIPTION
This is to allow to create formats for headers, which are line formats without a parentTag.

Please let me know if there are other concerns I missed with this fix!
