### PR TITLE
destroy() method for Quill instances

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -19,6 +19,9 @@ class Editor
     @timer = setInterval(_.bind(this.checkUpdate, this), @options.pollInterval)
     this.enable() unless @options.readOnly
 
+  destroy: ->
+    clearInterval(@timer)
+
   disable: ->
     this.enable(false)
 

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -73,6 +73,16 @@ class Quill extends EventEmitter2
       this.addModule(name, option)
     )
 
+  destroy: ->
+    html = this.getHTML()
+    _.each(@modules, (module, name) ->
+      module.destroy() if _.isFunction(module.destroy)
+    )
+    @editor.destroy()
+    this.removeAllListeners()
+    Quill.editors.splice(_.indexOf(Quill.editors, this), 1)
+    @container.innerHTML = html
+
   addContainer: (className, before = false) ->
     refNode = if before then @root else null
     container = document.createElement('div')

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -1,10 +1,13 @@
 describe('Editor', ->
   beforeEach( ->
-    resetContainer()
-    @container = $('#test-container').html('<div></div>').get(0)
-    Quill.Lib.EventEmitter2.events = Quill.events
-    emitter = new Quill.Lib.EventEmitter2
-    @editor = new Quill.Editor(@container.firstChild, emitter, { formats: Quill.DEFAULTS.formats })
+    @createEditor = (options) ->
+      resetContainer()
+      @container = $('#test-container').html('<div></div>').get(0)
+      Quill.Lib.EventEmitter2.events = Quill.events
+      emitter = new Quill.Lib.EventEmitter2
+      @editor = new Quill.Editor(@container.firstChild, emitter, options)
+
+    @createEditor({ formats: Quill.DEFAULTS.formats })
   )
 
   describe('_deleteAt()', ->
@@ -243,6 +246,28 @@ describe('Editor', ->
       @editor.applyDelta(delta)
       expected = '<div>01a23|</div>'
       expect(@editor.root).toEqualHTML(expected, true)
+    )
+  )
+
+  describe('destroy()', ->
+    beforeEach( ->
+      jasmine.clock().install()
+      # Mock checkUpdate() before creating the editor because it is bound
+      # in the constructor.
+      spyOn(Quill.Editor.prototype, 'checkUpdate')
+
+      @createEditor({ formats: Quill.DEFAULTS.formats, pollInterval: 100 })
+
+      @editor.destroy()
+    )
+
+    afterEach( ->
+      jasmine.clock().uninstall()
+    )
+
+    it('clears the update timer', ->
+      jasmine.clock().tick(5 * @editor.options.pollInterval)
+      expect(@editor.checkUpdate).not.toHaveBeenCalled()
     )
   )
 )

--- a/test/unit/core/quill.coffee
+++ b/test/unit/core/quill.coffee
@@ -199,4 +199,56 @@ describe('Quill', ->
       expect(source).toEqual('silent')
     )
   )
+
+  describe('destroy()', ->
+    htmlBeforeDestroying = null
+
+    beforeEach( ->
+      spyOn(@quill.editor, 'destroy')
+
+      Destroyable = ->
+        @destroy = jasmine.createSpy('destroy')
+        undefined
+
+      Quill.registerModule('destroyable', Destroyable)
+
+      @quill.addModule('destroyable')
+
+      @listener = jasmine.createSpy('listener')
+      @quill.on('some event', @listener)
+
+      @quill.insertText(0, 'Hello world!')
+      htmlBeforeDestroying = @quill.getHTML()
+
+      @quill.destroy()
+    )
+
+    afterEach( ->
+      delete Quill.modules.destroyable
+    )
+
+    it('destroys the editor', ->
+      expect(@quill.editor.destroy).toHaveBeenCalled()
+    )
+
+    it('sets the container innerHTML with the current editor html', ->
+      expect(@quill.container.innerHTML).toEqual(htmlBeforeDestroying)
+    )
+
+    it('removes the editor from the global list', ->
+      expect(Quill.editors.indexOf(@quill)).toEqual(-1)
+    )
+
+    it('destroys all modules that have a destroy() method', ->
+      _.each(@quill.modules, (module, name) ->
+        if _.isFunction(module.destroy)
+          expect(module.destroy).toHaveBeenCalled()
+      )
+    )
+
+    it('removes all listeners', ->
+      @quill.emit('some event')
+      expect(@listener).not.toHaveBeenCalled()
+    )
+  )
 )


### PR DESCRIPTION
This PR tackles #138.

This is the core `destroy` implementation, it still doesn't clean up modules, but as you can see it will call the `destroy` method on them if they define it.
I've reached a point where we need to define a couple of things.
First, we need to decide what the state of the container must be like after destroying. Should we empty it? Should we reset it to the original html? Should we leave the html as it was at the moment of destroying?
Second, you will notice that I still have a commented test that verifies that we're removing the "focus" event listener on the iframe container in the `Editor`. Since there is no `off` method implemented in the `dom` util, we need to have something for this. I have two ideas:
1. Implement `off` by tracking the real listener and the wrapped listener in the `Wrapper` class, and calling `removeEventListener` with the same function that `addEventListener` was called with. For this to work we need to use the same instance of the `Wrapper` class, so things like `dom(elem).on('focus', something); dom(elem).off('focus', something)` won't work.
2. Change the `on` method to return a function that will remove the listener, instead of returning the `Wrapper` instance. This is very helpful since you don't need to store all the listeners in a separate variable in order to reference the same function when calling `off`. Here, `off` will be called by you with the correct listener when you call the returning function from `on`. Also, I think there are no cases of `on` being chained with other methods, so this shouldn't break existing usage.

Let me know what you think! Open to more ideas or things I've missed!
