### PR TITLE
Fixes bug in UndoManager where entering text while redo stack is not emp...

### DIFF
--- a/src/modules/undo-manager.coffee
+++ b/src/modules/undo-manager.coffee
@@ -95,7 +95,7 @@ class UndoManager
       @emittedDelta = null
       index = this._getLastChangeIndex(change[source])
       @quill.setSelection(index, index)
-      @oldDelta = @quill.getContents();
+      @oldDelta = @quill.getContents()
       @stack[dest].push(change)
 
 


### PR DESCRIPTION
...ty causes error. The error is caught in record and therefore the undo and redo stacks are cleared. The error specifically occurs because the 'oldDelta' does not match the editor state, and more specifically when that means the oldDelta lengths are incorrect. This change causes the oldDelta to be updated whenever the UndoManager has an undo or redo triggered. Related to https://github.com/quilljs/quill/issues/229
