### PR TITLE
Do not modify argument to setContents()

### DIFF
--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -171,7 +171,9 @@ class Quill extends EventEmitter2
 
   setContents: (delta, source = Quill.sources.API) ->
     if Array.isArray(delta)
-      delta = { ops: delta }
+      delta = { ops: delta.slice() }
+    else
+      delta = { ops: delta.ops.slice() }
     delta.ops.unshift({ delete: this.getLength() })
     this.updateContents(delta, source)
 

--- a/test/unit/core/quill.coffee
+++ b/test/unit/core/quill.coffee
@@ -90,15 +90,21 @@ describe('Quill', ->
     )
 
     it('setContents() with delta', ->
-      @quill.setContents({
+      delta = {
+        ops: [{ insert: 'A', attributes: { bold: true } }]
+      }
+      @quill.setContents(delta)
+      expect(@quill.root).toEqualHTML('<div><b>A</b></div>', true)
+      expect(delta).toEqual({
         ops: [{ insert: 'A', attributes: { bold: true } }]
       })
-      expect(@quill.root).toEqualHTML('<div><b>A</b></div>', true)
     )
 
     it('setContents() with ops', ->
-      @quill.setContents([{ insert: 'A', attributes: { bold: true } }])
+      ops = [{ insert: 'A', attributes: { bold: true } }]
+      @quill.setContents(ops)
       expect(@quill.root).toEqualHTML('<div><b>A</b></div>', true)
+      expect(ops).toEqual([{ insert: 'A', attributes: { bold: true } }])
     )
 
     it('setHTML()', ->


### PR DESCRIPTION
I noticed in my app that the argument I pass to `quill.setContents(delta)` gets modified in place (a delete operation is prepended).

This uses `slice()` to ensure that the unshift operation happens on a copy of the array.
