### PR TITLE
Ignore unknown formats present in the delta but not configured for the doc

### DIFF
--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -71,6 +71,7 @@ class Line extends LinkedList.Node
       formats[name] = value
     _.each(formats, (value, name) =>
       format = @doc.formats[name]
+      return unless format?
       # TODO reassigning @node might be dangerous...
       if format.isType(Format.types.LINE)
         if format.config.exclude and @formats[format.config.exclude]
@@ -120,7 +121,9 @@ class Line extends LinkedList.Node
       this.resetContent()
     else
       node = _.reduce(formats, (node, value, name) =>
-        return @doc.formats[name].add(node, value)
+        format = @doc.formats[name]
+        node = format.add(node, value) if format?
+        return node
       , document.createTextNode(text))
       [prevNode, nextNode] = dom(leaf.node).split(leafOffset)
       nextNode = dom(nextNode).splitAncestors(@node).get() if nextNode


### PR DESCRIPTION
Allow formats to be present in a delta (such as `{ author: 1 }`), but not configured on the quill instance (e.g. you didn't enable the authorship module).

This allows for a single rich-text document to be used in different contexts, with different quill options and modules, without breaking.
