### PR TITLE
Use alternative method to determine when scrollIntoView() is required upon paste

### DIFF
--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -28,9 +28,9 @@ class PasteManager
       @quill.setSelection(range.start + lengthAdded, range.start + lengthAdded)
       # Make sure bottom of pasted content is visible
       [line, offset] = @quill.editor.doc.findLineAt(range.start + lengthAdded)
-      lineBottom = line.node.offsetTop + line.node.offsetHeight
-      editorBottom = @quill.container.scrollTop + @quill.container.offsetHeight
-      line.node.scrollIntoView(false) if lineBottom > editorBottom
+      lineBottom = line.node.getBoundingClientRect().bottom
+      windowBottom = document.documentElement.clientHeight
+      line.node.scrollIntoView(false) if lineBottom > windowBottom
     )
 
 


### PR DESCRIPTION
Measuring the height + scroll position of `@quill.container` is no longer sufficient, as the container can now expand to hold its contents without an internal scroll bar (container is no longer an iframe).

Change the check to be relative to the viewport by using `getBoundingClientRect()` and `document.documentElement.clientHeight`.
