### PR TITLE
Add a remove button to the link tooltip

### DIFF
--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -44,6 +44,7 @@ class LinkTooltip extends Tooltip
     )
     this.initTextbox(@textbox, this.saveLink, this.hide)
     @quill.onModuleLoad('toolbar', (toolbar) =>
+      @toolbar = toolbar
       toolbar.initFormat('link', _.bind(this._onToolbar, this))
     )
 
@@ -62,6 +63,7 @@ class LinkTooltip extends Tooltip
     if range.isCollapsed()
       range = this._expandRange(range)
     @quill.formatText(range, 'link', false, 'user')
+    @toolbar.setActive('link', false) if @toolbar?
 
   setMode: (url, edit = false) ->
     if edit

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -95,7 +95,6 @@ class LinkTooltip extends Tooltip
 
   _onToolbar: (range, value) ->
     return unless range
-
     if value and !range.isCollapsed()
       this.setMode(this._suggestURL(range), true)
       nativeRange = @quill.editor.selection._getNativeRange()

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -60,10 +60,7 @@ class LinkTooltip extends Tooltip
   removeLink: (range) ->
     # Expand range to the entire leaf
     if range.isCollapsed()
-      [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
-      range =
-        start: range.start - offset
-        end: range.start - offset + leaf.length
+      range = this._expandRange(range)
     @quill.formatText(range, 'link', false, 'user')
 
   setMode: (url, edit = false) ->
@@ -87,6 +84,12 @@ class LinkTooltip extends Tooltip
       return node if node.tagName == 'A'
       node = node.parentNode
     return null
+
+  _expandRange: (range) ->
+    [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
+    start = range.start - offset
+    end = start + leaf.length
+    return { start, end }
 
   _onToolbar: (range, value) ->
     return unless range

--- a/src/modules/link-tooltip.coffee
+++ b/src/modules/link-tooltip.coffee
@@ -13,6 +13,7 @@ class LinkTooltip extends Tooltip
       <input class="input" type="text">
       <span>&nbsp;&#45;&nbsp;</span>
       <a href="javascript:;" class="change">Change</a>
+      <a href="javascript:;" class="remove">Remove</a>
       <a href="javascript:;" class="done">Done</a>'
 
   constructor: (@quill, @options) ->
@@ -35,6 +36,9 @@ class LinkTooltip extends Tooltip
         this.hide()
     )
     dom(@container.querySelector('.done')).on('click', _.bind(this.saveLink, this))
+    dom(@container.querySelector('.remove')).on('click', =>
+      this.removeLink(@range)
+    )
     dom(@container.querySelector('.change')).on('click', =>
       this.setMode(@link.href, true)
     )
@@ -52,6 +56,15 @@ class LinkTooltip extends Tooltip
       else
         @quill.formatText(@range, 'link', url, 'user')
     this.setMode(url, false)
+
+  removeLink: (range) ->
+    # Expand range to the entire leaf
+    if range.isCollapsed()
+      [leaf, offset] = @quill.editor.doc.findLeafAt(range.start, true)
+      range =
+        start: range.start - offset
+        end: range.start - offset + leaf.length
+    @quill.formatText(range, 'link', false, 'user')
 
   setMode: (url, edit = false) ->
     if edit
@@ -76,13 +89,14 @@ class LinkTooltip extends Tooltip
     return null
 
   _onToolbar: (range, value) ->
-    return unless range and !range.isCollapsed()
-    if value
+    return unless range
+
+    if value and !range.isCollapsed()
       this.setMode(this._suggestURL(range), true)
       nativeRange = @quill.editor.selection._getNativeRange()
       this.show(nativeRange)
     else
-      @quill.formatText(range, 'link', false, 'user')
+      this.removeLink(range)
 
   _normalizeURL: (url) ->
     url = 'http://' + url unless /^(https?:\/\/|mailto:)/.test(url)

--- a/src/themes/base/modules/link-tooltip.styl
+++ b/src/themes/base/modules/link-tooltip.styl
@@ -7,5 +7,5 @@
 .ql-link-tooltip.editing
   input.input, a.done
     display: inline-block
-  a.url, a.change
+  a.url, a.change, a.remove
     display: none

--- a/src/themes/base/modules/link-tooltip.styl
+++ b/src/themes/base/modules/link-tooltip.styl
@@ -4,6 +4,8 @@
     width: 170px
   input.input, a.done
     display: none
+  a.change
+    margin-right: 4px
 .ql-link-tooltip.editing
   input.input, a.done
     display: inline-block


### PR DESCRIPTION
Uses `@quill.editor.doc.findLeafAt(range)` to expand the selection to include the entire contents of the anchor (assuming that the leaf found is the anchor). This assumption makes me kind of nervous... but I couldn't come up with a better way to do this.

Clicking the remove button in the tooltip always removes the link from the entire leaf.

Clicking the button in the WYSIWYG bar can remove the link from just the selected text (if the collection is not collapsed), otherwise it acts similarly to the tooltip remove button.