### PR TITLE
Refactor Normalizer as a class for configurable whitelists and aliases

### DIFF
--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -10,12 +10,14 @@ Normalizer = require('../lib/normalizer')
 class Document
   constructor: (@root, options = {}) ->
     @formats = {}
+    @normalizer = new Normalizer()
     _.each(options.formats, _.bind(this.addFormat, this))
     this.setHTML(@root.innerHTML)
 
   addFormat: (name, config) ->
     config = Format.FORMATS[name] unless _.isObject(config)
     console.warn('Overwriting format', name, @formats[name]) if @formats[name]?
+    @normalizer.addFormat(config)
     @formats[name] = new Format(config)
 
   appendLine: (lineNode) ->
@@ -90,7 +92,7 @@ class Document
       while line.node != lineNode
         if line.node.parentNode == @root or line.node.parentNode?.parentNode == @root
           # New line inserted
-          lineNode = Normalizer.normalizeLine(lineNode)
+          lineNode = @normalizer.normalizeLine(lineNode)
           newLine = this.insertLineBefore(lineNode, line)
           lineNode = dom(lineNode).nextLineNode(@root)
         else
@@ -98,13 +100,13 @@ class Document
           return this.removeLine(line)
       if line.outerHTML != lineNode.outerHTML
         # Existing line changed
-        line.node = Normalizer.normalizeLine(line.node)
+        line.node = @normalizer.normalizeLine(line.node)
         line.rebuild()
       lineNode = dom(lineNode).nextLineNode(@root)
     )
     # New lines appended
     while lineNode?
-      lineNode = Normalizer.normalizeLine(lineNode)
+      lineNode = @normalizer.normalizeLine(lineNode)
       this.appendLine(lineNode)
       lineNode = dom(lineNode).nextLineNode(@root)
 

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -10,10 +10,12 @@ class Format
     bold:
       tag: 'B'
       prepare: 'bold'
+      aliasTags: ['STRONG']
 
     italic:
       tag: 'I'
       prepare: 'italic'
+      aliasTags: ['EM']
 
     underline:
       tag: 'U'
@@ -22,6 +24,7 @@ class Format
     strike:
       tag: 'S'
       prepare: 'strikeThrough'
+      aliasTags: ['DEL', 'STRIKE']
 
     color:
       style: 'color'

--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -5,7 +5,6 @@ Format     = require('./format')
 Leaf       = require('./leaf')
 Line       = require('./line')
 LinkedList = require('../lib/linked-list')
-Normalizer = require('../lib/normalizer')
 
 
 class Line extends LinkedList.Node
@@ -21,7 +20,7 @@ class Line extends LinkedList.Node
 
   buildLeaves: (node, formats) ->
     _.each(dom(node).childNodes(), (node) =>
-      node = Normalizer.normalizeNode(node)
+      node = @doc.normalizer.normalizeNode(node)
       nodeFormats = _.clone(formats)
       # TODO: optimize
       _.each(@doc.formats, (format, name) ->
@@ -131,7 +130,7 @@ class Line extends LinkedList.Node
       this.rebuild()
 
   optimize: ->
-    Normalizer.optimizeLine(@node)
+    @doc.normalizer.optimizeLine(@node)
     this.rebuild()
 
   rebuild: (force = false) ->
@@ -140,7 +139,7 @@ class Line extends LinkedList.Node
         return dom(leaf.node).isAncestor(@node)
       )
         return false
-    @node = Normalizer.normalizeNode(@node)
+    @node = @doc.normalizer.normalizeNode(@node)
     if dom(@node).length() == 0 and !@node.querySelector(dom.DEFAULT_BREAK_TAG)
       @node.appendChild(document.createElement(dom.DEFAULT_BREAK_TAG))
     @leaves = new LinkedList()

--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -1,7 +1,6 @@
 _          = require('lodash')
 dom        = require('../lib/dom')
 Leaf       = require('./leaf')
-Normalizer = require('../lib/normalizer')
 Range      = require('../lib/range')
 
 
@@ -92,7 +91,7 @@ class Selection
         offset = 0
       else if node.childNodes.length == 0
         # TODO revisit fix for encoding edge case <p><em>|</em></p>
-        unless Normalizer.TAGS[node.tagName]?
+        unless @doc.normalizer.tags[node.tagName]?
           text = document.createTextNode('')
           node.appendChild(text)
           node = text

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -6,6 +6,7 @@ dom           = require('./lib/dom')
 Editor        = require('./core/editor')
 Format        = require('./core/format')
 Range         = require('./lib/range')
+Normalizer    = require('./lib/normalizer')
 
 
 class Quill extends EventEmitter2
@@ -16,7 +17,7 @@ class Quill extends EventEmitter2
   @themes: []
 
   @DEFAULTS:
-    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
+    formats: Object.keys(Format.FORMATS)
     modules:
       'keyboard': true
       'paste-manager': true

--- a/test/unit/lib/normalizer.coffee
+++ b/test/unit/lib/normalizer.coffee
@@ -1,9 +1,10 @@
 describe('Normalizer', ->
   beforeEach( ->
     @container = $('#test-container').html('').get(0)
+    @normalizer = new Quill.Lib.Normalizer()
   )
 
-  describe('handleBreaks()', ->
+  describe('_handleBreaks()', ->
     tests =
       'Break in middle of line':
         initial:  '<div><b>One<br>Two</b></div>'
@@ -20,7 +21,7 @@ describe('Normalizer', ->
       return if test.ieOmit and Quill.Lib.DOM.isIE(10)
       it(name, ->
         @container.innerHTML = test.initial
-        lineNode = Quill.Lib.Normalizer.handleBreaks(@container.firstChild)
+        lineNode = @normalizer._handleBreaks(@container.firstChild)
         expect(@container).toEqualHTML(test.expected)
         expect(lineNode).toEqual(@container.firstChild)
       )
@@ -42,7 +43,7 @@ describe('Normalizer', ->
     _.each(tests, (test, name) ->
       it(name, ->
         @container.innerHTML = test.initial
-        lineNode = Quill.Lib.Normalizer.normalizeLine(@container.firstChild)
+        lineNode = @normalizer.normalizeLine(@container.firstChild)
         expect(@container).toEqualHTML(test.expected)
         expect(lineNode).toEqual(@container.firstChild)
       )
@@ -50,21 +51,28 @@ describe('Normalizer', ->
   )
 
   describe('normalizeNode()', ->
+    beforeEach(->
+      @normalizer.tags.B = true
+      @normalizer.aliases.STRONG = 'B'
+      @normalizer.styles.color = true
+      @normalizer.styles.fontSize = true
+    )
+
     it('whitelist style and tag', ->
       @container.innerHTML = '<strong style="color: red; display: inline;">Test</strong>'
-      Quill.Lib.Normalizer.normalizeNode(@container.firstChild)
+      @normalizer.normalizeNode(@container.firstChild)
       expect(@container).toEqualHTML('<b style="color: red;">Test</b>')
     )
 
     it('convert size attribute', ->
       @container.innerHTML = '<font size="3">Test</font>'
-      Quill.Lib.Normalizer.normalizeNode(@container.firstChild)
+      @normalizer.normalizeNode(@container.firstChild)
       expect(@container).toEqualHTML('<span style="font-size: 16px;">Test</span>')
     )
 
     it('text node', ->
       @container.innerHTML = 'Test'
-      Quill.Lib.Normalizer.normalizeNode(@container.firstChild)
+      @normalizer.normalizeNode(@container.firstChild)
       expect(@container).toEqualHTML('Test')
     )
   )
@@ -120,13 +128,13 @@ describe('Normalizer', ->
     _.each(tests, (test, name) ->
       it(name, ->
         @container.innerHTML = "<div>#{test.initial}</div>"
-        Quill.Lib.Normalizer.optimizeLine(@container.firstChild)
+        @normalizer.optimizeLine(@container.firstChild)
         expect(@container.firstChild).toEqualHTML(test.expected)
       )
     )
   )
 
-  describe('pullBlocks()', ->
+  describe('_pullBlocks()', ->
     tests =
       'No children':
         initial:  '<div></div>'
@@ -163,7 +171,7 @@ describe('Normalizer', ->
       it(name, ->
         @container.innerHTML = test.initial
         firstChild = @container.firstChild
-        Quill.Lib.Normalizer.pullBlocks(firstChild)
+        @normalizer._pullBlocks(firstChild)
         expect(@container).toEqualHTML(test.expected)
       )
     )
@@ -211,7 +219,7 @@ describe('Normalizer', ->
     )
   )
 
-  describe('whitelistStyles()', ->
+  describe('_whitelistStyles()', ->
     tests =
       'no styles':
         initial:  '<div></div>'
@@ -228,14 +236,15 @@ describe('Normalizer', ->
 
     _.each(tests, (test, name) ->
       it(name, ->
+        @normalizer.styles.color = true
         @container.innerHTML = test.initial
-        Quill.Lib.Normalizer.whitelistStyles(@container.firstChild)
+        @normalizer._whitelistStyles(@container.firstChild)
         expect(@container).toEqualHTML(test.expected)
       )
     )
   )
 
-  describe('whitelistTags()', ->
+  describe('_whitelistTags()', ->
     tests =
       'not element':
         initial:  'Test'
@@ -255,14 +264,16 @@ describe('Normalizer', ->
 
     _.each(tests, (test, name) ->
       it(name, ->
+        @normalizer.tags.B = true
+        @normalizer.aliases.STRONG = 'B'
         @container.innerHTML = test.initial
-        Quill.Lib.Normalizer.whitelistTags(@container.firstChild)
+        @normalizer._whitelistTags(@container.firstChild)
         expect(@container).toEqualHTML(test.expected)
       )
     )
   )
 
-  describe('wrapInline()', ->
+  describe('_wrapInline()', ->
     tests =
       'Wrap newline':
         initial:  ['<br>']
@@ -285,13 +296,13 @@ describe('Normalizer', ->
     _.each(tests, (test, name) ->
       it(name, ->
         @container.innerHTML = test.initial.join('')
-        Quill.Lib.Normalizer.wrapInline(@container.firstChild)
+        @normalizer._wrapInline(@container.firstChild)
         expect(@container).toEqualHTML(test.expected)
       )
     )
   )
 
-  describe('unwrapText()', ->
+  describe('_unwrapText()', ->
     tests =
       'inner text':
         initial:  '<span><span>Inner</span>Test</span>'
@@ -306,7 +317,7 @@ describe('Normalizer', ->
     _.each(tests, (test, name) ->
       it(name, ->
         @container.innerHTML = test.initial
-        Quill.Lib.Normalizer.unwrapText(@container)
+        @normalizer._unwrapText(@container)
         expect(@container).toEqualHTML(test.expected)
       )
     )


### PR DESCRIPTION
This turns Normalizer into a class that stores tag & style whitelists, and aliases.
- Document#addFormat makes sure that format tags, styles and aliases are properly added to the normalizer.
- Prefixed all the internal-only methods of the normalizer with an _.
- Added aliasTags settings to certain formats to configure the aliasing behavior.
- Normalizer.stripWhitespace and Normalizer.stripComments are kept as class methods.
- Formats specify styles as camelCase while dom#styles returns dash-separated, so a manual conversion to camelCase was added in _whitelistStyles.

I know that some module + format internals may be in flux, but for now this has helped me to add formats with new tags successfully (e.g. H1 / H2 / H3).
