### PR TITLE
hack to prevent cloning "data-reactid" attribute and avoid react error

### DIFF
--- a/src/lib/picker.coffee
+++ b/src/lib/picker.coffee
@@ -42,7 +42,8 @@ class Picker
 
   buildPicker: ->
     _.each(dom(@select).attributes(), (value, name) =>
-      @container.setAttribute(name, value)
+      if name != 'data-reactid'
+        @container.setAttribute(name, value)
     )
     @container.innerHTML = Normalizer.stripWhitespace(Picker.TEMPLATE)
     @label = @container.querySelector('.ql-picker-label')


### PR DESCRIPTION
when using quilljs with react (and a theme) the pickers get cloned and with them the "data-reactid" attribute which in turn causes a react error.. this is a quick fix 
