### PR TITLE
Fix backspace-at-index-0 behavior by ignoring negative start indices

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -50,7 +50,7 @@ class Keyboard
           @quill.deleteText(range.start, range.end, Quill.sources.USER)
         else
           start = if (hotkey.key == dom.KEYS.BACKSPACE) then range.start - 1 else range.start
-          @quill.deleteText(start, start + 1, Quill.sources.USER)
+          @quill.deleteText(start, start + 1, Quill.sources.USER) if start >= 0
       return false
     )
 


### PR DESCRIPTION
Reproducible on quilljs.com by placing cursor before first letter and hitting the 'Backspace' key.

Expected behavior: nothing happens.
Observed behavior: the first character is deleted.
