### PR TITLE
Always return a DOM node from switchTag()

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -213,7 +213,7 @@ class Wrapper
 
   switchTag: (newTag) ->
     newTag = newTag.toUpperCase()
-    return this if @node.tagName == newTag
+    return @node if @node.tagName == newTag
     newNode = document.createElement(newTag)
     attributes = this.attributes()
     this.moveChildren(newNode) unless dom.VOID_TAGS[newTag]?

--- a/test/unit/lib/dom.coffee
+++ b/test/unit/lib/dom.coffee
@@ -316,7 +316,9 @@ describe('DOM', ->
 
     it('switchTag() to same', ->
       html = @container.innerHTML
+      node = dom(@container.firstChild).switchTag('div')
       expect(@container).toEqualHTML(html)
+      expect(node).toEqual(@container.firstChild)
     )
 
     it('switchTag() to void', ->


### PR DESCRIPTION
Previous: `dom(aDiv).switchTag('div') == dom(aDiv)`
Expected: `dom(aDiv).switchTag('div') == aDiv`
