### PR TITLE
Correct docs Quill.prototype.getSelection return

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -363,7 +363,7 @@ Retrieves the user's selection range.
 
 **Returns**
 
-- *String* contents of the editor
+- *Range* contents of the editor
 
 **Examples**
 


### PR DESCRIPTION
The documentation's Quill.prototype.getSelection return type said "String", but a range is actually returned.
