### PR TITLE
Allow calling quill.updateContents() with an array

### DIFF
--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -211,6 +211,7 @@ class Quill extends EventEmitter2
     this.setContents(delta, source)
 
   updateContents: (delta, source = Quill.sources.API) ->
+    delta = { ops: delta } if Array.isArray(delta)
     @editor.applyDelta(delta, source)
 
   # fn(Number start, Number end, String name, String value, String source)


### PR DESCRIPTION
Provides consistency with the setContents() method, which currently accepts
both array and delta objects as the argument.