### PR TITLE
Use event.clipboardData to implement onpaste

### DIFF
--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -11,7 +11,7 @@ class PasteManager
     dom(@quill.root).on('paste', _.bind(this._paste, this))
 
   _paste: (event) ->
-    html = event.clipboardData.getData('text/html')
+    html = event?.clipboardData.getData('text/html')
     if html
       event.preventDefault()
       @range = @quill.getSelection()

--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -10,28 +10,36 @@ class PasteManager
     @container.setAttribute('contenteditable', true)
     dom(@quill.root).on('paste', _.bind(this._paste, this))
 
-  _paste: ->
-    oldDocLength = @quill.getLength()
-    range = @quill.getSelection()
+  _paste: (event) ->
+    html = event.clipboardData.getData('text/html')
+    if html
+      event.preventDefault()
+      @range = @quill.getSelection()
+      @container.innerHTML = html
+      this._insert()
+    else
+      @range = @quill.getSelection()
+      @container.focus()
+      _.defer(this._insert.bind(this))
+
+  _insert: () ->
+    delta = new Document(@container, @quill.options).toDelta()
+    @container.innerHTML = ""
+    range = @range
+    @range = null
     return unless range?
-    @container.focus()
-    _.defer( =>
-      doc = new Document(@container, @quill.options)
-      delta = doc.toDelta()
-      lengthAdded = delta.length() - 1
-      # Need to remove trailing newline so paste is inline, losing format is expected and observed in Word
-      delta.compose(new Delta().retain(lengthAdded).delete(1))
-      delta.ops.unshift({ retain: range.start }) if range.start > 0
-      delta.delete(range.end - range.start)
-      @quill.updateContents(delta, 'user')
-      @quill.setSelection(range.start + lengthAdded, range.start + lengthAdded)
-      # Make sure bottom of pasted content is visible
-      [line, offset] = @quill.editor.doc.findLineAt(range.start + lengthAdded)
-      lineBottom = line.node.getBoundingClientRect().bottom
-      windowBottom = document.documentElement.clientHeight
-      line.node.scrollIntoView(false) if lineBottom > windowBottom
-      @container.innerHTML = ""
-    )
+    # Need to remove trailing newline so paste is inline, losing format is expected and observed in Word
+    lengthAdded = delta.length() - 1
+    delta.compose(new Delta().retain(lengthAdded).delete(1))
+    delta.ops.unshift({ retain: range.start }) if range.start > 0
+    delta.delete(range.end - range.start)
+    @quill.updateContents(delta, 'user')
+    @quill.setSelection(range.start + lengthAdded, range.start + lengthAdded)
+    # Make sure bottom of pasted content is visible
+    [line, offset] = @quill.editor.doc.findLineAt(range.start + lengthAdded)
+    lineBottom = line.node.getBoundingClientRect().bottom
+    windowBottom = document.documentElement.clientHeight
+    line.node.scrollIntoView(false) if lineBottom > windowBottom
 
 
 Quill.registerModule('paste-manager', PasteManager)


### PR DESCRIPTION
This seems to behave better in recent versions of Firefox, where the
native behavior happens before the .ql-paste-manager div can be focused.

All recent versions of major browsers now support accessing clipboardData
from the paste event, according to http://stackoverflow.com/questions/2176861.

However, some browsers (e.g. Safari on Mac) do not return anything in the call
to getData('text/html'). If this is the case, fall back to the previous logic
of changing focus and allowing the default behavior.

This seems like something that merits a test, but I am unsure of the best way
to go about that. Help on writing one would be appreciated. I've manually
verified that paste behavior continues to work in the latest versions of Safari,
Chrome, and Firefox on OSX.

Viewing the diff with `?w=1` is encouraged.