### PR TITLE
Allow a format config to specify override functions for add/remove/match/value

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -74,7 +74,7 @@ class Format
 
   add: (node, value) ->
     return this.remove(node) unless value
-    return node if this.value(node) == value
+    return node if _.isEqual(this.value(node), value)
     return @config.add.call(this, node, value) if _.isFunction(@config.add)
     if _.isString(@config.parentTag)
       parentNode = document.createElement(@config.parentTag)

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -75,6 +75,7 @@ class Format
   add: (node, value) ->
     return this.remove(node) unless value
     return node if this.value(node) == value
+    return @config.add.call(this, node, value) if _.isFunction(@config.add)
     if _.isString(@config.parentTag)
       parentNode = document.createElement(@config.parentTag)
       dom(node).wrap(parentNode)
@@ -111,6 +112,7 @@ class Format
     return type == @config.type
 
   match: (node) ->
+    return @config.match.call(this, node) if _.isFunction(@config.match)
     return false unless dom(node).isElement()
     if _.isString(@config.parentTag) and node.parentNode?.tagName != @config.parentTag
       return false
@@ -130,10 +132,11 @@ class Format
     if _.isString(@config.prepare)
       document.execCommand(@config.prepare, false, value)
     else if _.isFunction(@config.prepare)
-      @config.prepare(value)
+      @config.prepare.call(this, value)
 
   remove: (node) ->
     return node unless this.match(node)
+    return @config.remove.call(this, node) if _.isFunction(@config.remove)
     if _.isString(@config.style)
       node.style[@config.style] = ''    # IE10 requires setting to '', other browsers can take null
       node.removeAttribute('style') unless node.getAttribute('style')  # Some browsers leave empty style attribute
@@ -159,6 +162,7 @@ class Format
 
   value: (node) ->
     return undefined unless this.match(node)
+    return @config.value.call(this, node) if _.isFunction(@config.value)
     if _.isString(@config.attribute)
       return node.getAttribute(@config.attribute) or undefined    # So "" does not get returned
     else if _.isString(@config.style)


### PR DESCRIPTION
This pull request makes it possible to specify `add`, `remove`, `match`, and `value` options in the call to `quill.addFormat()`, which provide an opportunity to customize the behavior of the format. There is already some precedent for this with the `prepare` option.

I know there is an ongoing refactor to the formats subsystem of Quill, but I'd like to share this code as a use case that you may want to consider supporting. In this example, I've configured two formats, `asset`, and `video`, both of which specify custom `add` and `value` functions.

These functions allow these two formats to both render as `<iframe>` elements, but still be distinguishable by quill because of their different `class` attributes. The `add` function writes the value as a suffix to the src attribute, and the `value` function correspondingly reads that suffix back in.

```
var dom = Quill.require('dom');
quill.addFormat('asset', {
  tag: 'IFRAME',
  class: 'asset',
  attribute: 'src',
  add: function(node, value) {
    var formatNode = document.createElement('iframe');
    if (node.parentNode) {
      dom(node).replace(formatNode);
    }
    node = formatNode;
    node.classList.add('asset');
    node.setAttribute('src', '/iframe.html?' + value);
    return node;
  },
  value: function(node) {
    return Number(node.getAttribute('src').split('?')[1]);
  }
});

quill.addFormat('video', {
  tag: 'IFRAME',
  class: 'video',
  attribute: 'src',
  add: function(node, value) {
    var formatNode = document.createElement('iframe');
    if (node.parentNode) {
      dom(node).replace(formatNode);
    }
    node = formatNode;
    node.classList.add('video');
    node.setAttribute('src', '/iframe.html?' + value);
    return node;
  },
  value: function(node) {
    return Number(node.getAttribute('src').split('?')[1]);
  }
});
```