### PR TITLE
change lodash grunt config flag to 'development' from 'debug'

### DIFF
--- a/config/grunt/dist.coffee
+++ b/config/grunt/dist.coffee
@@ -81,7 +81,7 @@ module.exports = (grunt) ->
         'isElement', 'isEqual', 'isNumber', 'isObject', 'isString'
         'uniqueId'
       ]
-      flags: ['debug']
+      flags: ['development']
     target:
       dest: '.build/lodash.js'
   )


### PR DESCRIPTION
I was having a build error when running:

`grunt dist`

```
grunt dist
Running "clean:all" (clean) task
>> 2 paths cleaned.

Running "clean:coverage" (clean) task
>> 0 paths cleaned.

Running "lodash:target" (lodash) task

Running "browserify:quill" (browserify) task
>> Error: ENOENT, open '.build/lodash.js'
Warning: Error running grunt-browserify. Use --force to continue.

Aborted due to warnings.
```

It looks like 'debug' is no longer a supported flag, at least according to what I found at https://www.npmjs.com/package/grunt-lodash:

```
// with or without the -- 
    // these are the only tested options, 
    // as the others don't make sense to use here 
    'flags': [
      '--stdout',
      'development',
      '--production',
      'source-map'
    ],
```

Changing 'debug' to 'development' results in a successful `grunt dist` and the tests all pass.  I am by no means a grunt expert so maybe I missed something obvious here.