### PR TITLE
Make toolbar handle formats created through quill.addFormat()

### DIFF
--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -21,10 +21,12 @@ class Toolbar
     @preventUpdate = false
     @triggering = false
     _.each(@quill.options.formats, (name) =>
-      this.initFormat(name)
+      return if Toolbar.formats.TOOLTIP[name]?
+      this.initFormat(name, _.bind(this._applyFormat, this, name))
     )
-    @quill.on(Quill.events.FORMAT_INIT, (name, format) =>
-      this.initFormat(name)
+    @quill.on(Quill.events.FORMAT_INIT, (name) =>
+      return if Toolbar.formats.TOOLTIP[name]?
+      this.initFormat(name, _.bind(this._applyFormat, this, name))
     )
     @quill.on(Quill.events.SELECTION_CHANGE, (range) =>
       this.updateActive(range) if range?
@@ -42,8 +44,7 @@ class Toolbar
         return false
       )
 
-  initFormat: (format) ->
-    return if Toolbar.formats.TOOLTIP[format]?
+  initFormat: (format, callback) ->
     selector = ".ql-#{format}"
     if Toolbar.formats.SELECT[format]?
       selector = "select#{selector}"    # Avoid selecting the picker container
@@ -58,7 +59,7 @@ class Toolbar
       @preventUpdate = true
       @quill.focus()
       range = @quill.getSelection()
-      this._applyFormat(format, range, value) if range?
+      callback(range, value) if range?
       @preventUpdate = false
       return true
     )

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -28,6 +28,7 @@ class Quill extends EventEmitter2
     theme: 'base'
 
   @events:
+    FORMAT_INIT      : 'format-init'
     MODULE_INIT      : 'module-init'
     POST_EVENT       : 'post-event'
     PRE_EVENT        : 'pre-event'
@@ -94,6 +95,7 @@ class Quill extends EventEmitter2
 
   addFormat: (name, format) ->
     @editor.doc.addFormat(name, format)
+    this.emit(Quill.events.FORMAT_INIT, name, format)
 
   addModule: (name, options) ->
     moduleClass = Quill.modules[name]

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -93,9 +93,9 @@ class Quill extends EventEmitter2
     @container.insertBefore(container, refNode)
     return container
 
-  addFormat: (name, format) ->
-    @editor.doc.addFormat(name, format)
-    this.emit(Quill.events.FORMAT_INIT, name, format)
+  addFormat: (name, config) ->
+    @editor.doc.addFormat(name, config)
+    this.emit(Quill.events.FORMAT_INIT, name)
 
   addModule: (name, options) ->
     moduleClass = Quill.modules[name]


### PR DESCRIPTION
Wire up a `FORMAT_INIT` event that parallels `MODULE_INIT`, so that modules can keep track of formats added via `quill.addFormat()`.

I've refactored the toolbar class a bit so that init logic can be shared between formats passed in through options and formats added in later.