### PR TITLE
adding content to style element for ie8

### DIFF
--- a/src/themes/base/index.coffee
+++ b/src/themes/base/index.coffee
@@ -26,7 +26,10 @@ class BaseTheme
     css = BaseTheme.objToCss(css) if _.isObject(css)
     style = document.createElement('style')
     style.type = 'text/css'
-    style.appendChild(document.createTextNode(css))
+    if style.styleSheet # IE 8
+      style.styleSheet.cssText = css
+    else # w3c
+      style.appendChild(document.createTextNode(css))
     document.head.appendChild(style)
 
 


### PR DESCRIPTION
this single change together with these polyfills makes quilljs work on ie8 (so far)
polyfills:
* es5-shim
* luwes/selection-polyfill
* https://mathiasbynens.be/notes/document-head
* webreflection/ie8