### PR TITLE
Prevent double space

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -46,18 +46,19 @@ class Keyboard
   _initDeletes: ->
     this.addHotkey([dom.KEYS.DELETE, dom.KEYS.BACKSPACE], (range, hotkey) =>
       if range? and @quill.getLength() > 0
-        if range.start != range.end
-          @quill.deleteText(range.start, range.end, Quill.sources.USER)
+        { start, end } = range
+        if start != end
+          @quill.deleteText(start, end, Quill.sources.USER)
         else
           if hotkey.key == dom.KEYS.BACKSPACE
-            [line, offset] = @quill.editor.doc.findLineAt(range.start)
+            [line, offset] = @quill.editor.doc.findLineAt(start)
             if offset == 0 and (line.formats.bullet or line.formats.list)
               format = if line.format.bullet then 'bullet' else 'list'
-              @quill.formatLine(range.start, range.start, format, false)
-            else if range.start > 0
-              @quill.deleteText(range.start - 1, range.start, Quill.sources.USER)
-          else if range.start < @quill.getLength()
-            @quill.deleteText(range.start, range.start + 1, Quill.sources.USER)
+              @quill.formatLine(start, start, format, false)
+            else if start > 0
+              @quill.deleteText(start - 1, start, Quill.sources.USER)
+          else if start < @quill.getLength()
+            @quill.deleteText(start, start + 1, Quill.sources.USER)
       return false
     )
 

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -50,7 +50,9 @@ class Keyboard
         if start != end
           # if the surrounding characters are both spaces,
           # kill the preceding space to prevent leaving double-spaces
-          if ' ' == @quill.getText(start - 1, start) == @quill.getText(end, end + 1)
+          before = @quill.getText(Math.max(start - 1, 0), start)
+          after = @quill.getText(end, Math.min(end + 1, @quill.getLength()))
+          if ' ' == before == after
             start = start - 1
           @quill.deleteText(start, end, Quill.sources.USER)
         else

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -48,6 +48,10 @@ class Keyboard
       if range? and @quill.getLength() > 0
         { start, end } = range
         if start != end
+          # if the surrounding characters are both spaces,
+          # kill the preceding space to prevent leaving double-spaces
+          if ' ' == @quill.getText(start - 1, start) == @quill.getText(end, end + 1)
+            start = start - 1
           @quill.deleteText(start, end, Quill.sources.USER)
         else
           if hotkey.key == dom.KEYS.BACKSPACE


### PR DESCRIPTION
What happens:

- Highlight a word in the middle of a sentence
- Delete it
- End up with two spaces where the word or words used to be

What should happen:

- End up with only one space where the word or words used to be

While this may look odd, it is very useful to be able to double-click a word in the middle of a sentence and delete it without breaking the syntax of your sentence with a double space. In fact, this is native behavior in many environments!

Please excuse the refactoring. If you'd like to merge this without the first commit, I can revise.