### PR TITLE
Allows getBounds to return bottom as well

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -100,6 +100,7 @@ class Editor
       height: bounds.height
       left: bounds[side] - containerBounds.left,
       top: bounds.top - containerBounds.top
+      bottom: bounds.bottom
     }
 
   _deleteAt: (index, length) ->


### PR DESCRIPTION
getBounds returns bottom as well.

I needed this because i made a module for a floating toolbar and in order to calculate it's position i need to have the bottom position of the selection in order to calculate it properly.