### PR TITLE
Fixes getBounds calculation not error when moving the cursor directly be...

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -104,6 +104,10 @@ class Editor
           range.setStart(leaf.node, offset - 1)
           range.setEnd(leaf.node, offset - 1)
       bounds = range.getBoundingClientRect()
+      # In FF and IE it seems that if you create a range with both start and end offset being 0
+      # then getBoundingClientRect on range does not return anything, we assume it is then the leaf positioning we need
+      if leaf.length == 1 and range.startOffset == 0 and range.endOffset == 0 and bounds.height == 0
+        bounds = leaf.node.getBoundingClientRect()
     return {
       height: bounds.height
       left: bounds[side] - containerBounds.left,

--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -89,12 +89,20 @@ class Editor
     else
       range = document.createRange()
       if offset < leaf.length
-        range.setStart(leaf.node, offset)
-        range.setEnd(leaf.node, offset + 1)
+        try
+          range.setStart(leaf.node, offset)
+          range.setEnd(leaf.node, offset + 1)
+        catch IndexSizeError
+          range.setStart(leaf.node, offset)
+          range.setEnd(leaf.node, offset)
       else
-        range.setStart(leaf.node, offset - 1)
-        range.setEnd(leaf.node, offset)
-        side = 'right'
+        try
+          side = 'right'
+          range.setStart(leaf.node, offset - 1)
+          range.setEnd(leaf.node, offset)
+        catch IndexSizeError
+          range.setStart(leaf.node, offset - 1)
+          range.setEnd(leaf.node, offset - 1)
       bounds = range.getBoundingClientRect()
     return {
       height: bounds.height

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -343,5 +343,29 @@ describe('Editor', ->
       expect(bounds.height).toBeApproximately(reference.large.height, 1)
       expect(bounds.left).toBeApproximately(2*reference.normal.width + 2*reference.large.width, 2)
     )
+
+    describe('with image', ->
+      beforeEach( ->
+        @editor.root.innerHTML = '<div><img src="data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7"/></div>'
+
+        reference.image =
+          height: @editor.root.firstChild.firstChild.offsetHeight
+          width: @editor.root.firstChild.firstChild.offsetWidth
+      )
+
+      it('directly before image', ->
+        bounds = @editor.getBounds(0)
+
+        expect(bounds.height).toBeApproximately(reference.image.height, 1)
+        expect(bounds.left).toBeApproximately(0, 1)
+      )
+
+      it('directly after image', ->
+        bounds = @editor.getBounds(1)
+
+        expect(bounds.height).toBeApproximately(reference.image.height, 1)
+        expect(bounds.left).toBeApproximately(reference.image.width, 1)
+      )
+    )
   )
 )


### PR DESCRIPTION
I was having issues with using the getBounds method (IndexSizeError) if the selection was directly after or before an image element. I happens mostly when you are using the cursor keys. I don't know if the main cause from the getBounds method or when the offset gets determined. But this fixed my issues. Includes test as well.