### PR TITLE
Fixes issue with calculation position from index with BR tags in ie

### DIFF
--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -122,6 +122,9 @@ class Selection
     return this._decodePosition(leaf.node, offset)
 
   _positionToIndex: (node, offset) ->
+    if dom.isIE(10) and node.innerHTML == '<br>' and offset == 1
+      offset = 0;
+
     [leafNode, offset] = this._encodePosition(node, offset)
     line = @doc.findLine(leafNode)
     # TODO move to linked list

--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -122,9 +122,7 @@ class Selection
     return this._decodePosition(leaf.node, offset)
 
   _positionToIndex: (node, offset) ->
-    if dom.isIE(10) and node.innerHTML == '<br>' and offset == 1
-      offset = 0;
-
+    offset = 0 if dom.isIE(10) and node.tagName == 'BR' and offset == 1
     [leafNode, offset] = this._encodePosition(node, offset)
     line = @doc.findLine(leafNode)
     # TODO move to linked list

--- a/test/unit/core/selection.coffee
+++ b/test/unit/core/selection.coffee
@@ -194,6 +194,14 @@ describe('Selection', ->
         expect(range.start).toEqual(0)
         expect(range.end).toEqual(0)
       )
+
+      it('empty line', ->
+        @container.innerHTML = '<div><br></div>'
+        quill = new Quill(@container.firstChild)
+        quill.editor.selection.setRange(new Quill.Lib.Range(0, 0))
+        range = quill.editor.selection.getRange()
+        expect(range.start).toEqual(0)
+      )
     )
   )
 


### PR DESCRIPTION
When you focus on a line that only has a BR tag in it ie will set the start of the range always to 1 which is inconsistent with other browsers which return 0.