### PR TITLE
Ensure targetNode matches leaf.length in formatText

### DIFF
--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -101,6 +101,7 @@ class Line extends LinkedList.Node
           dom(targetNode).splitBefore(@node)
           while !format.match(targetNode)
             targetNode = targetNode.parentNode
+          dom(targetNode).split(leaf.length)
         # Isolate target node
         if leafOffset > 0
           [leftNode, targetNode] = dom(targetNode).split(leafOffset)

--- a/test/unit/core/line.coffee
+++ b/test/unit/core/line.coffee
@@ -275,6 +275,10 @@ describe('Line', ->
         initial: '<b><i>01</i><s>23</s></b><i><s>45</s><b>67</b></i>'
         expected: '<b><i>01</i></b><b><s>2</s></b><s>3</s><i><s>45</s></i><i>6<b>7</b></i>'
         args: [3, 4, 'bold', false]
+      'split boundaries with parents remove at beginning':
+        initial: '<b><i>01</i><s>23</s></b>'
+        expected: '<i>01</i><s>23</s>'
+        args: [0, 4, 'bold', false]
       'remove image':
         initial: '<b>01</b><img src="http://quilljs.com/images/cloud.png"><s>34</s>'
         expected: "<b>01</b>#{dom.EMBED_TEXT}<s>34</s>"


### PR DESCRIPTION
Without this call to split(), the targetNode may outgrow leaf.length, causing
the call to format.add(targetNode, value) to operate on more than was intended.

Fixes #310