### PR TITLE
Remove an optimization in Line#insertText, rely on Line#optimize instead

### DIFF
--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -26,18 +26,5 @@ class Leaf extends LinkedList.Node
     else
       dom(@node).text(@text)
 
-  insertText: (offset, text) ->
-    @text = @text.slice(0, offset) + text + @text.slice(offset)
-    if dom(@node).isTextNode()
-      dom(@node).text(@text)
-    else
-      textNode = document.createTextNode(text)
-      if @node.tagName == dom.DEFAULT_BREAK_TAG
-        @node = dom(@node).replace(textNode)
-      else
-        @node.appendChild(textNode)
-        @node = textNode
-    @length = @text.length
-
 
 module.exports = Leaf

--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -117,19 +117,15 @@ class Line extends LinkedList.Node
     return unless text.length > 0
     [leaf, leafOffset] = this.findLeafAt(offset)
     # offset > 0 for multicursor
-    if _.isEqual(leaf.formats, formats)
-      leaf.insertText(leafOffset, text)
-      this.resetContent()
-    else
-      node = _.reduce(formats, (node, value, name) =>
-        format = @doc.formats[name]
-        node = format.add(node, value) if format?
-        return node
-      , document.createTextNode(text))
-      [prevNode, nextNode] = dom(leaf.node).split(leafOffset)
-      nextNode = dom(nextNode).splitBefore(@node).get() if nextNode
-      @node.insertBefore(node, nextNode)
-      this.rebuild()
+    node = _.reduce(formats, (node, value, name) =>
+      format = @doc.formats[name]
+      node = format.add(node, value) if format?
+      return node
+    , document.createTextNode(text))
+    [prevNode, nextNode] = dom(leaf.node).split(leafOffset)
+    nextNode = dom(nextNode).splitBefore(@node).get() if nextNode
+    @node.insertBefore(node, nextNode)
+    this.optimize()
 
   optimize: ->
     Normalizer.optimizeLine(@node)

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -148,7 +148,7 @@ describe('Editor', ->
           index: 6, text: 'A'
         'insert formatted text with match':
           expected: ['<div>0123<b><i>45A67</i></b></div>']
-          index: 6, text: 'A', formats: { bold: true, italic: true }
+          index: 6, text: 'A', formats: { italic: true, bold: true }
         'prepend newline':
           expected: ['<div><br></div>', '<div>0123<b><i>4567</i></b></div>']
           index: 0, text: '\n'

--- a/test/unit/core/leaf.coffee
+++ b/test/unit/core/leaf.coffee
@@ -95,33 +95,4 @@ describe('Leaf', ->
       expect(dom(leaf.node).text()).toEqualHTML('')
     )
   )
-
-  describe('insertText()', ->
-    tests =
-      'element with text node':
-        initial:  'Test'
-        expected: 'Te|st'
-        text: 'Test'
-      'element without text node':
-        initial:  '<b></b>'
-        expected: '<b>|</b>'
-      'break':
-        initial:  '<br>'
-        expected: '|'
-
-    _.each(tests, (test, name) ->
-      it(name, ->
-        @container.innerHTML = test.initial
-        leaf = new Quill.Leaf(@container.firstChild, {})
-        text = test.text or ''
-        length = text.length
-        expect(leaf.text).toEqual(text)
-        expect(leaf.length).toEqual(length)
-        leaf.insertText(length/2, '|')
-        expect(@container).toEqualHTML(test.expected)
-        expect(leaf.text).toEqual(dom(leaf.node).text())
-        expect(leaf.length).toEqual(length + 1)
-      )
-    )
-  )
 )

--- a/test/unit/core/line.coffee
+++ b/test/unit/core/line.coffee
@@ -324,7 +324,7 @@ describe('Line', ->
       'inside leaf with multiple formats':
         initial: '<b><i>01</i></b>'
         expected: '<b><i>0|1</i></b>'
-        offset: 1, formats: { bold: true, italic: true }
+        offset: 1, formats: { italic: true, bold: true }
       'empty line':
         initial: '<br>'
         expected: '|'
@@ -335,11 +335,11 @@ describe('Line', ->
         offset: 1
       'format in empty line':
         initial: '<br>'
-        expected: '<b>|</b><br>'
+        expected: '<b>|</b>'
         offset: 0, formats: { bold: true }
       'void in empty line':
         initial: '<br>'
-        expected: '<img src="http://quilljs.com/images/cloud.png"><br>'
+        expected: '<img src="http://quilljs.com/images/cloud.png">'
         offset: 0, formats: { image: 'http://quilljs.com/images/cloud.png' }
       'void in middle of node':
         initial: '<b>01</b>'

--- a/test/unit/core/selection.coffee
+++ b/test/unit/core/selection.coffee
@@ -218,7 +218,7 @@ describe('Selection', ->
         quill.editor._insertAt(0, Quill.Lib.DOM.EMBED_TEXT, { image: 'http://quilljs.com/images/cloud.png' })
         quill.editor._formatAt(2, 4, 'bold', true)
         expect(quill.root).toEqualHTML('
-          <div><img src="http://quilljs.com/images/cloud.png"><br></div>
+          <div><img src="http://quilljs.com/images/cloud.png"></div>
           <div><b>1234</b></div>
         ', true)
         range = quill.editor.selection.getRange()


### PR DESCRIPTION
Avoiding the optimization of inserting text into an existing node with identical formats fixes #312.

Without this optimization, insertText() will always split the existing html at the offset and create a new node just for the inserted text. To achieve similar behavior as before, Line#optimize() is called instead of Line#rebuild(). This results in `<br>` being stripped where it wasn't before.

Leaf#insertText() is removed, as it is no longer used.

This commit contains some changes to test expectations to reflect the slightly changed behavior.

Is this an acceptable workaround?