### PR TITLE
Fix deactivation of image toolbar button after deletion.

### DIFF
--- a/src/modules/image-tooltip.coffee
+++ b/src/modules/image-tooltip.coffee
@@ -30,6 +30,7 @@ class ImageTooltip extends Tooltip
     dom(@textbox).on('input', _.bind(this._preview, this))
     this.initTextbox(@textbox, this.insertImage, this.hide)
     @quill.onModuleLoad('toolbar', (toolbar) =>
+      @toolbar = toolbar
       toolbar.initFormat('image', _.bind(this._onToolbar, this))
     )
 
@@ -54,6 +55,7 @@ class ImageTooltip extends Tooltip
       )
     else
       @quill.deleteText(range, 'user')
+      @toolbar.setActive('image', false)
 
   _preview: ->
     return unless this._matchImageURL(@textbox.value)


### PR DESCRIPTION
This fixes an issue where the image toolbar button does not update properly after an image has been deleted. In order to reproduce do the following:
1. Go to the [Quill homepage](http://quilljs.com/)
2. In the example editor select the image with your cursor (you will see the image button in the toolbar turn blue).
3. Click the image button in the toolbar.
At this point you will see that the image has been removed, but the button is still blue, seeming to indicate there is an image still present. If you select somewhere else or use the left/right keys and then come back to that same position it will be properly stay deactivated.
There were no tests for the image tooltip module unfortunately, but I based the code on the link tooltip which is somewhat similar.