### PR TITLE
Avoid calling root.focus() unless absolutely necessary, to prevent scrolling

### DIFF
--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -145,7 +145,7 @@ class Selection
     if startNode?
       # Need to focus before setting or else in IE9/10 later focus will cause a set on 0th index on line div
       # to be set at 1st index
-      @doc.root.focus() unless this.checkFocus()
+      @doc.root.focus() if dom.isIE(10) and !this.checkFocus()
       nativeRange = this._getNativeRange()
       if !nativeRange? or startNode != nativeRange.startContainer or startOffset != nativeRange.startOffset or endNode != nativeRange.endContainer or endOffset != nativeRange.endOffset
         # IE9 requires removeAllRanges() regardless of value of


### PR DESCRIPTION
I'm not sure what the comment above this line means, but assuming it applies only to IE9/10, I added that as a condition.

Calling focus() is disruptive because it may cause the scroll position of the document to be lost, and so I would like to avoid it if possible.