### PR TITLE
allow custom line formats to exclude more than one other line format

### DIFF
--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -74,11 +74,15 @@ class Line extends LinkedList.Node
       return unless format?
       # TODO reassigning @node might be dangerous...
       if format.isType(Format.types.LINE)
-        if format.config.exclude and @formats[format.config.exclude]
-          excludeFormat = @doc.formats[format.config.exclude]
-          if excludeFormat?
-            @node = excludeFormat.remove(@node)
-            delete @formats[format.config.exclude]
+        if format.config.exclude?
+          excludes = if Array.isArray(format.config.exclude) then format.config.exclude else [format.config.exclude]
+          _.each(excludes, (exclude) =>
+            if @formats[exclude]?
+              excludeFormat = @doc.formats[exclude]
+              if excludeFormat?
+                @node = excludeFormat.remove(@node)
+                delete @formats[exclude]
+          )
         @node = format.add(@node, value)
       if value
         @formats[name] = value

--- a/test/unit/core/line.coffee
+++ b/test/unit/core/line.coffee
@@ -181,11 +181,38 @@ describe('Line', ->
         initial: '<div><br></div>'
         expected: '<div><br></div>'
         formats: { bold: true }
+      'add bullet':
+        initial: '<div><br></div>'
+        expected: '<ul><li><br></li></ul>'
+        expectedIsParent: true
+        formats: { bullet: true }
+      'remove excluded style (string)':
+        initial: '<ul><li><br></li></ul>'
+        initialIsParent: true
+        expected: '<ol><li><br></li></ol>'
+        expectedIsParent: true
+        formats: { list: true }
+      'remove excluded style (array)':
+        custom:
+          h1:
+            tag: 'H1'
+            prepare: 'heading'
+            exclude: ['bullet', 'list']
+            type: 'line'
+        initial: '<ol><li><br></li></ol>'
+        initialIsParent: true
+        expected: '<h1><br></h1>'
+        formats: { h1: true }
 
     _.each(tests, (test, name) ->
       it(name, ->
+        if test.custom?
+          for k, v of test.custom
+            @doc.addFormat(k, v)
         @container.innerHTML = test.initial
         lineNode = @container.firstChild
+        if test.initialIsParent?
+          lineNode = lineNode.firstChild
         line = new Quill.Line(@doc, lineNode)
         expectedFormats = _.clone(test.formats)
         _.each(test.formats, (value, name) ->
@@ -193,7 +220,10 @@ describe('Line', ->
           delete expectedFormats[name] unless value
         )
         expect(line.formats).toEqual(expectedFormats)
-        expect(line.node.outerHTML).toEqualHTML(test.expected, true)
+        if test.expectedIsParent?
+          expect(line.node.parentNode.outerHTML).toEqualHTML(test.expected, true)
+        else
+          expect(line.node.outerHTML).toEqualHTML(test.expected, true)
       )
     )
   )


### PR DESCRIPTION
Allows custom format definitions with multiple `config.exclude` values as an array of strings, e.g., 
```coffeescript
editor.addFormat
  h1:
    tag: 'H1'
    prepare: 'heading'
    type: 'line'
    exclude: [ 'h2', 'h3', 'blockquote', 'bullet', 'list' ]
```
 Original behavior preserved when `config.exclude` is simply a string. Resolves #322 . Tests included.