### PR TITLE
Prevent unwanted scrolling as a result of setSelection()

### DIFF
--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -155,6 +155,7 @@ class Selection
         nativeRange.setStart(startNode, startOffset)
         nativeRange.setEnd(endNode, endOffset)
         selection.addRange(nativeRange)
+      @doc.root.focus() if nativeRange? and !this.checkFocus()
     else
       selection.removeAllRanges()
       @doc.root.blur()

--- a/src/core/selection.coffee
+++ b/src/core/selection.coffee
@@ -145,7 +145,7 @@ class Selection
     if startNode?
       # Need to focus before setting or else in IE9/10 later focus will cause a set on 0th index on line div
       # to be set at 1st index
-      @doc.root.focus() unless this.checkFocus()
+      @doc.root.focus() if dom.isIE(10) and !this.checkFocus()
       nativeRange = this._getNativeRange()
       if !nativeRange? or startNode != nativeRange.startContainer or startOffset != nativeRange.startOffset or endNode != nativeRange.endContainer or endOffset != nativeRange.endOffset
         # IE9 requires removeAllRanges() regardless of value of


### PR DESCRIPTION
This is an adjustment to #321, which attempted to prevent the call to `root.focus()` before the native range is set from causing a scroll to the beginning of the document.

These changes work around this scroll behavior by moving the call to `root.focus()` until after the native range has been set, for all browsers except for IE9/10 which need it to happen beforehand for some reason.