### PR TITLE
Deep-linking to quill tag on stackoverflow.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Check out Gruntfile.coffee and config/grunt for more testing options.
 Get help or stay up to date.
 
 - Follow [@quilljs](https://twitter.com/quilljs) on Twitter
-- Ask questions on [Stack Overflow](http://stackoverflow.com/) (tag with quill)
+- Ask questions on [Stack Overflow](http://stackoverflow.com/questions/tagged/quill) (tag with quill)
 - Visit the [discussion group](http://discuss.quilljs.com)
 - If a private channel is required, you may also email support@quilljs.com
 


### PR DESCRIPTION
A minor change to the README, but might help for faster navigation (I was confused when clicking the link that I saw questions about PHP etc, since I got redirected to stackoverflow's homepage).