### PR TITLE
add support for the html CODE element

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="file://$PROJECT_DIR$" libraries="{quill node_modules}" />
+  </component>
+</project>

--- a/.idea/libraries/quill_node_modules.xml
+++ b/.idea/libraries/quill_node_modules.xml
@@ -1,0 +1,14 @@
+<component name="libraryTable">
+  <library name="quill node_modules" type="javaScript">
+    <properties>
+      <option name="frameworkName" value="node_modules" />
+      <sourceFilesUrls>
+        <item url="file://$PROJECT_DIR$/node_modules" />
+      </sourceFilesUrls>
+    </properties>
+    <CLASSES>
+      <root url="file://$PROJECT_DIR$/node_modules" />
+    </CLASSES>
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectTasksOptions" suppressed-tasks="CoffeeScript" />
+</project>

--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -12,7 +12,7 @@ class Document
     @normalizer = new Normalizer()
     @formats = {}
     _.each(options.formats, _.bind(this.addFormat, this))
-    this.setHTML(@root.innerHTML)
+    this.setHTML(@root.innerHTML, true)
 
   addFormat: (name, config) ->
     config = Format.FORMATS[name] unless _.isObject(config)
@@ -119,9 +119,11 @@ class Document
     delete @lineMap[line.id]
     @lines.remove(line)
 
-  setHTML: (html) ->
+  setHTML: (html, shouldStripWhitespace) ->
     html = Normalizer.stripComments(html)
-    html = Normalizer.stripWhitespace(html)
+    if typeof shouldStripWhitespace == 'undefined' or shouldStripWhitespace == true
+      html = Normalizer.stripWhitespace(html)
+
     @root.innerHTML = html
     @lines = new LinkedList()
     @lineMap = {}

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -23,6 +23,10 @@ class Format
       tag: 'S'
       prepare: 'strikeThrough'
 
+    code:
+      tag: 'CODE'
+      prepare: 'code'
+
     color:
       style: 'color'
       default: 'rgb(0, 0, 0)'

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -15,6 +15,7 @@ class Normalizer
     'EM'     : 'I'
     'DEL'    : 'S'
     'STRIKE' : 'S'
+    'CODE'   : 'CODE'
   }
 
   @ATTRIBUTES: {

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -135,7 +135,7 @@ class Normalizer
     html = html.trim()
     # Replace all newline characters
     html = html.replace(/(\r?\n|\r)+/g, ' ')
-    # Remove whitespace between tags, requires &nbsp; for legitmate spaces
+    # Remove whitespace between tags, requires &nbsp; for legitimate spaces
     html = html.replace(/\>\s+\</g, '><')
     return html
 

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -68,7 +68,7 @@ class Quill extends EventEmitter2
     @root = this.addContainer('ql-editor')
     @editor = new Editor(@root, this, @options)
     Quill.editors.push(this)
-    this.setHTML(html, Quill.sources.SILENT)
+    this.setHTML(html, true, Quill.sources.SILENT)
     themeClass = Quill.themes[@options.theme]
     throw new Error("Cannot load #{@options.theme} theme. Are you sure you registered it?") unless themeClass?
     @theme = new themeClass(this, @options)
@@ -197,9 +197,9 @@ class Quill extends EventEmitter2
     delta.ops.push({ delete: this.getLength() })
     this.updateContents(delta, source)
 
-  setHTML: (html, source = Quill.sources.API) ->
+  setHTML: (html, shouldStripWhitespace, source = Quill.sources.API) ->
     html = "<#{dom.DEFAULT_BLOCK_TAG}><#{dom.DEFAULT_BREAK_TAG}></#{dom.DEFAULT_BLOCK_TAG}>" unless html.trim()
-    @editor.doc.setHTML(html)
+    @editor.doc.setHTML(html, shouldStripWhitespace)
     @editor.checkUpdate(source)
 
   setSelection: (start, end, source = Quill.sources.API) ->


### PR DESCRIPTION
This adds basic support for the CODE element.  CODE is part of the HTML 5 spec and it has semantic meaning, so I think it should be supported by default.  