### PR TITLE
add support for the html CODE element

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -23,6 +23,10 @@ class Format
       tag: 'S'
       prepare: 'strikeThrough'
 
+    code:
+      tag: 'CODE'
+      prepare: 'code'
+
     color:
       style: 'color'
       default: 'rgb(0, 0, 0)'

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -15,6 +15,7 @@ class Normalizer
     'EM'     : 'I'
     'DEL'    : 'S'
     'STRIKE' : 'S'
+    'CODE'   : 'CODE'
   }
 
   @ATTRIBUTES: {


### PR DESCRIPTION
This adds CODE element support to Quill. I think it should be included by default because CODE is part of HTML 5 and has semantic meaning.