### PR TITLE
Update toolbar documentation to use working values for font size

### DIFF
--- a/docs/modules/toolbar.md
+++ b/docs/modules/toolbar.md
@@ -32,10 +32,10 @@ Simply create a container and the module to the Quill editor.
 <div id="toolbar">
   <!-- Add font size dropdown -->
   <select class="ql-size">
-    <option value="small">Small</option>
-    <option value="normal" selected>Normal</option>
-    <option value="large">Large</option>
-    <option value="huge">Huge</option>
+    <option value="10px">Small</option>
+    <option value="13px" selected>Normal</option>
+    <option value="18px">Large</option>
+    <option value="32px">Huge</option>
   </select>
   <!-- Add a bold button -->
   <button class="ql-bold"></button>


### PR DESCRIPTION
'huge' and 'normal' are not valid values for the CSS font-size property (see https://developer.mozilla.org/en-US/docs/Web/CSS/font-size).
As a result, the sizes in the toolbar example code only work for the 'small' and 'large' options, which are valid values. 

This change updates all values to pixels, which works as expected.