### PR TITLE
Remove doc references to startLength and endLength

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -273,8 +273,6 @@ Applies Delta to editor contents.
 {% highlight javascript %}
 // Assuming editor currently contains [{ insert: 'Hello World!' }]
 editor.updateContents({
-  startLength: 12,
-  endLength: 13,
   ops: [
     { retain: 6 },        // Keep 'Hello '
     { delete: 5 },        // 'World' is deleted


### PR DESCRIPTION
The docs for updateContents show an example delta with startLength and endLength properties set. From reading http://quilljs.com/blog/a-new-delta/ , I believe these properties are no longer used. Removing for clarity.