### PR TITLE
link to Github repo from website

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ bodyClass: 'home'
     <hr class="half-rule">
 
     <div id="download-container">
-      <p>Quill is open source. It is hosted and maintained <a href="https://github.com/quilljs/quill/">on GitHub</a>.</p>
+      <p>Quill is open source. It is hosted and maintained on <a href="https://github.com/quilljs/quill/">GitHub</a>.</p>
       <a href="https://github.com/quilljs/quill/releases/download/v{{ site.version }}/quill.tar.gz" class="btn-lg btn" title="Quill v{{ site.version }}" onclick="ga('send','event','download',this.href);">Download Quill</a>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@ bodyClass: 'home'
     <hr class="half-rule">
 
     <div id="download-container">
-      <p>Quill is open source. It is hosted and maintained on GitHub.</p>
+      <p>Quill is open source. It is hosted and maintained <a href="https://github.com/quilljs/quill/">on GitHub</a>.</p>
       <a href="https://github.com/quilljs/quill/releases/download/v{{ site.version }}/quill.tar.gz" class="btn-lg btn" title="Quill v{{ site.version }}" onclick="ga('send','event','download',this.href);">Download Quill</a>
     </div>
   </div>


### PR DESCRIPTION
I just saw the link within the editor (when viewing the source), but didn't notice it when on the website. This change makes it easier to get to the repo.