### PR TITLE
add instructions for viewing example pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ All tests assume the local server is running.
 
 Check out Gruntfile.coffee and config/grunt for more testing options.
 
+### Examples
+
+All examples assume the local server is running.
+
+  visit [localhost:9000/examples/index.html](http://localhost:9000/examples/index.html) or [localhost:9000/examples/advanced.html](http://localhost:9000/examples/advanced.html) 
+
 
 ## Community
 


### PR DESCRIPTION
As a newcomer to the js ecosystem of build tools it wasn't exactly clear to me how to access the example pages since I was not familiar with jade or harp.  I added two links in the readme to easily access the two example pages.