### PR TITLE
Fix selection of embedded objects.

### DIFF
--- a/config/grunt/dist.coffee
+++ b/config/grunt/dist.coffee
@@ -70,6 +70,7 @@ module.exports = (grunt) ->
         'clone', 'extend', 'defaults', 'omit', 'values'
         'isElement', 'isEqual', 'isFunction', 'isNumber', 'isObject', 'isString'
         'uniqueId'
+        'omit'
       ]
       flags: ['development']
     target:

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -1,6 +1,7 @@
 Quill = require('../quill')
-_     = Quill.require('lodash')
-dom   = Quill.require('dom')
+Format = require('../core/format')
+_ = Quill.require('lodash')
+dom = Quill.require('dom')
 
 
 class Toolbar
@@ -61,7 +62,6 @@ class Toolbar
     )
 
   setActive: (format, value) ->
-    value = false if format == 'image'  # TODO generalize to all embeds
     input = @inputs[format]
     return unless input?
     $input = dom(input)
@@ -117,7 +117,12 @@ class Toolbar
     else
       contents = @quill.getContents(range)
     formatsArr = _.map(contents.ops, 'attributes')
-    return this._intersectFormats(formatsArr)
+    activeFormats = this._intersectFormats(formatsArr)
+
+    if range.isCollapsed()
+      activeFormats = _.omit(activeFormats, (value, format) => return @quill.editor.doc.formats[format].isType(Format.types.EMBED))
+
+    return activeFormats
 
   _getLineActive: (range) ->
     formatsArr = []

--- a/test/unit/modules/toolbar.coffee
+++ b/test/unit/modules/toolbar.coffee
@@ -184,4 +184,16 @@ describe('Toolbar', ->
       expect(dom(@button).hasClass('ql-active')).toBe(false)
     )
   )
+
+  describe('embed button should become active when selecting', ->
+    it('an image', ->
+      @quill.addModule('image-tooltip', true)
+      image = @toolbarContainer.querySelector('.ql-image')
+
+      @quill.setSelection(0, 0)
+      @quill.insertEmbed(0, 'image', 'http://quilljs.com/images/cloud.png')
+      @quill.setSelection(0, 1)
+      expect(dom(image).hasClass('ql-active')).toBe(true)
+    )
+  )
 )


### PR DESCRIPTION
This fixes an issue where the image toolbar button does not become active when an image is selected. You can reproduce this by going to the Quill homepage and selecting the image there, you will see that the image button stays inactive. This also prevents the image from being able to be deleted by clicking the image button while active.
I found that the issue is due to [this line](https://github.com/quilljs/quill/blob/7f78558384f95b05256919e3e1d67d3d4adc8ba6/src/modules/toolbar.coffee#L69) which was added to fix #351. The toolbar automatically expands a collapsed selection in order to display correctly when next to formatted text, so before this line of code was added to allow for double insertion of images from the toolbar, you could have your cursor next to an image and the toolbar button would be active (which I thought was unexpected behavior anyways).
This more permanently fixes #351 as well as any other types of embeds from now on, while still allowing the button to display as active if the image is indeed selected.