### PR TITLE
check for toolbar before calling setActive

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -57,7 +57,7 @@ class Keyboard
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)
-        @toolbar.setActive(format, value)
+        @toolbar.setActive(format, value) if @toolbar?
       )
       return false
     )


### PR DESCRIPTION
Otherwise keyboard module throws error when loaded without toolbar module