### PR TITLE
set leaf data when replacing leaf node

### DIFF
--- a/src/core/leaf.coffee
+++ b/src/core/leaf.coffee
@@ -22,6 +22,7 @@ class Leaf extends LinkedList.Node
     @length = @text.length
     if dom.EMBED_TAGS[@node.tagName]?
       textNode = document.createTextNode(@text)
+      dom(textNode).data(Leaf.DATA_KEY, this)
       @node = dom(@node).replace(textNode)
     else
       dom(@node).text(@text)
@@ -32,6 +33,7 @@ class Leaf extends LinkedList.Node
       dom(@node).text(@text)
     else
       textNode = document.createTextNode(text)
+      dom(textNode).data(Leaf.DATA_KEY, this)
       if @node.tagName == dom.DEFAULT_BREAK_TAG
         @node = dom(@node).replace(textNode)
       else


### PR DESCRIPTION
`Leaf` methods `deleteText()` and `insertText()` sometimes replace the leaf node with a new `textNode`, but neglect to call `dom(textNode).data(Leaf.DATA_KEY, this)`, breaking `line.getLeaf()` and anything that depends on it.

This fix solves the problem, eliminating mysterious side-effects, e.g., not firing `quill-selection-change` events when the selection moves to some nodes.

Alternatively, the fix could be done inside `dom.replace()` instead.