### PR TITLE
Enter key behavior

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -69,12 +69,14 @@ class Format
     bullet:
       type: Format.types.LINE
       exclude: 'list'
+      inherit: true
       parentTag: 'UL'
       tag: 'LI'
 
     list:
       type: Format.types.LINE
       exclude: 'bullet'
+      inherit: true
       parentTag: 'OL'
       tag: 'LI'
 

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -54,22 +54,29 @@ class Keyboard
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
       delta = new Delta().retain(range.start)
+      removeInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and format.config.inherit
+          formats[name] = false
+        return formats
+      , {})
+      removeNonInheritedFormats = _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and !format.config.inherit
+          formats[name] = false
+        return formats
+      , {})
 
-      # if on an empty line formatted as a list, remove the format
-      if range.isCollapsed() and line.length == 1 and (line.formats.bullet or line.formats.list)
-        delta.retain(1, { list: false, bullet: false })
+      # if on an empty line, remove the inheritable formats
+      if range.isCollapsed() and line.length == 1 and Object.keys(removeInheritedFormats).length > 0
+        delta.retain(1, removeInheritedFormats)
       else
         delta.insert('\n', line.formats).delete(range.end - range.start)
 
       # if creating a new empty line (was at the end of the old line),
       # remove line formats from the new line that should not be inherited
       if !leaf.next and offset == leaf.length
-        delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
-          format = @quill.editor.doc.formats[name]
-          if format and format.isType('line') and !format.config.inherit
-            formats[name] = false
-          return formats
-        , {}))
+        delta.retain(1, removeNonInheritedFormats)
 
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>

--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -53,7 +53,22 @@ class Keyboard
       return true unless range?
       [line, offset] = @quill.editor.doc.findLineAt(range.start)
       [leaf, offset] = line.findLeafAt(offset)
-      delta = new Delta().retain(range.start).insert('\n', line.formats).delete(range.end - range.start)
+      delta = new Delta().retain(range.start)
+
+      # hitting enter on an empty line formatted as a list should remove the format
+      if range.isCollapsed() and line.length == 1 and (line.formats.bullet or line.formats.list)
+        delta.retain(1, { list: false, bullet: false })
+      else
+        delta.insert('\n', line.formats).delete(range.end - range.start)
+
+      # remove line formats from the new line that should not be inherited
+      delta.retain(1, _.reduce(line.formats, (formats, value, name) =>
+        format = @quill.editor.doc.formats[name]
+        if format and format.isType('line') and !format.config.inherit
+          formats[name] = false
+        return formats
+      , {}))
+
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)

--- a/test/unit/modules/keyboard.coffee
+++ b/test/unit/modules/keyboard.coffee
@@ -31,6 +31,55 @@ describe('Keyboard', ->
     )
   )
 
+  describe('enter key', ->
+    beforeEach( ->
+      @container.innerHTML = '<div><div>01234</div></div>'
+      @quill = new Quill(@container.firstChild)
+      @keyboard = @quill.getModule('keyboard')
+      @enterKey = { key: dom.KEYS.ENTER }
+    )
+
+    it('inserts a newline', ->
+      @quill.setSelection(2, 2)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div>01</div><div>234</div>')
+    )
+
+    it('replaces selected text with a newline', ->
+      @quill.setSelection(2, 3)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div>01</div><div>34</div>')
+    )
+
+    it('inherits line formats when breaking a line in two', ->
+      @quill.formatText(5, 6, 'align', 'right')
+      @quill.setSelection(2, 2)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div style="text-align: right;">01</div><div style="text-align: right;">234</div>')
+    )
+
+    it('does not inherit line formats when inserting a blank line', ->
+      @quill.formatText(5, 6, 'align', 'right')
+      @quill.setSelection(5, 5)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<div style="text-align: right;">01234</div><div><br></div>')
+    )
+
+    it('inherits line formats for formats with "inherit: true" specified', ->
+      @quill.formatText(5, 6, 'list', true)
+      @quill.setSelection(5, 5)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<ol><li>01234</li><li><br></li></ol>')
+    )
+
+    it('removes the list format when starting from an empty line', ->
+      @quill.setHTML('<ol><li>one</li><li><br></li></ol>')
+      @quill.setSelection(4, 4)
+      dom(@quill.root).trigger('keydown', @enterKey)
+      expect(@quill.root).toEqualHTML('<ol><li>one</li></ol><div><br></div>')
+    )
+  )
+
   describe('hotkeys', ->
     beforeEach( ->
       @container.innerHTML = '<div><div>0123</div></div>'


### PR DESCRIPTION
This modifies the enter-key behavior for certain situations to make quill act similarly to other WYSIWYG editors.

Hitting enter on an empty line formatted as a list or bullet should remove that formatting (current behavior is to create a new blank line also formatted as a list), i.e. hitting enter with the cursor at `[|]` should continue to behave as in the following:

`<ol><li>Hello</li><li>[|]<br></li></ol>` => `<ol><li>Hello</li></ol><div><br></div>`

Hitting enter while at the end of a line (so as to create a new blank line) should cause the new blank line to be free of line formats, with some exceptions. Again, to be clear, this only affects the situation where a new blank line would be created, i.e. hitting enter with the cursor at `[|]` should continue to behave as in the following:

`<h1>Hello World[|]</h1>` => `<h1>Hello World</h1><div><br></div>`
`<h1>Hello[|]World</h1>` => `<h1>Hello</h1><h1>World</h1>`
`<ol><li>Hello World[|]</li></ol>` => `<ol><li>Hello World</li><li><br></li></ol>`

I've set the `list` and `bullet` format configs to contain `inherit: true` as an exception to the rule (the third case above). This instructs the enter key handler to make new blank lines formatted `list` or `bullet` also. But for other line formats (such as headings in my implementation), the new blank line will not inherit the heading format. 

I've added some tests to verify the intended behavior.