### PR TITLE
Remove unnecessary references to toolbar in keyboard module.

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -16,9 +16,6 @@ class Keyboard
     @hotkeys = {}
     this._initListeners()
     this._initHotkeys()
-    @quill.onModuleLoad('toolbar', (toolbar) =>
-      @toolbar = toolbar
-    )
 
   addHotkey: (hotkeys, callback) ->
     hotkeys = [hotkeys] unless Array.isArray(hotkeys)
@@ -42,7 +39,6 @@ class Keyboard
       @quill.prepareFormat(format, value, Quill.sources.USER)
     else
       @quill.formatText(range, format, value, Quill.sources.USER)
-    @toolbar.setActive(format, value) if @toolbar?
 
   _initEnter: ->
     keys = [
@@ -57,7 +53,6 @@ class Keyboard
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)
-        @toolbar.setActive(format, value)
       )
       return false
     )


### PR DESCRIPTION
This removes all references to the `toolbar` module from the `keyboard` module. Recent changes to the `toolbar` module make sure that it is updated when content is changed so triggering an update manually is not longer necessary.