### PR TITLE
Fix cursor top position in multi-cursor module when the quill container is scrolled.

### DIFF
--- a/src/modules/multi-cursor.coffee
+++ b/src/modules/multi-cursor.coffee
@@ -102,7 +102,7 @@ class MultiCursor extends EventEmitter2
 
   _updateCursor: (cursor) ->
     bounds = @quill.getBounds(cursor.index)
-    cursor.elem.style.top = (bounds.top - @quill.container.scrollTop) + 'px'
+    cursor.elem.style.top = (bounds.top + @quill.container.scrollTop) + 'px'
     cursor.elem.style.left = bounds.left + 'px'
     cursor.elem.style.height = bounds.height + 'px'
     flag = cursor.elem.querySelector('.cursor-flag')


### PR DESCRIPTION
Cursors are absolutely positioned with respect to the top of the .ql-container.
quill.getBounds().top returns a smaller integer when the .ql-container is scrolled vertically.
As a result, positioning a cursor requires adding container.scrollTop to the cursor bounds.