### PR TITLE
Enter event shouldn't assume that toolbar exists

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -57,7 +57,7 @@ class Keyboard
       @quill.updateContents(delta, Quill.sources.USER)
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)
-        @toolbar.setActive(format, value)
+        @toolbar.setActive(format, value) if @toolbar?
       )
       return false
     )


### PR DESCRIPTION
This fixes a bug that causes enter to fail when it's in formatted
text.