### PR TITLE
Fix retention of formats between lines.

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -58,6 +58,7 @@ class Keyboard
       _.each(leaf.formats, (value, format) =>
         @quill.prepareFormat(format, value)
         @toolbar.setActive(format, value) if @toolbar?
+        return
       )
       return false
     )

--- a/test/unit/modules/keyboard.coffee
+++ b/test/unit/modules/keyboard.coffee
@@ -66,5 +66,19 @@ describe('Keyboard', ->
       dom(@quill.root).trigger('keydown', Quill.Module.Keyboard.hotkeys.OUTDENT)
       expect(@quill.root).toEqualHTML('<div>0123</div>', true)
     )
+
+    it('retain formatting', ->
+      @quill.addModule('toolbar', { container: $('#toolbar-container').get(0) })
+      size = '18px'
+
+      @quill.setText('foo bar baz')
+      @quill.formatText(0, @quill.getLength(), { 'bold': true, 'size': size })
+
+      @quill.setSelection(@quill.getLength(), @quill.getLength())
+      dom(@quill.root).trigger('keydown', { key: dom.KEYS.ENTER })
+
+      expect(dom($('.ql-bold').get(0)).hasClass('ql-active')).toBe(true)
+      expect(dom($('.ql-size').get(0)).value()).toBe(size)
+    )
   )
 )


### PR DESCRIPTION
This ~~fixes #386~~ fixes the situation mentioned in #386 where a single enter will clear certain formats, while leaving others in place, it does not fix the double enter issue.
There's a bug in [this each loop](https://github.com/quilljs/quill/blob/564848ee95521520118249b98bd122eaad230d27/src/modules/keyboard.coffee#L58-L61) when the CoffeeScript is converted to JavaScript. Since CoffeeScript always returns the last statement, it is returning the result of setting the format which can be false and will then drop out of the loop, not applying the remaining formats.
I also added a test to make sure that formatting is retained from now on.