### PR TITLE
Add methods for retrieving formats applied to a range.

### DIFF
--- a/test/unit/core/quill.coffee
+++ b/test/unit/core/quill.coffee
@@ -150,6 +150,32 @@ describe('Quill', ->
     it('getText()', ->
       expect(@quill.getText()).toEqual('0123\n5678\n')
     )
+
+    it('getActiveFormats()', ->
+      @quill.formatText(0, 1, 'bold', true)
+      @quill.formatText(1, 3, 'italic', true)
+      @quill.formatText(0, 3, 'size', '18px')
+      @quill.formatLine(0, 0, 'align', 'right')
+
+      expect(@quill.getActiveFormats(1, 3)).toEqual({'italic': true, 'size': '18px', 'align': 'right'})
+      expect(@quill.getActiveFormats(0, 5)).toEqual({})
+      expect(@quill.getActiveFormats(9, 9)).toEqual({})
+    )
+
+    it('_getLeafFormats()', ->
+      @quill.formatText(0, 1, 'bold', true)
+      @quill.formatText(1, 3, 'italic', true)
+      @quill.formatText(0, 4, 'size', '18px')
+
+      expect(@quill._getLeafFormats(0, 0)).toEqual({'bold': true, 'size': '18px'})
+    )
+
+    it('_getLineFormats()', ->
+      @quill.formatLine(0, 0, 'align', 'right')
+      @quill.formatLine(6, 6, 'bullet', true)
+
+      expect(@quill._getLineFormats(7, 9)).toEqual({'bullet': true})
+    )
   )
 
   describe('selection', ->


### PR DESCRIPTION
This PR adds three methods: `getFormats`, `getLeafFormats`, and `getLineFormats` as discussed in #379. They all accept either a start and end index, a range, or if nothing is passed then the current selection range is used. It will then return an object representing all the formats and values which have been applied to the **entire** range. These methods are based on the ones in the [toolbar module](https://github.com/quilljs/quill/blob/54cae74b1994d87bea7fb349733abdc9ddb0c697/src/modules/toolbar.coffee#L105-L130), but differ in that they only return those formats which extend over the whole range. For example, if two different fonts are set for a range or only part of the range is set to bold then neither of those formats will be returned.
This is a work in progress, so I'm looking for feedback to improve the functionality. For instance, I'm a little unsure about the name of the methods, especially `getFormats` as that might be confusing.