### PR TITLE
Fix nested anchor tags after applying multiple link formats.

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -91,7 +91,7 @@ class Format
         dom(node.parentNode.previousSibling).merge(node.parentNode)
       if node.parentNode.tagName == node.parentNode.nextSibling?.tagName
         dom(node.parentNode).merge(node.parentNode.nextSibling)
-    if _.isString(@config.tag)
+    if _.isString(@config.tag) and node.tagName != @config.tag
       formatNode = document.createElement(@config.tag)
       if dom.VOID_TAGS[formatNode.tagName]?
         dom(node).replace(formatNode) if node.parentNode?

--- a/test/unit/core/format.coffee
+++ b/test/unit/core/format.coffee
@@ -137,6 +137,13 @@ describe('Format', ->
       expect(@container).toEqualHTML('<span style="color: red;">Text</span>')
     )
 
+    it('change value with given tag', ->
+      @container.innerHTML = '<a href="link1">a</a>'
+      format = new Quill.Format(Quill.Format.FORMATS.link)
+      format.add(@container.firstChild, 'link2')
+      expect(@container).toEqualHTML('<a href="link2">a</a>')
+    )
+
     it('default value', ->
       @container.innerHTML = '<span>Text</span>'
       format = new Quill.Format(Quill.Format.FORMATS.size)


### PR DESCRIPTION
To reproduce the bug: let's say we have text "abc", select "a", apply link "link1", then select "ab", apply link "link2" we will have the following markup: `<a href="link2"><a href="link1">a</a>b</a>c`. This is malformed url as per html standard, plus `quill.getContents()` will return text with 2 urls rather than just 1.