### PR TITLE
Fix infinite loop which can be caused with a null lineNode.

### DIFF
--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -81,7 +81,7 @@ class Document
     lineNode = lineNode.firstChild if lineNode? and dom.LIST_TAGS[lineNode.tagName]?
     _.each(lines, (line, index) =>
       while line.node != lineNode
-        if line.node.parentNode == @root or line.node.parentNode?.parentNode == @root
+        if lineNode and (line.node.parentNode == @root or line.node.parentNode?.parentNode == @root)
           # New line inserted
           lineNode = @normalizer.normalizeLine(lineNode)
           newLine = this.insertLineBefore(lineNode, line)


### PR DESCRIPTION
There is some html which causes an infinite loop within Quill (using setHtml). This is the error and callstack:

Uncaught TypeError: Cannot read property 'tagName' of null

```
Normalizer.wrapInLine
Normalizer.normalizeLine
Document.rebuild
```

The solution which worked for us is to add a simple null check around lineNode within the while loop. If it's null, we just return and remove the line.