### PR TITLE
Provide a embed class so that not all nodes get merged.

### DIFF
--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -99,6 +99,7 @@ class Normalizer
       node = nodes.pop()
       continue unless node?.parentNode?
       continue if dom.EMBED_TAGS[node.tagName]?
+      continue if dom(node).hasClass("ql-node-embed")
       if node.tagName == dom.DEFAULT_BREAK_TAG
         # Remove unneeded BRs
         dom(node).remove() unless lineNodeLength == 0

--- a/test/unit/core/normalizer.coffee
+++ b/test/unit/core/normalizer.coffee
@@ -117,6 +117,9 @@ describe('Normalizer', ->
       'preserve similar images':
         initial:  '<img src="http://quilljs.com/images/cloud.png"><img src="http://quilljs.com/images/cloud.png">'
         expected: '<img src="http://quilljs.com/images/cloud.png"><img src="http://quilljs.com/images/cloud.png">'
+      'preserve similar embed nodes':
+        initial:  '<span class="ql-node-embed">a</span><span class="ql-node-embed">b</span>'
+        expected: '<span class="ql-node-embed">a</span><span class="ql-node-embed">b</span>'
       'wrap orphaned text node':
         initial:  '<s><b>0</b></s><s><span>1</span></s>'
         expected: '<s><b>0</b><span>1</span></s>'


### PR DESCRIPTION
This can be useful for formats intended to represent 'tokens'.