### PR TITLE
Remove a cursor with an invalid index in _updateCursor()

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -85,7 +85,7 @@ class Editor
   getBounds: (index) ->
     this.checkUpdate()
     [leaf, offset] = @doc.findLeafAt(index, true)
-    throw new Error('Invalid index') unless leaf?
+    return null unless leaf?
     containerBounds = @root.parentNode.getBoundingClientRect()
     side = 'left'
     if leaf.length == 0   # BR case

--- a/src/modules/multi-cursor.coffee
+++ b/src/modules/multi-cursor.coffee
@@ -101,7 +101,10 @@ class MultiCursor extends EventEmitter2
     return cursor
 
   _updateCursor: (cursor) ->
-    bounds = @quill.getBounds(cursor.index)
+    try
+      bounds = @quill.getBounds(cursor.index)
+    catch err
+      return this.removeCursor(cursor.userId)
     cursor.elem.style.top = (bounds.top + @quill.container.scrollTop) + 'px'
     cursor.elem.style.left = bounds.left + 'px'
     cursor.elem.style.height = bounds.height + 'px'

--- a/src/modules/multi-cursor.coffee
+++ b/src/modules/multi-cursor.coffee
@@ -101,10 +101,8 @@ class MultiCursor extends EventEmitter2
     return cursor
 
   _updateCursor: (cursor) ->
-    try
-      bounds = @quill.getBounds(cursor.index)
-    catch err
-      return this.removeCursor(cursor.userId)
+    bounds = @quill.getBounds(cursor.index)
+    return this.removeCursor(cursor.userId) unless bounds?
     cursor.elem.style.top = (bounds.top + @quill.container.scrollTop) + 'px'
     cursor.elem.style.left = bounds.left + 'px'
     cursor.elem.style.height = bounds.height + 'px'


### PR DESCRIPTION
An example scenario:

- Two clients (client A and client B) are connected to the same document in such a way that client A's changes take 5 seconds to propagate to client B and vice versa.
- Let the initial length of the document be 100.
- Client A changes her cursor position to 95. At the same time, Client B deletes 20 characters from the beginning of the document.
- By the time Client B receives A's new cursor position, the document length is 80 characters, and the cursor position of 95 is invalid (beyond the end of the document).

The right thing to do in this scenario would be to transform Client A's cursor against the 20 character deletion. However, the amount of bookkeeping necessary to compute this diff is not trivial, and so for this edge case I prefer to just remove the offending cursor.
