### PR TITLE
Transform the undo/redo stacks against non-user initiated changes

### DIFF
--- a/src/modules/undo-manager.coffee
+++ b/src/modules/undo-manager.coffee
@@ -31,9 +31,9 @@ class UndoManager
         return false
       )
     )
-    @quill.on(@quill.constructor.events.TEXT_CHANGE, (delta, origin) =>
+    @quill.on(@quill.constructor.events.TEXT_CHANGE, (delta, source) =>
       return if @ignoreChange
-      if origin == 'user'
+      if source == Quill.sources.USER
         this.record(delta, @oldDelta)
       else
         this._transform(delta)

--- a/src/modules/undo-manager.coffee
+++ b/src/modules/undo-manager.coffee
@@ -7,6 +7,7 @@ class UndoManager
   @DEFAULTS:
     delay: 1000
     maxStack: 100
+    userOnly: false
 
   @hotkeys:
     UNDO: { key: 'Z', metaKey: true }
@@ -33,7 +34,7 @@ class UndoManager
     )
     @quill.on(@quill.constructor.events.TEXT_CHANGE, (delta, source) =>
       return if @ignoreChange
-      if source == Quill.sources.USER
+      if !@options.userOnly or source == Quill.sources.USER
         this.record(delta, @oldDelta)
       else
         this._transform(delta)

--- a/test/unit/modules/undo-manager.coffee
+++ b/test/unit/modules/undo-manager.coffee
@@ -9,7 +9,7 @@ describe('UndoManager', ->
       </div>'
     @quill = new Quill(@container.firstChild, {
       modules: {
-        'undo-manager': { delay: 400 }
+        'undo-manager': { delay: 400, userOnly: true }
       }
     })
     @undoManager = @quill.getModule('undo-manager')

--- a/test/unit/modules/undo-manager.coffee
+++ b/test/unit/modules/undo-manager.coffee
@@ -9,7 +9,7 @@ describe('UndoManager', ->
       </div>'
     @quill = new Quill(@container.firstChild, {
       modules: {
-        'undo-manager': { delay: 400, userOnly: true }
+        'undo-manager': { delay: 400 }
       }
     })
     @undoManager = @quill.getModule('undo-manager')
@@ -42,7 +42,7 @@ describe('UndoManager', ->
   describe('undo/redo', ->
     _.each(tests, (test, name) ->
       it(name, ->
-        @quill.updateContents(test.delta, Quill.sources.USER)
+        @quill.updateContents(test.delta)
         changed = @quill.getContents()
         expect(changed).not.toEqualDelta(@original)
         @undoManager.undo()
@@ -65,9 +65,9 @@ describe('UndoManager', ->
 
     it('merge changes', ->
       expect(@undoManager.stack.undo.length).toEqual(0)
-      @quill.updateContents(new Quill.Delta().retain(12).insert('e'), Quill.sources.USER)
+      @quill.updateContents(new Quill.Delta().retain(12).insert('e'))
       expect(@undoManager.stack.undo.length).toEqual(1)
-      @quill.updateContents(new Quill.Delta().retain(13).insert('s'), Quill.sources.USER)
+      @quill.updateContents(new Quill.Delta().retain(13).insert('s'))
       expect(@undoManager.stack.undo.length).toEqual(1)
       @undoManager.undo()
       expect(@quill.getContents()).toEqual(@original)
@@ -76,10 +76,10 @@ describe('UndoManager', ->
 
     it('dont merge changes', (done) ->
       expect(@undoManager.stack.undo.length).toEqual(0)
-      @quill.updateContents(new Quill.Delta().retain(12).insert('e'), Quill.sources.USER)
+      @quill.updateContents(new Quill.Delta().retain(12).insert('e'))
       expect(@undoManager.stack.undo.length).toEqual(1)
       setTimeout( =>
-        @quill.updateContents(new Quill.Delta().retain(13).insert('s'), Quill.sources.USER)
+        @quill.updateContents(new Quill.Delta().retain(13).insert('s'))
         expect(@undoManager.stack.undo.length).toEqual(2)
         done()
       , @undoManager.options.delay * 1.25)
@@ -87,10 +87,10 @@ describe('UndoManager', ->
 
     it('multiple undos', (done) ->
       expect(@undoManager.stack.undo.length).toEqual(0)
-      @quill.updateContents(new Quill.Delta().retain(12).insert('e'), Quill.sources.USER)
+      @quill.updateContents(new Quill.Delta().retain(12).insert('e'))
       contents = @quill.getContents()
       setTimeout( =>
-        @quill.updateContents(new Quill.Delta().retain(13).insert('s'), Quill.sources.USER)
+        @quill.updateContents(new Quill.Delta().retain(13).insert('s'))
         @undoManager.undo()
         expect(@quill.getContents()).toEqual(contents)
         @undoManager.undo()
@@ -100,7 +100,7 @@ describe('UndoManager', ->
     )
 
     it('hotkeys', ->
-      @quill.updateContents(new Quill.Delta().insert('A'), Quill.sources.USER)
+      @quill.updateContents(new Quill.Delta().insert('A'))
       changed = @quill.getContents()
       expect(changed).not.toEqualDelta(@original)
       dom(@quill.root).trigger('keydown', Quill.Module.UndoManager.hotkeys.UNDO)
@@ -110,6 +110,7 @@ describe('UndoManager', ->
     )
 
     it('api change transform', ->
+      @quill.getModule('undo-manager').options.userOnly = true
       @quill.updateContents(new Quill.Delta().retain(12).insert('es'), Quill.sources.USER)
       @quill.updateContents(new Quill.Delta().retain(4).delete(5), Quill.sources.API)
       @quill.updateContents(new Quill.Delta().retain(9).insert('!'), Quill.sources.USER)


### PR DESCRIPTION
This allows one to mark changes that should be "undoable" by specifying source = 'user', which is useful for a collaborative editing environment in which each client maintains their own undo / redo stack (instead of sharing a global one).