### PR TITLE
Added support for displaying images in the picker

### DIFF
--- a/src/lib/picker.coffee
+++ b/src/lib/picker.coffee
@@ -32,7 +32,15 @@ class Picker
   buildItem: (picker, option, index) ->
     item = document.createElement('span')
     item.setAttribute('data-value', option.getAttribute('value'))
-    dom(item).addClass('ql-picker-item').text(dom(option).text()).on('click', =>
+    dom(item).addClass('ql-picker-item').text(dom(option).text())
+    if (option.getAttribute('data-image-src'))
+      itemimg = document.createElement('img')
+      itemimg.setAttribute('src', option.getAttribute('data-image-src'))
+      if (item.firstChild)
+        item.insertBefore(itemimg, item.firstChild)
+      else
+        item.appendChild(itemimg);
+    dom(item).on('click', =>
       this.selectItem(item, true)
       this.close()
     )
@@ -60,7 +68,14 @@ class Picker
     if item?
       value = item.getAttribute('data-value')
       dom(item).addClass('ql-selected')
-      dom(@label).text(dom(item).text())
+
+      # Copy all the child nodes from the selected item and put them on the label
+      @label.removeChild(@label.firstChild) while @label.firstChild
+      _.each(item.childNodes, (element, index) =>
+        @label.appendChild(element.cloneNode())
+      )
+      #dom(@label).text(dom(item).text())
+
       dom(@select).option(value, trigger)
       @label.setAttribute('data-value', value)
     else

--- a/test/unit/lib/picker.coffee
+++ b/test/unit/lib/picker.coffee
@@ -6,7 +6,8 @@ describe('Picker', ->
       <select title="Font" class="ql-font">
         <option value="sans-serif" selected>Sans Serif</option>
         <option value="serif">Serif</option>
-        <option value="monospace">Monospace</option>
+        <option value="cursive" data-image-src="http://static.tinypic.com/i/tinypic-branding_@1x.png"></option>
+        <option value="monospace" data-image-src="http://static.tinypic.com/i/tinypic-branding_@1x.png">Monospace</option>
       </select>
     ')).get(0)
     @select = @container.querySelector('select')
@@ -20,7 +21,8 @@ describe('Picker', ->
         <span class="ql-picker-options">
           <span data-value="sans-serif" class="ql-picker-item ql-selected">Sans Serif</span>
           <span data-value="serif" class="ql-picker-item">Serif</span>
-          <span data-value="monospace" class="ql-picker-item">Monospace</span>
+          <span data-value="cursive" class="ql-picker-item"><img src="http://static.tinypic.com/i/tinypic-branding_@1x.png"/></span>
+          <span data-value="monospace" class="ql-picker-item"><img src="http://static.tinypic.com/i/tinypic-branding_@1x.png"/>Monospace</span>
         </span>
       </span>
     ')
@@ -44,7 +46,7 @@ describe('Picker', ->
     dom(@container.querySelector('.ql-picker-options').lastChild).trigger('click')
     expect(dom(@picker.label).text()).toEqual('Monospace')
     _.each(@container.querySelectorAll('.ql-picker-item'), (item, i) ->
-      expect(dom(item).hasClass('ql-selected')).toBe(i == 2)
+      expect(dom(item).hasClass('ql-selected')).toBe(i == 3)
     )
   )
 


### PR DESCRIPTION
If 'data-image-src' is included in the option, the image will be added as the first child of the label (before the text). I needed this to include web fonts so I could display what the font looks like in the picker with an image of the font name written in the font.