### PR TITLE
Show the flag while a remote user is typing like in Google Docs

### DIFF
--- a/src/modules/multi-cursor.coffee
+++ b/src/modules/multi-cursor.coffee
@@ -61,8 +61,12 @@ class MultiCursor extends EventEmitter2
 
   shiftCursors: (index, length, authorId = null) ->
     _.each(@cursors, (cursor, id) =>
-      return unless cursor and (cursor.index > index or cursor.userId == authorId)
-      cursor.index += Math.max(length, index - cursor.index)
+      return unless cursor
+      shift = Math.max(length, index - cursor.index)
+      if cursor.userId == authorId
+        this.moveCursor(authorId, cursor.index + shift)
+      else if cursor.index > index
+        cursor.index += shift
     )
 
   update: ->


### PR DESCRIPTION
This behavior:

![cursor](https://cloud.githubusercontent.com/assets/238948/8915547/a247d93a-3473-11e5-80ee-07b08bf31a5e.gif)

Without this change, the nametag part of the cursor does not appear as new characters are inserted.