### PR TITLE
Headings

### DIFF
--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -66,15 +66,21 @@ class Format
       style: 'textAlign'
       default: 'left'
 
+    h1:
+      type: Format.types.LINE
+      exclude: ['list','bullet']
+      # parentTag: 'UL'
+      tag: 'H1'
+
     bullet:
       type: Format.types.LINE
-      exclude: 'list'
+      exclude: ['list','h1']
       parentTag: 'UL'
       tag: 'LI'
 
     list:
       type: Format.types.LINE
-      exclude: 'bullet'
+      exclude: ['bullet','h1']
       parentTag: 'OL'
       tag: 'LI'
 

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -68,12 +68,12 @@ class Format
 
     h1: ( ->
       headers = (lvl) ->
-        exclude = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'list','bullet']
-        exclude.slice(lvl-1, 1)
+        exclude = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'list', 'bullet']
+        exclude.splice(lvl-1, 1)
         {
           type: Format.types.LINE
           exclude: exclude
-          tag: "h#{lvl}"
+          tag: "H#{lvl}"
         }
       headers(1)
     )()

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -1,6 +1,6 @@
 _   = require('lodash')
 dom = require('../lib/dom')
-
+headers = null
 
 class Format
   @types:
@@ -66,21 +66,32 @@ class Format
       style: 'textAlign'
       default: 'left'
 
-    h1:
-      type: Format.types.LINE
-      exclude: ['list','bullet']
-      # parentTag: 'UL'
-      tag: 'H1'
+    h1: ( ->
+      headers = (lvl) ->
+        exclude = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'list','bullet']
+        exclude.slice(lvl-1, 1)
+        {
+          type: Format.types.LINE
+          exclude: exclude
+          tag: "h#{lvl}"
+        }
+      headers(1)
+    )()
+    h2: headers(2)
+    h3: headers(3)
+    h4: headers(4)
+    h5: headers(5)
+    h6: headers(6)
 
     bullet:
       type: Format.types.LINE
-      exclude: ['list','h1']
+      exclude: ['list','h1', 'h2', 'h3', 'h4', 'h5', 'h6']
       parentTag: 'UL'
       tag: 'LI'
 
     list:
       type: Format.types.LINE
-      exclude: ['bullet','h1']
+      exclude: ['bullet', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
       parentTag: 'OL'
       tag: 'LI'
 

--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -67,11 +67,15 @@ class Line extends LinkedList.Node
       return unless format?
       # TODO reassigning @node might be dangerous...
       if format.isType(Format.types.LINE)
-        if format.config.exclude and @formats[format.config.exclude]
-          excludeFormat = @doc.formats[format.config.exclude]
-          if excludeFormat?
-            @node = excludeFormat.remove(@node)
-            delete @formats[format.config.exclude]
+        # if format.config.exclude and @formats[format.config.exclude]
+        # debugger
+        if format.config.exclude and _.find(format.config.exclude, (candidateToExclude) => @formats[candidateToExclude])
+          _.each format.config.exclude, (excludeFormatName) =>
+            excludeFormat = @doc.formats[excludeFormatName]
+            if excludeFormat?
+              @node = excludeFormat.remove(@node)
+              console.log "delete format: #{format.config.exclude}"
+              delete @formats[excludeFormatName]
         @node = format.add(@node, value)
       if value
         @formats[name] = value

--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -67,14 +67,11 @@ class Line extends LinkedList.Node
       return unless format?
       # TODO reassigning @node might be dangerous...
       if format.isType(Format.types.LINE)
-        # if format.config.exclude and @formats[format.config.exclude]
-        # debugger
         if format.config.exclude and _.find(format.config.exclude, (candidateToExclude) => @formats[candidateToExclude])
           _.each format.config.exclude, (excludeFormatName) =>
             excludeFormat = @doc.formats[excludeFormatName]
             if excludeFormat?
               @node = excludeFormat.remove(@node)
-              console.log "delete format: #{format.config.exclude}"
               delete @formats[excludeFormatName]
         @node = format.add(@node, value)
       if value

--- a/src/core/normalizer.coffee
+++ b/src/core/normalizer.coffee
@@ -35,6 +35,7 @@ class Normalizer
     @whitelist.tags[config.tag] = true if config.tag?
     @whitelist.tags[config.parentTag] = true if config.parentTag?
     @whitelist.styles[config.style] = true if config.style?
+    config.exclude = [config.exclude] if _.isString(config.exclude)
 
   normalizeLine: (lineNode) ->
     lineNode = Normalizer.wrapInline(lineNode)

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -1,7 +1,7 @@
 Quill  = require('../quill')
 _      = Quill.require('lodash')
 dom    = Quill.require('dom')
-Format = Quill.require('Format')
+Format = Quill.require('format')
 
 
 class Toolbar
@@ -99,7 +99,9 @@ class Toolbar
     else
       @quill.formatText(range, format, value, 'user')
     _.defer( =>
-      this.updateActive(range, ['bullet', 'list', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'])  # Clear exclusive formats
+      exclude = @quill.editor.doc.formats[format].config.exclude
+      exclusive = if exclude then [].concat(exclude, format) else [format]
+      this.updateActive(range, exclusive)  # Clear exclusive formats
       this.setActive(format, value)
     )
 

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -1,6 +1,7 @@
-Quill = require('../quill')
-_     = Quill.require('lodash')
-dom   = Quill.require('dom')
+Quill  = require('../quill')
+_      = Quill.require('lodash')
+dom    = Quill.require('dom')
+Format = Quill.require('Format')
 
 
 class Toolbar
@@ -8,9 +9,9 @@ class Toolbar
     container: null
 
   @formats:
-    LINE    : { 'align', 'bullet', 'list', 'h1' }
+    LINE    : { 'align', 'bullet', 'list', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'h1' }
+    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' }
     TOOLTIP : { 'image', 'link' }
 
   constructor: (@quill, @options) ->
@@ -85,7 +86,6 @@ class Toolbar
     activeFormats = this._getActive(range)
     _.each(@inputs, (input, format) =>
       if !Array.isArray(formats) or formats.indexOf(format) > -1
-        # debugger
         this.setActive(format, activeFormats[format])
       return true
     )
@@ -99,7 +99,7 @@ class Toolbar
     else
       @quill.formatText(range, format, value, 'user')
     _.defer( =>
-      this.updateActive(range, ['bullet', 'list'])  # Clear exclusive formats
+      this.updateActive(range, ['bullet', 'list', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'])  # Clear exclusive formats
       this.setActive(format, value)
     )
 
@@ -122,8 +122,6 @@ class Toolbar
 
   _getLineActive: (range) ->
     formatsArr = []
-    # debugger
-    console.log '_getLineActive'
     [firstLine, offset] = @quill.editor.doc.findLineAt(range.start)
     [lastLine, offset] = @quill.editor.doc.findLineAt(range.end)
     lastLine = lastLine.next if lastLine? and lastLine == firstLine

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -8,9 +8,9 @@ class Toolbar
     container: null
 
   @formats:
-    LINE    : { 'align', 'bullet', 'list' }
+    LINE    : { 'align', 'bullet', 'list', 'h1' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline' }
+    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'h1' }
     TOOLTIP : { 'image', 'link' }
 
   constructor: (@quill, @options) ->
@@ -85,6 +85,7 @@ class Toolbar
     activeFormats = this._getActive(range)
     _.each(@inputs, (input, format) =>
       if !Array.isArray(formats) or formats.indexOf(format) > -1
+        # debugger
         this.setActive(format, activeFormats[format])
       return true
     )
@@ -121,6 +122,8 @@ class Toolbar
 
   _getLineActive: (range) ->
     formatsArr = []
+    # debugger
+    console.log '_getLineActive'
     [firstLine, offset] = @quill.editor.doc.findLineAt(range.start)
     [lastLine, offset] = @quill.editor.doc.findLineAt(range.end)
     lastLine = lastLine.next if lastLine? and lastLine == firstLine

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -18,7 +18,7 @@ class Quill extends EventEmitter2
   @themes: []
 
   @DEFAULTS:
-    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
+    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list', 'h1']
     modules:
       'keyboard': true
       'paste-manager': true

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -18,7 +18,7 @@ class Quill extends EventEmitter2
   @themes: []
 
   @DEFAULTS:
-    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list', 'h1']
+    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
     modules:
       'keyboard': true
       'paste-manager': true


### PR DESCRIPTION
Hi! I have added headings — h1, h2, h3, h4, h5, h6

For that i had to make `exclude` option as array, but preserved string type also:
```coffeescript
list:
  type: Format.types.LINE
  exclude: ['bullet', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
  parentTag: 'OL'
  tag: 'LI'
```

And In toolbar i made getting of exclusive formats for clearing dynamically. Now it works properly for formats that has been added by API:
```coffeescript
exclude = @quill.editor.doc.formats[format].config.exclude
exclusive = if exclude then [].concat(exclude, format) else [format]
this.updateActive(range, exclusive)  # Clear exclusive formats
```
grunt test:unit — passed
grunt test:e2e — can't run it on my local machine because some problems with Java. Upgade for Java didn't help