### PR TITLE
Only apply non-line formats when building a new leaf

### DIFF
--- a/src/core/line.coffee
+++ b/src/core/line.coffee
@@ -110,7 +110,8 @@ class Line extends LinkedList.Node
     [leaf, leafOffset] = this.findLeafAt(offset)
     node = _.reduce(formats, (node, value, name) =>
       format = @doc.formats[name]
-      node = format.add(node, value) if format?
+      if format? and !format.isType(Format.types.LINE)
+        node = format.add(node, value)
       return node
     , node)
     [prevNode, nextNode] = dom(leaf.node).split(leafOffset)

--- a/test/unit/core/line.coffee
+++ b/test/unit/core/line.coffee
@@ -345,6 +345,10 @@ describe('Line', ->
         initial: '<b>01</b>'
         expected: '<b>0</b><img src="http://quilljs.com/images/cloud.png"><b>1</b>'
         offset: 1, formats: { image: 'http://quilljs.com/images/cloud.png' }
+      'line formats ignored':
+        initial: 'ab'
+        expected: 'a<b>|</b>b'
+        offset: 1, formats: { list: true, bold: true }
 
     _.each(tests, (test, name) ->
       it(name, ->


### PR DESCRIPTION
Sometimes, a strange looking delta may come into quill, such as:

```
// 'list' is not a valid format for inline text
{ ops: [{ insert: 'abc', attributes: { list: true }, { insert: '\n' }] }
```

Line formats like `list` are expected to only apply to line nodes (they have a parentNode, etc). When `format.add(node, value)` is called on a leaf node, especially one that is detached from the DOM, bad things may happen, such as:

```
Uncaught TypeError: Cannot read property 'replaceChild' of null
  Wrapper.replace @ dom.coffee:165
  Wrapper.switchTag @ dom.coffee:232
  Format.add @ format.coffee:102
  (anonymous function) @ line.coffee:110
```

Quill should be resilient when such a delta is passed to `quill.setContents()`, by ignoring formats in the wrong context. This change ensures that only non-line formats are applied to new leaf nodes, avoiding these types of errors.