### PR TITLE
Add superscript and subscript support

### DIFF
--- a/examples/index.jade
+++ b/examples/index.jade
@@ -45,6 +45,7 @@ html
           button.ql-format-button.ql-italic(title='Italic') Italic
           button.ql-format-button.ql-underline(title='Underline') Under
           button.ql-format-button.ql-strike(title='Strikethrough') Strike
+          button.ql-format-button.ql-superscript(title='Superscript') Super
           button.ql-format-button.ql-link(title='Link') Link
           button.ql-format-button.ql-image(title='Image') Image
           button.ql-format-button.ql-bullet(title='Bullet') Bullet

--- a/examples/index.jade
+++ b/examples/index.jade
@@ -46,6 +46,7 @@ html
           button.ql-format-button.ql-underline(title='Underline') Under
           button.ql-format-button.ql-strike(title='Strikethrough') Strike
           button.ql-format-button.ql-superscript(title='Superscript') Super
+          button.ql-format-button.ql-subscript(title='Subscript') Sub
           button.ql-format-button.ql-link(title='Link') Link
           button.ql-format-button.ql-image(title='Image') Image
           button.ql-format-button.ql-bullet(title='Bullet') Bullet

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -28,6 +28,10 @@ class Format
       tag: 'SUP'
       prepare: 'superscript'
 
+    subscript:
+      tag: 'SUB'
+      prepare: 'subscript'
+
     color:
       style: 'color'
       default: 'rgb(0, 0, 0)'

--- a/src/core/format.coffee
+++ b/src/core/format.coffee
@@ -24,6 +24,10 @@ class Format
       tag: 'S'
       prepare: 'strikeThrough'
 
+    superscript:
+      tag: 'SUP'
+      prepare: 'superscript'
+
     color:
       style: 'color'
       default: 'rgb(0, 0, 0)'

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -10,7 +10,7 @@ class Toolbar
   @formats:
     LINE    : { 'align', 'bullet', 'list' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'superscript' }
+    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'superscript', 'subscript' }
     TOOLTIP : { 'image', 'link' }
 
   constructor: (@quill, @options) ->

--- a/src/modules/toolbar.coffee
+++ b/src/modules/toolbar.coffee
@@ -10,7 +10,7 @@ class Toolbar
   @formats:
     LINE    : { 'align', 'bullet', 'list' }
     SELECT  : { 'align', 'background', 'color', 'font', 'size' }
-    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline' }
+    TOGGLE  : { 'bold', 'bullet', 'image', 'italic', 'link', 'list', 'strike', 'underline', 'superscript' }
     TOOLTIP : { 'image', 'link' }
 
   constructor: (@quill, @options) ->

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -18,7 +18,7 @@ class Quill extends EventEmitter2
   @themes: []
 
   @DEFAULTS:
-    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'superscript', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
+    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'superscript', 'subscript', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
     modules:
       'keyboard': true
       'paste-manager': true

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -18,7 +18,7 @@ class Quill extends EventEmitter2
   @themes: []
 
   @DEFAULTS:
-    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
+    formats: ['align', 'bold', 'italic', 'strike', 'underline', 'superscript', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
     modules:
       'keyboard': true
       'paste-manager': true


### PR DESCRIPTION
Add support for `<sup>` and `<sub>` tags, as requested here: https://github.com/quilljs/quill/issues/249.
I didn't find this caused the nesting problem described in the issue.

I wasn't sure which tests I needed to add for this as the unit tests iterate over formats, so please let me know and I can add whatever tests are needed. I've manually tested in several browsers.