### PR TITLE
Improve keyboard accessibility for multiple Quill instances

### DIFF
--- a/src/modules/paste-manager.coffee
+++ b/src/modules/paste-manager.coffee
@@ -11,6 +11,7 @@ class PasteManager
   constructor: (@quill, options) ->
     @container = @quill.addContainer('ql-paste-manager')
     @container.setAttribute('contenteditable', true)
+    @container.setAttribute('tabindex', '-1')
     dom(@quill.root).on('paste', _.bind(this._paste, this))
     @options = _.defaults(options, PasteManager.DEFAULTS)
     @options.onConvert ?= this._onConvert;


### PR DESCRIPTION
When there are multiple Quill instances on a page (for example, a form that needs to be filled in with rich text data) and you have disabled tab using the technique in https://github.com/quilljs/quill/issues/110, it takes about 6 hits of the tab key to get from one field to the next.

This is due to the extra keyboard-focusable elements in the paste manager and tooltip modules.

Solution: add `tabindex="-1"` to these elements so they are skipped when tabbing through the page.

This also solves numerous problems with screenreaders not automatically reading down the page.