### PR TITLE
Alternative fix for #432 that also works with formats added via quill.addFormat()

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -92,7 +92,7 @@ class Keyboard
     )
     _.each(['bold', 'italic', 'underline'], (format) =>
       this.addHotkey(Keyboard.hotkeys[format.toUpperCase()], (range) =>
-        if (@quill.options.formats.indexOf(format) > -1)
+        if (@quill.editor.doc.formats[format])
           this.toggleFormat(range, format)
         return false
       )


### PR DESCRIPTION
Commit c5d2ede caused my bold / italic / underline hotkeys to stop working, because I set up all of my formats programatically through `quill.addFormat()`.

Instead of checking `@quill.options.formats`, the handler should instead check `@quill.editor.doc.formats`.