### PR TITLE
Allow keyboard options to be passed which disable the default hotkeys

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -5,6 +5,14 @@ Delta  = Quill.require('delta')
 
 
 class Keyboard
+  @DEFAULTS:
+    enter: true
+    indent: true
+    outdent: true
+    bold: true
+    italic: true
+    underline: true
+
   @hotkeys:
     BOLD:       { key: 'B',          metaKey: true }
     INDENT:     { key: dom.KEYS.TAB }
@@ -12,7 +20,8 @@ class Keyboard
     OUTDENT:    { key: dom.KEYS.TAB, shiftKey: true }
     UNDERLINE:  { key: 'U',          metaKey: true }
 
-  constructor: (@quill, options) ->
+  constructor: (@quill, @options) ->
+    @options = _.defaults(@options, Keyboard.DEFAULTS)
     @hotkeys = {}
     this._initListeners()
     this._initHotkeys()
@@ -85,20 +94,20 @@ class Keyboard
     this.addHotkey(Keyboard.hotkeys.INDENT, (range) =>
       this._onTab(range, false)
       return false
-    )
+    ) if @options.indent
     this.addHotkey(Keyboard.hotkeys.OUTDENT, (range) =>
       # TODO implement when we implement multiline tabs
       return false
-    )
+    ) if @options.outdent
     _.each(['bold', 'italic', 'underline'], (format) =>
       this.addHotkey(Keyboard.hotkeys[format.toUpperCase()], (range) =>
         if (@quill.options.formats.indexOf(format) > -1)
           this.toggleFormat(range, format)
         return false
-      )
+      ) if @options[format]
     )
     this._initDeletes()
-    this._initEnter()
+    this._initEnter() if @options.enter
 
   _initListeners: ->
     dom(@quill.root).on('keydown', (event) =>

--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -20,7 +20,7 @@ class Quill extends EventEmitter2
   @DEFAULTS:
     formats: ['align', 'bold', 'italic', 'strike', 'underline', 'color', 'background', 'font', 'size', 'link', 'image', 'bullet', 'list']
     modules:
-      'keyboard': true
+      'keyboard': {}
       'paste-manager': true
       'undo-manager': true
     pollInterval: 100

--- a/test/unit/modules/keyboard.coffee
+++ b/test/unit/modules/keyboard.coffee
@@ -81,4 +81,13 @@ describe('Keyboard', ->
       expect(dom($('.ql-size').get(0)).value()).toBe(size)
     )
   )
+
+  describe('options', ->
+    it('does not set up handlers', ->
+      @container.innerHTML = '<div>abc</div>'
+      quill = new Quill(@container.firstChild, { modules: { keyboard: { enter: false } } })
+      keyboard = quill.getModule('keyboard')
+      expect(keyboard.hotkeys[Quill.Lib.DOM.KEYS.ENTER]).toBe(undefined)
+    )
+  )
 )


### PR DESCRIPTION
I needed to register a hotkey handler for ENTER that ran before the built-in one (for making a single line input that blurs when enter is pressed). Since using `addHotkey` adds a handler to run AFTER the built-in one, I was stuck.

The solution I came up with lets you selectively disable any of the default handlers, which may be useful in its own right.