### PR TITLE
Add <input> tag to embed tags

### DIFF
--- a/src/lib/dom.coffee
+++ b/src/lib/dom.coffee
@@ -415,7 +415,8 @@ dom = _.extend(dom,
   }
 
   EMBED_TAGS: {
-    'IMG'
+    'IMG',
+    'INPUT'
   }
 
   LINE_TAGS: {


### PR DESCRIPTION
Adding `<input>` tag to embed tags, since we went with it for endnotes, since `<meta>` tag with pseudo-elements was generating a closing tag, and that leads to 'funny' behaviours (like managing to get text inside the tag, etc).

It really do not seem like a pretty thing to add `<input>` to embed tags, but its our best shot at the moment to support endnotes. Probably this won't be accepted on upstream, as well. :confused: 