### PR TITLE
In applyDelta(), emit the change for localDelta before continuing

### DIFF
--- a/src/core/editor.coffee
+++ b/src/core/editor.coffee
@@ -35,10 +35,9 @@ class Editor
     @root.setAttribute('contenteditable', enabled)
 
   applyDelta: (delta, source) ->
-    localDelta = this._update()
+    localDelta = this.checkUpdate()
     if localDelta
       delta = localDelta.transform(delta, true)
-      localDelta = delta.transform(localDelta, false)
     if delta.ops.length > 0
       delta = this._trackDelta( =>
         index = 0
@@ -63,8 +62,6 @@ class Editor
       @length = @delta.length()
       @innerHTML = @root.innerHTML
       @quill.emit(@quill.constructor.events.TEXT_CHANGE, delta, source) if delta and source != Editor.sources.SILENT
-    if localDelta and localDelta.ops.length > 0 and source != Editor.sources.SILENT
-      @quill.emit(@quill.constructor.events.TEXT_CHANGE, localDelta, Editor.sources.USER)
 
   checkUpdate: (source = 'user') ->
     return clearInterval(@timer) unless @root.parentNode?
@@ -75,6 +72,7 @@ class Editor
       @quill.emit(@quill.constructor.events.TEXT_CHANGE, delta, source)
     source = Editor.sources.SILENT if delta
     @selection.update(source)
+    return delta
 
   focus: ->
     if @selection.range?

--- a/test/unit/core/editor.coffee
+++ b/test/unit/core/editor.coffee
@@ -270,11 +270,16 @@ describe('Editor', ->
     it('local change', ->
       @editor.doc.setHTML('<div>0123</div>')
       @editor.checkUpdate()
+      changes = []
+      @editor.quill.on('text-change', (d) -> changes.push(d))
       delta = new Quill.Delta().retain(4).insert('|')
       @editor.root.querySelector('div').innerHTML = '01a23'
       @editor.applyDelta(delta)
       expected = '<div>01a23|</div>'
       expect(@editor.root).toEqualHTML(expected, true)
+      expect(changes.length).toEqual(2)
+      expect(changes[0]).toEqual(new Quill.Delta().retain(2).insert('a'))
+      expect(changes[1]).toEqual(new Quill.Delta().retain(5).insert('|'))
     )
   )
 
@@ -393,6 +398,26 @@ describe('Editor', ->
         expect(bounds.height).toBeApproximately(reference.image.height, 1)
         expect(bounds.left).toBeApproximately(reference.image.width, 1)
       )
+    )
+  )
+
+  describe('checkUpdate()', ->
+    beforeEach(->
+      @changes = []
+      @editor.quill.on('text-change', (d) => @changes.push(d))
+    )
+
+    it('no changes', ->
+      result = @editor.checkUpdate()
+      expect(result).toEqual(false)
+    )
+
+    it('changed contents', ->
+      @editor.doc.setHTML('<div>abc</div>')
+      result = @editor.checkUpdate()
+      expected = new Quill.Delta().insert('abc\n')
+      expect(result).toEqual(expected)
+      expect(@changes).toEqual([expected])
     )
   )
 )


### PR DESCRIPTION
This fixes a bug where the changes represented by `localDelta` would be emitted twice, because in that case the result of `_trackDelta()` will effectively be `delta.compose(localDelta)`.

I thought it was clearest to use `checkUpdate()` to trigger the text-change event for any `localDelta` before proceeding. In order to do this, I modified `checkUpdate()` to return the delta found.

An alternative solution would be to continue using `_update()`, and simply let there be a single text-change event emitted, containing the composition of `localDelta` and `delta. I thought two separate events felt cleaner, however.

I've added some assertions to the local update test to demonstrate the expected behavior, and also to verify the return value of `checkUpdate()`.