### PR TITLE
Fix for when trying to insert before a list item

### DIFF
--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -52,7 +52,14 @@ class Document
   insertLineBefore: (newLineNode, refLine) ->
     line = new Line(this, newLineNode)
     if refLine?
-      @root.insertBefore(newLineNode, refLine.node) unless dom(newLineNode.parentNode).isElement()  # Would prefer newLineNode.parentNode? but IE will have non-null object
+      refNode = refLine.node
+
+      if refLine.node.tagName == 'LI' and newLineNode.tagName != 'LI'
+        refNode = refLine.node.parentNode
+        while refLine and refLine.prev and refLine.node.tagName != 'LI'
+          refLine = refLine.prev
+
+      @root.insertBefore(newLineNode, refNode) unless dom(newLineNode.parentNode).isElement()  # Would prefer newLineNode.parentNode? but IE will have non-null object
       @lines.insertAfter(refLine.prev, line)
     else
       @root.appendChild(newLineNode) unless dom(newLineNode.parentNode).isElement()

--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -52,14 +52,18 @@ class Document
   insertLineBefore: (newLineNode, refLine) ->
     line = new Line(this, newLineNode)
     if refLine?
+      parentNode = @root
       refNode = refLine.node
 
-      if refLine.node.tagName == 'LI' and newLineNode.tagName != 'LI'
-        refNode = refLine.node.parentNode
-        while refLine and refLine.prev and refLine.node.tagName != 'LI'
-          refLine = refLine.prev
+      # if refLine.node.tagName == 'LI'
+      #   if newLineNode.tagName == 'LI'
+      #     parentNode = refLine.node.parentNode
+      #   else
+      #     refNode = refLine.node.parentNode
+      #     while refLine and refLine.prev and refLine.node.tagName != 'LI'
+      #       refLine = refLine.prev
 
-      @root.insertBefore(newLineNode, refNode) unless dom(newLineNode.parentNode).isElement()  # Would prefer newLineNode.parentNode? but IE will have non-null object
+      parentNode.insertBefore(newLineNode, refNode) unless dom(newLineNode.parentNode).isElement()  # Would prefer newLineNode.parentNode? but IE will have non-null object
       @lines.insertAfter(refLine.prev, line)
     else
       @root.appendChild(newLineNode) unless dom(newLineNode.parentNode).isElement()

--- a/src/core/document.coffee
+++ b/src/core/document.coffee
@@ -55,13 +55,13 @@ class Document
       parentNode = @root
       refNode = refLine.node
 
-      # if refLine.node.tagName == 'LI'
-      #   if newLineNode.tagName == 'LI'
-      #     parentNode = refLine.node.parentNode
-      #   else
-      #     refNode = refLine.node.parentNode
-      #     while refLine and refLine.prev and refLine.node.tagName != 'LI'
-      #       refLine = refLine.prev
+      if refLine.node.tagName == 'LI'
+        if newLineNode.tagName == 'LI'
+          parentNode = refLine.node.parentNode
+        else
+          refNode = refLine.node.parentNode
+          while refLine and refLine.prev and refLine.node.tagName != 'LI'
+            refLine = refLine.prev
 
       parentNode.insertBefore(newLineNode, refNode) unless dom(newLineNode.parentNode).isElement()  # Would prefer newLineNode.parentNode? but IE will have non-null object
       @lines.insertAfter(refLine.prev, line)

--- a/test/unit/core/document.coffee
+++ b/test/unit/core/document.coffee
@@ -145,6 +145,33 @@ describe('Document', ->
       @lines = @doc.lines.toArray()
     )
 
+    describe('insertLineBefore() into list', ->
+      listNode = null
+      listItemLine = null
+
+      beforeEach( ->
+        listNode = @doc.root.ownerDocument.createElement('ul')
+        listNode.innerHTML = '<li>Item 1</li><li>Item 2</li>'
+        @doc.root.appendChild(listNode)
+        @doc.rebuild()
+        listItemLine = @doc.findLine(listNode.firstChild)
+      )
+
+      it('with list item', ->
+        newListItemNode = @doc.root.ownerDocument.createElement('li')
+        newListItemNode.innerHTML = 'Item 0'
+        @doc.insertLineBefore(newListItemNode, listItemLine)
+        expect(listItemLine.node.previousSibling).toBe(newListItemNode)
+      )
+
+      it('with standard line', ->
+        lineNode = @doc.root.ownerDocument.createElement(dom.DEFAULT_BLOCK_TAG)
+        lineNode.innerHTML = 'Line'
+        @doc.insertLineBefore(lineNode, listItemLine)
+        expect(listNode.previousSibling).toBe(lineNode)
+      )
+    )
+
     it('mergeLines() normal', ->
       @doc.mergeLines(@lines[0], @lines[1])
       expect(@doc.root).toEqualHTML('


### PR DESCRIPTION
Hi @jhchen, I'm creating a drag and drop module that allows to move the line objects around and I ran into an issue when trying to call `insertLineBefore` before an `LI` ... so as I understand the `LI`s are classed as the line object and the `UL` or the `OL` are kind of ignored.

So when I'm moving line objects around, if I hit an `UL` or a `OL`, I target the first `LI` so I can get a line object, but calling `insertBeforeLine` when the `newLineNode` is not an `LI` causes issues. 

My proposed changes are when the `newLineNode` is not `LI` and the `refLine` is, then target the first `LI` in the series set the dom node to be inserted before to be the `UL` or the `OL`.

If I'm going about this wrong, please let me know :smile_cat: 

