### PR TITLE
Backspacing on a list item

### DIFF
--- a/src/modules/keyboard.coffee
+++ b/src/modules/keyboard.coffee
@@ -87,7 +87,7 @@ class Keyboard
             [line, offset] = @quill.editor.doc.findLineAt(range.start)
             if offset == 0 and (line.formats.bullet or line.formats.list)
               format = if line.formats.bullet then 'bullet' else 'list'
-              @quill.formatLine(range.start, range.start, format, false)
+              @quill.formatLine(range.start, range.start, format, false, Quill.sources.USER)
             else if range.start > 0
               @quill.deleteText(range.start - 1, range.start, Quill.sources.USER)
           else if range.start < @quill.getLength() - 1


### PR DESCRIPTION
@jhchen I'm not sure if this is a bug or intentional (so haven't done a test) ... but when backspacing on a list item, it would behave correctly in the client (removing the format) but it wouldn't be classed as a user change, so when filtering out API text changes it can't be transmitted to other clients.  