### PR TITLE
Add 'none' to the theme options

### DIFF
--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -244,6 +244,7 @@ class Quill extends EventEmitter2
 
 Quill.registerTheme('base', require('./themes/base'))
 Quill.registerTheme('snow', require('./themes/snow'))
+Quill.registerTheme('none', require('./themes/none'))
 
 
 module.exports = Quill

--- a/src/themes/none/index.coffee
+++ b/src/themes/none/index.coffee
@@ -1,4 +1,3 @@
-_ = require('lodash')
 dom = require('../../lib/dom')
 
 class BaseTheme

--- a/src/themes/none/index.coffee
+++ b/src/themes/none/index.coffee
@@ -1,6 +1,7 @@
 dom = require('../../lib/dom')
 
 class BaseTheme
+  @OPTIONS: {}
 
   constructor: (@quill, @options) ->
     dom(@quill.container).addClass('ql-container')

--- a/src/themes/none/index.coffee
+++ b/src/themes/none/index.coffee
@@ -1,0 +1,13 @@
+_ = require('lodash')
+dom = require('../../lib/dom')
+
+class BaseTheme
+
+  constructor: (@quill, @options) ->
+    dom(@quill.container).addClass('ql-container')
+    if dom.isIE(10)
+      version = if dom.isIE(9) then '9' else '10'
+      dom(@quill.root).addClass('ql-ie-' + version)
+
+
+module.exports = BaseTheme


### PR DESCRIPTION
This PR allows you to initialise Quill with `theme: 'none'` passed in as an option, with the effect that no `<style>` tags are injected into the page.

This enables you to apply your own styling to your Quill instance without having to override the base theme CSS.

It should be noted that if a theme other than `none` is applied to Quill, it will inject one `<style>` tag into the page per instance of Quill (I haven't changed this behaviour). That could be fixed in another PR.