### PR TITLE
Don't throw an error when moveCursor() is called with an invalid userId

### DIFF
--- a/src/modules/multi-cursor.coffee
+++ b/src/modules/multi-cursor.coffee
@@ -29,6 +29,7 @@ class MultiCursor extends EventEmitter2
 
   moveCursor: (userId, index) ->
     cursor = @cursors[userId]
+    return unless cursor?
     cursor.index = index
     dom(cursor.elem).removeClass('hidden')
     clearTimeout(cursor.timer)


### PR DESCRIPTION
For some reason, my application generates errors like this:

```
TypeError: Cannot set property 'index' of undefined
  at MultiCursor.moveCursor(~/quill/src/modules/multi-cursor.coffee:32:4)
  at ?(~/quill/src/modules/multi-cursor.coffee:58:11)
  at ?(~/lodash/index.js:1807:36)
```

I'd rather `moveCursor` just be a no-op in that case.