### PR TITLE
fixed context of this in formatText

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,6 +4,5 @@ bower.json
 config
 docs
 examples
-src
 test
 Gruntfile.coffee

--- a/src/quill.js
+++ b/src/quill.js
@@ -167,7 +167,7 @@ class Quill extends EventEmitter {
     this._track(source, () => {
       Object.keys(formats).forEach(function(format) {
         this.editor.formatAt(start, end-start, format, formats[format]);
-      });
+      }, this);
     });
   }
 

--- a/src/quill.js
+++ b/src/quill.js
@@ -21,7 +21,7 @@ import ListFormat from './formats/list';
 
 class Quill extends EventEmitter {
   static registerFormat(format) {
-    let name = format.blotName || formatAttrName;
+    let name = format.blotName || format.AttrName;
     // TODO this is static cannot emit
     if (Parchment.match(name)) {
       this.emit(Quill.events.DEBUG, 'warning', "Overwriting " + name + " format");
@@ -248,7 +248,7 @@ class Quill extends EventEmitter {
       delta = delta.slice();
     }
     this._track(source, () => {
-      this.editor.deleteText(0, this.editor.getLength());
+      this.deleteText(0, this.editor.getLength());
       this.editor.applyDelta(delta);
     });
   }

--- a/src/selection.js
+++ b/src/selection.js
@@ -129,8 +129,12 @@ class Selection {
     let pos = this.doc.findPath(range.start).pop();
     let target = pos.blot.split(pos.offset);
     let cursor = Parchment.create('cursor');
-    target.parent.insertBefore(cursor, target);
-    cursor.format(format, value);
+    
+    if (target) {
+      target.parent.insertBefore(cursor, target);
+      cursor.format(format, value);
+    }
+    
     // Cursor will not blink if we make selection
     this.setNativeRange(cursor.domNode.firstChild, 1);
   }


### PR DESCRIPTION
Quill is awesome. Great to see it migrating to ES6 too.

I was getting an error with this `forEach`. Have updated so it includes the correct context for `this`.