### PR TITLE
Add gulp-connect to dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "css-loader": "~0.20.2",
     "del": "^2.0.2",
     "gulp": "^3.9.0",
+    "gulp-connect": "^2.2.0",
     "gulp-flatten": "~0.2.0",
     "gulp-gzip": "^1.2.0",
     "gulp-header": "^1.7.1",


### PR DESCRIPTION
When running `npm install` I was getting an error that `gulp-connect` could not be found. This makes sure that `gulp-connect` is installed correctly for use in [config/build.js](https://github.com/quilljs/quill/blob/61f26327eea1cae659916555fb7296065922e2d6/config/build.js#L2) and [config/test.js](https://github.com/quilljs/quill/blob/61f26327eea1cae659916555fb7296065922e2d6/config/test.js#L4).