### PR TITLE
Add ability to derive range from a clientX/clientY point. Used with drop events

### DIFF
--- a/src/quill.js
+++ b/src/quill.js
@@ -264,6 +264,14 @@ class Quill extends EventEmitter {
     });
   }
 
+  setSelectionFromPoint(clientX, clientY, source = Quill.sources.API) {
+    let range = this.selection.getRangeFromPoint(clientX, clientY);
+    if (range) {
+      this.selection.setRange(range, source)
+    }
+    return range;
+  }
+
   setSelection(start, end = start, source = Quill.sources.API) {
     let range;
     if (typeof end === 'string') {

--- a/src/selection.js
+++ b/src/selection.js
@@ -165,8 +165,8 @@ class Selection {
       try {
         let nativeRange = document.body.createTextRange();
         nativeRange.moveToPoint(clientX, clientY);
-        let {commonAncestorContainer, startOffset} = nativeRange;
-        range = new Range(this.convertNativeRange(commonAncestorContainer, startOffset));
+        nativeRange.select();
+        range = this.getRange();
       } catch (e) { }
     }
     return range;

--- a/src/selection.js
+++ b/src/selection.js
@@ -128,28 +128,48 @@ class Selection {
     return nativeRange;
   }
 
+  convertNativeRange(node, offset) {
+    // Does not handle custom parent blots with multiple non-blot children
+    let blot;
+    if (!(node instanceof Text)) {
+      if (offset < node.childNodes.length) {
+        node = node.childNodes[offset];
+        offset = 0;
+      } else {
+        blot = Parchment.findBlot(node, true);
+        return blot.offset(this.doc) + blot.getLength();
+      }
+    }
+    blot = Parchment.findBlot(node, true);
+    return blot.offset(this.doc) + offset;
+  }
+
   getRange() {
     if (!this.checkFocus()) return null;
-    let convert = (node, offset) => {
-      // Does not handle custom parent blots with multiple non-blot children
-      let blot;
-      if (!(node instanceof Text)) {
-        if (offset < node.childNodes.length) {
-          node = node.childNodes[offset];
-          offset = 0;
-        } else {
-          blot = Parchment.findBlot(node, true);
-          return blot.offset(this.doc) + blot.getLength();
-        }
-      }
-      blot = Parchment.findBlot(node, true);
-      return blot.offset(this.doc) + offset;
-    }
     let nativeRange = this.getNativeRange();
     if (nativeRange == null) return null;
-    let start = convert(nativeRange.startContainer, nativeRange.startOffset);
-    let end = (nativeRange.collapsed) ? start : convert(nativeRange.endContainer, nativeRange.endOffset);
+    let start = this.convertNativeRange(nativeRange.startContainer, nativeRange.startOffset);
+    let end = (nativeRange.collapsed) ? start : this.convertNativeRange(nativeRange.endContainer, nativeRange.endOffset);
     return new Range(Math.min(start, end), Math.max(start, end));
+  }
+
+  getRangeFromPoint(clientX, clientY) {
+    let range;
+    if (document.caretPositionFromPoint) { // FF
+      let {offsetNode, offset} = document.caretPositionFromPoint(clientX, clientY);
+      range = new Range(this.convertNativeRange(offsetNode, offset));
+    } else if (document.caretRangeFromPoint) { // Chrome/Safari
+      let {commonAncestorContainer, startOffset} = document.caretRangeFromPoint(clientX, clientY);
+      range = new Range(this.convertNativeRange(commonAncestorContainer, startOffset));
+    } else if (document.body.createTextRange) { // IE
+      try {
+        let nativeRange = document.body.createTextRange();
+        nativeRange.moveToPoint(clientX, clientY);
+        let {commonAncestorContainer, startOffset} = nativeRange;
+        range = new Range(this.convertNativeRange(commonAncestorContainer, startOffset));
+      } catch (e) { }
+    }
+    return range;
   }
 
   onUpdate(range) { }

--- a/test/unit/selection.js
+++ b/test/unit/selection.js
@@ -33,6 +33,24 @@ describe('Selection', function() {
     });
   });
 
+  describe('getRangeFromPoint()', function() {
+    it('end of line', function () {
+      this.setContainer('<p>0123</p>');
+      let selection = new Selection(new Editor(this.container));
+      let range = selection.getRangeFromPoint(300,20);
+      expect(range.start).toEqual(4);
+      expect(range.start).toEqual(4);
+    });
+
+    it('beginning of line', function () {
+      this.setContainer('<p>0123</p>');
+      let selection = new Selection(new Editor(this.container));
+      let range = selection.getRangeFromPoint(10,20);
+      expect(range.start).toEqual(0);
+      expect(range.start).toEqual(0);
+    });
+  });
+
   describe('getRange()', function() {
     it('empty document', function() {
       this.setContainer('');


### PR DESCRIPTION
I've added the `getRangeFromPoint(clientX, clientY)` method to `selection.js`, as well as `setSelectionFromPoint(clientX, clientY, source)` to quill.js. 

This was needed for an experiment to add a module that listened for image drop events and inserted them at the point of drop.

Feel free to close this if you had a different approach in mind!