### PR TITLE
Return DOM object consistently with findNode

### DIFF
--- a/src/blots/block.js
+++ b/src/blots/block.js
@@ -25,7 +25,7 @@ class Block extends Parchment.Block {
 
   findNode(index) {
     if (index === this.getLength()) {
-      return [this.children.tail, this.children.tail.getLength()];
+      return [this.children.tail.domNode, this.children.tail.getLength()];
     }
     return super.findNode(index);
   }


### PR DESCRIPTION
This would result in errors because of inconsistencies with the return type of this method.