### PR TITLE
Added eslintrc to enforce style guide

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,29 @@
+{
+  "rules": {
+    "indent": [
+      2,
+      2,
+      {
+        "SwitchCase": 1
+      }
+    ],
+    "semi": [
+      2,
+      "always"
+    ],
+    "no-trailing-spaces": [
+      2,
+      {
+        "skipBlankLines": true
+      }
+    ]
+  },
+  "env": {
+    "es6": true,
+    "browser": true
+  },
+  "ecmaFeatures": {
+    "experimentalObjectRestSpread": true,
+    "modules": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.eslintrc
 /.build
 /dist
 /lib


### PR DESCRIPTION
Not at requirement of course. 

If you enable `eslint` with Webstorm for example you'll get errors if you don't follow the style guide: https://github.com/quilljs/quill/blob/develop/docs/style-guide.md
