### PR TITLE
Log webpack warnings & errors; throw on any errors

### DIFF
--- a/config/build.js
+++ b/config/build.js
@@ -23,6 +23,17 @@ var BANNER =
 module.exports = function(config) {
   gulp.task('source', function(callback) {
     webpack(webpackConfig, function(err, stats) {
+      if (stats.hasWarnings()) {
+        stats.toJson().warnings.forEach((warning) => {
+          console.warn(warning)
+        });
+      }
+      if (stats.hasErrors()) {
+        stats.toJson().errors.forEach((error) => {
+          console.error(error)
+        });
+        throw new Error("webpack failed")
+      }
       if (err) throw new gutil.PluginError('webpack', err);
       callback();
     });


### PR DESCRIPTION
On the develop branch, webpack is silently failing to include the parchment module. This branch provides insight into the cause and fails loudly rather than silently during build. Fix for this error in separate pull request (https://github.com/quilljs/quill/pull/556).

```./~/parchment/src/parchment.ts
Module build failed: TypeError: compiler.parseConfigFile is not a function
    at ensureTypeScriptInstance (/Users/matt/proj/2015-12-27-editor/quill/node_modules/ts-loader/index.js:147:38)
    at Object.loader (/Users/matt/proj/2015-12-27-editor/quill/node_modules/ts-loader/index.js:365:14)
 @ ./src/quill.js 33:17-37
```