### PR TITLE
Upgrade ts-loader to ~0.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "protractor": "^2.5.1",
     "run-sequence": "^1.1.3",
     "stylus-loader": "^1.3.1",
-    "ts-loader": "~0.5.6",
+    "ts-loader": "~0.7.2",
     "typescript": "^1.6.2",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.1"


### PR DESCRIPTION
Upgrading ts-loader to ~0.7.2 fixes the webpack errors mentioned in https://github.com/quilljs/quill/pull/555