### PR TITLE
Removes parens on single arg arrow functions

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -30,7 +30,7 @@ class Editor extends Parchment.Container {
         this.deleteAt(index, op.delete);
         return index;
       } else if (typeof op.retain === 'number') {
-        Object.keys(op.attributes || {}).forEach((name) => {
+        Object.keys(op.attributes || {}).forEach(name => {
           this.formatAt(index, op.retain, name, op.attributes[name]);
         });
         return index + op.retain;

--- a/src/modules/image-tooltip.js
+++ b/src/modules/image-tooltip.js
@@ -22,7 +22,7 @@ class ImageTooltip extends Tooltip {
     this.container.querySelector('.cancel').addEventListener('click', this.hide.bind(this));
     this.textbox.addEventListener('input', this._preview.bind(this));
     this.initTextbox(this.textbox, this.insertImage, this.hide);
-    this.quill.onModuleLoad('toolbar', (toolbar) => {
+    this.quill.onModuleLoad('toolbar', toolbar => {
       this.toolbar = toolbar;
       toolbar.initFormat('image', this._onToolbar.bind(this));
     });

--- a/src/modules/keyboard.js
+++ b/src/modules/keyboard.js
@@ -21,10 +21,10 @@ class Keyboard {
     this.addBinding({ key: keys.BACKSPACE }, this._onDelete.bind(this, true));
     this.addBinding({ key: keys.DELETE }, this._onDelete.bind(this, false));
     this.addBinding({ key: keys.TAB }, this._onTab.bind(this));
-    this.options.bindings.forEach((def) => {
+    this.options.bindings.forEach(def => {
       this.addBinding(def.binding, def.callback);
     });
-    this.quill.root.addEventListener('keydown', (evt) => {
+    this.quill.root.addEventListener('keydown', evt => {
       let which = evt.which || evt.keyCode;
       let range = undefined;
       let prevent = (this.bindings[which] || []).reduce((prevent, binding) => {

--- a/src/modules/link-tooltip.js
+++ b/src/modules/link-tooltip.js
@@ -14,7 +14,7 @@ class LinkTooltip extends Tooltip {
   }
 
   initListeners() {
-    this.quill.on(Quill.events.SELECTION_CHANGE, (range) => {
+    this.quill.on(Quill.events.SELECTION_CHANGE, range => {
       if (range == null || !range.isCollapsed()) return;
       let anchor = this._findAnchor(range);
       if (anchor != null) {
@@ -32,11 +32,11 @@ class LinkTooltip extends Tooltip {
       this.setMode(this.link.href, true);
     });
     this.initTextbox(this.textbox, this.saveLink, this.hide);
-    this.quill.onModuleLoad('toolbar', (toolbar) => {
+    this.quill.onModuleLoad('toolbar', toolbar => {
       this.toolbar = toolbar;
       toolbar.initFormat('link', this._onToolbar.bind(this));
     });
-    this.quill.onModuleLoad('keyboard', (keyboard) => {
+    this.quill.onModuleLoad('keyboard', keyboard => {
       keyboard.addHotkey(LinkTooltip.hotkeys.LINK, this._onKeyboard.bind(this));
     });
   }

--- a/src/modules/multi-cursor.js
+++ b/src/modules/multi-cursor.js
@@ -57,7 +57,7 @@ class MultiCursor extends EventEmitter {
   };
 
   shiftCursors(index, length, authorId = null) {
-    Object.keys(this.cursors).forEach((id) => {
+    Object.keys(this.cursors).forEach(id => {
       if (this.cursors[id] == null) return;
       let shift = Math.max(length, index - this.cursors[id].index);
       if (this.cursors[id].userId === authorId) {
@@ -69,7 +69,7 @@ class MultiCursor extends EventEmitter {
   };
 
   update() {
-    Object.keys(this.cursors).forEach((id) => {
+    Object.keys(this.cursors).forEach(id => {
       if (this.cursors[id] != null) {
         this._updateCursor(this.cursors[id]);
       }
@@ -78,7 +78,7 @@ class MultiCursor extends EventEmitter {
 
   _applyDelta(delta) {
     let index = 0;
-    delta.ops.forEach((op) => {
+    delta.ops.forEach(op => {
       let length = 0;
       if (op.insert != null) {
         length = op.insert.length || 1;

--- a/src/modules/toolbar.js
+++ b/src/modules/toolbar.js
@@ -26,7 +26,7 @@ class Toolbar {
     }, {});
     this._initFormats();
     this.quill.on(Quill.events.SELECTION_CHANGE, (range, formats) => {
-      Object.keys(this.formats).forEach((name) => {
+      Object.keys(this.formats).forEach(name => {
         this.setActive(name, formats[name]);
       });
     });
@@ -48,9 +48,9 @@ class Toolbar {
   }
 
   _initFormats() {
-    Object.keys(this.formats).forEach((format) => {
+    Object.keys(this.formats).forEach(format => {
       let inputs = this.container.querySelectorAll(`.ql-${format}`);
-      [].forEach.call(inputs, (input) => {
+      [].forEach.call(inputs, input => {
         let eventName = input.tagName === 'SELECT' ? 'change' : 'click';
         input.addEventListener(eventName, () => {
           let range = this.quill.getSelection(true);
@@ -66,7 +66,7 @@ class Toolbar {
               }
             }
           };
-          handler.call(this, input, range, (value) => {
+          handler.call(this, input, range, value => {
             if (Parchment.match(format, Parchment.Block)) {
               let formatObj = {};
               formatObj[format] = value;

--- a/src/quill.js
+++ b/src/quill.js
@@ -98,7 +98,7 @@ class Quill extends EventEmitter {
         throw new Error("Cannot load " + this.options.theme + " theme. Are you sure you registered it?");
       }
     }
-    Object.keys(this.options.modules).forEach((name) => {
+    Object.keys(this.options.modules).forEach(name => {
       this.addModule(name, this.options.modules[name]);
     });
     if (this.options.readOnly) {
@@ -161,7 +161,7 @@ class Quill extends EventEmitter {
     let formats;
     [start, end, formats, source] = this._buildParams(start, end, name, value, source);
     this._track(source, () => {
-      Object.keys(formats).forEach((format) => {
+      Object.keys(formats).forEach(format => {
         this.editor.getLines(start, end-start).forEach(function(line) {
           line.format(format, formats[format]);
         });
@@ -173,7 +173,7 @@ class Quill extends EventEmitter {
     let formats;
     [start, end, formats, source] = this._buildParams(start, end, name, value, source);
     this._track(source, () => {
-      Object.keys(formats).forEach((format) => {
+      Object.keys(formats).forEach(format => {
         this.editor.formatAt(start, end-start, format, formats[format]);
       });
     });
@@ -232,7 +232,7 @@ class Quill extends EventEmitter {
     [index, , formats, source] = this._buildParams(index, 0, name, value, source);
     this._track(source, () => {
       this.editor.insertAt(index, text);
-      Object.keys(formats).forEach((format) => {
+      Object.keys(formats).forEach(format => {
         this.editor.formatAt(index, text.length, format, formats[format]);
       });
     });

--- a/src/selection.js
+++ b/src/selection.js
@@ -33,7 +33,7 @@ class Selection {
     this.doc = doc;
     this.root = this.doc.domNode;
     this.lastRange = this.savedRange = new Range(0, 0);
-    ['keyup', 'mouseup', 'mouseleave', 'touchend', 'touchleave'].forEach((eventName) => {
+    ['keyup', 'mouseup', 'mouseleave', 'touchend', 'touchleave'].forEach(eventName => {
       this.root.addEventListener(eventName, () => {
         this.update();  // Do not pass event handler params
       });
@@ -136,7 +136,7 @@ class Selection {
     if (!nativeRange.collapsed) {
       positions.push([nativeRange.endContainer, nativeRange.endOffset]);
     }
-    let indexes = positions.map((position) => {
+    let indexes = positions.map(position => {
       let [container, offset] = position;
       let blot = Parchment.findBlot(container, true);
       return blot.offset(this.doc) + blot.findOffset(container) + offset;
@@ -205,7 +205,7 @@ class Selection {
     if (range != null) {
       let indexes = range.isCollapsed() ? [range.start] : [range.start, range.end];
       let args = [];
-      indexes.map((index) => {
+      indexes.map(index => {
         let [node, offset] = this.doc.findNode(index);
         if (node instanceof Text) {
           args.push(node, offset);

--- a/src/themes/snow/index.js
+++ b/src/themes/snow/index.js
@@ -8,7 +8,7 @@ class SnowTheme extends BaseTheme {
     super(quill, false);
     this.quill.container.classList.add('ql-snow');
     this.pickers = [];
-    this.quill.on(this.quill.constructor.events.SELECTION_CHANGE, (range) => {
+    this.quill.on(this.quill.constructor.events.SELECTION_CHANGE, range => {
       if (range == null) return;
       this.pickers.forEach(function(picker) {
         picker.close();
@@ -28,7 +28,7 @@ class SnowTheme extends BaseTheme {
 
   extendToolbar(module) {
     module.container.classList.add('ql-snow');
-    ['color', 'background', 'font', 'size', 'align'].forEach((format) => {
+    ['color', 'background', 'font', 'size', 'align'].forEach(format => {
       let select = module.container.querySelector(".ql-" + format);
       if (select == null) return;
       switch (format) {

--- a/src/ui/picker.js
+++ b/src/ui/picker.js
@@ -6,7 +6,7 @@ class Picker {
     this.container.classList.add('ql-picker');
     this.select.style.display = 'none';
     this.select.parentNode.insertBefore(this.container, this.select);
-    document.body.addEventListener('click', (evt) => {
+    document.body.addEventListener('click', evt => {
       if (evt.target !== this.label) {
         this.close();
       }
@@ -39,7 +39,7 @@ class Picker {
   }
 
   buildPicker() {
-    [].slice.call(this.select.attributes).forEach((item) => {
+    [].slice.call(this.select.attributes).forEach(item => {
       this.container.setAttribute(item.name, item.value);
     });
     this.container.innerHTML = Picker.TEMPLATE;

--- a/src/ui/tooltip.js
+++ b/src/ui/tooltip.js
@@ -19,7 +19,7 @@ class Tooltip {
   }
 
   initTextbox(textbox, enterCallback, escapeCallback) {
-    textbox.addEventListener('keydown', (evt) => {
+    textbox.addEventListener('keydown', evt => {
       if (evt.which !== keys.ENTER && evt.which !== keys.ESCAPE) return;
       let fn = evt.which === keys.ENTER ? enterCallback : escapeCallback;
       fn.call(this);


### PR DESCRIPTION
Parenthesis are not required in ES6 arrow functions that have only 1 argument ([arrow function docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)). I am proposing the current functions using the unneeded parens be corrected. I've noticed removing the parens seems to be the most popular ES6 code style. 