### PR TITLE
Fixed issue of duplicate inline CSS being included when more than one…

### DIFF
--- a/src/themes/base/index.js
+++ b/src/themes/base/index.js
@@ -13,9 +13,12 @@ class BaseTheme {
 
   addStyles(css) {
     let style = document.createElement('style');
+    style.id = 'quill-inline-css';
     style.type = 'text/css';
     style.appendChild(document.createTextNode(css));
-    document.head.appendChild(style);
+    if (!document.getElementById('quill-inline-css')) {
+      document.head.appendChild(style);
+    }
   }
 }
 BaseTheme.OPTIONS = {};


### PR DESCRIPTION
Hello,

when more than one Quill editor is present on the same page duplicate inline styles are appended to the header. Included a simple check to stop this from happening. The other option is to check document.head.children.namedItem(), but this method doesn't have as strong browser support.