### PR TITLE
Fixing Quill.insertEmbed()

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -110,9 +110,9 @@ class Editor {
     }).join('');
   }
 
-  insertEmbed(index, embed, value, formats = {}, source = Emitter.sources.API) {
+  insertEmbed(index, embed, value, source = Emitter.sources.API) {
     this.scroll.insertAt(index, embed, value);
-    this.formatText(index, index + 1, formats, source);
+    this.update(source);
   }
 
   insertText(index, text, formats = {}, source = Emitter.sources.API) {

--- a/core/quill.js
+++ b/core/quill.js
@@ -174,8 +174,6 @@ class Quill {
   }
 
   insertEmbed(index, embed, value, source) {
-    let formats;
-    [index, , formats, source] = overload(index, 0, source);
     this.editor.insertEmbed(index, embed, value, source);
   }
 


### PR DESCRIPTION
editor.insertEmbed wanted a formats object, which quill.insertEmbed didn't pass in, though embeds don't have text so instead of fixing the formats reference I decided to remove the functionality entirely. I'm open to just fixing the formats reference instead but thought this was the better approach.

Unit tests added.