### PR TITLE
Restores getHTML and adds ability to get html fragments

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -15,24 +15,28 @@ class Editor {
   }
 
   applyDelta(delta, source = Emitter.sources.API) {
+    this.applyDeltaToScroll(this.scroll, delta);
+    this.update(source);
+  }
+
+  applyDeltaToScroll(scroll, delta) {
     delta.ops.reduce((index, op) => {
       if (typeof op.delete === 'number') {
-        this.scroll.deleteAt(index, op.delete);
+        scroll.deleteAt(index, op.delete);
         return index;
       }
       let length = op.retain || op.insert.length || 1;
       if (typeof op.insert === 'string') {
-        this.scroll.insertAt(index, op.insert);
+        scroll.insertAt(index, op.insert);
       } else if (typeof op.insert === 'object') {
         let key = Object.keys(op.insert)[0];
-        this.scroll.insertAt(index, key, op.insert[key]);
+        scroll.insertAt(index, key, op.insert[key]);
       }
       Object.keys(op.attributes || {}).forEach((name) => {
-        this.scroll.formatAt(index, length, name, op.attributes[name]);
+        scroll.formatAt(index, length, name, op.attributes[name]);
       });
       return index + length;
     }, 0);
-    this.update(source);
   }
 
   deleteText(index, length, source = Emitter.sources.API) {
@@ -58,6 +62,13 @@ class Editor {
       this.scroll.formatAt(index, length, format, formats[format]);
     });
     this.update(source);
+  }
+
+  getHTML(index, length) {
+    let scroll = Parchment.create(document.createElement('div'), new Emitter());
+    let delta = this.getContents(index, length);
+    this.applyDeltaToScroll(scroll, delta);
+    return scroll.domNode.innerHTML;
   }
 
   getContents(index, length) {

--- a/core/quill.js
+++ b/core/quill.js
@@ -149,6 +149,11 @@ class Quill {
     return this.editor.getContents(index, length);
   }
 
+  getHTML(index = 0, length = this.getLength() - index) {
+    [index, length] = overload(index, length);
+    return this.editor.getHTML(index, length);
+  }
+
   getFormat(index = this.getSelection(), length = 0) {
     if (typeof index === 'number') {
       return this.editor.getFormat(index, length);

--- a/test/unit/editor.js
+++ b/test/unit/editor.js
@@ -1,6 +1,8 @@
 import Delta from 'rich-text/lib/delta';
 import Editor from '../../core/editor';
 import Selection, { Range } from '../../core/selection';
+import Parchment from 'parchment';
+import Emitter from '../../core/emitter';
 
 
 describe('Editor', function() {
@@ -194,6 +196,38 @@ describe('Editor', function() {
       let editor = this.initialize(Editor, '<p>03</p>');
       editor.applyDelta(new Delta().retain(2, { bold: true }));
       expect(this.container.innerHTML).toEqualHTML('<p><strong>03</strong></p>');
+    });
+  });
+
+  describe('applyDeltaToScroll', function() {
+    it('should apply a delta to the scroll with only inserts in it', function() {
+      let editor = this.initialize(Editor, '<p></p>');
+      let scroll = Parchment.create(document.createElement('div'), new Emitter());
+      editor.applyDeltaToScroll(scroll, new Delta().insert('03'));
+      expect(scroll.domNode.innerHTML).toEqualHTML('<p>03</p>');
+    });
+
+    it('should apply a delta to the scroll with only inserts and attributes in it', function() {
+      let editor = this.initialize(Editor, '<p></p>');
+      let scroll = Parchment.create(document.createElement('div'), new Emitter());
+      editor.applyDeltaToScroll(scroll, new Delta().insert('03', { bold: true }));
+      expect(scroll.domNode.innerHTML).toEqualHTML('<p><strong>03</strong></p>');
+    });
+
+    it('should apply a delta to the scroll with retains and attributes in it', function() {
+      let editor = this.initialize(Editor, '<p>03</p>');
+      let node = document.createElement('div')
+      node.innerHTML = '<p>03</p>';
+      let scroll = Parchment.create(node, new Emitter());
+      editor.applyDeltaToScroll(scroll, new Delta().retain(2, { bold: true }));
+      expect(scroll.domNode.innerHTML).toEqualHTML('<p><strong>03</strong></p>');
+    });
+  });
+
+  describe('getHTML()', function() {
+    it('should return the a fragment of html when given index and length', function() {
+      let editor = this.initialize(Editor, '<p>0123<strong>4567</strong></p>');
+      expect(editor.getHTML(2, 4)).toEqualHTML('<p>23<strong>45</strong></p>');
     });
   });
 

--- a/test/unit/quill.js
+++ b/test/unit/quill.js
@@ -203,6 +203,20 @@ describe('Quill', function() {
     });
   });
 
+  describe('getHTML()', function() {
+    it('should return the whole html with no parameters', function() {
+      expect(this.quill.getHTML()).toEqualHTML('<p>01234567</p><p><br></p>');
+    });
+
+    it('should return the a fragment of html when given index and length', function() {
+      expect(this.quill.getHTML(2, 4)).toEqualHTML('<p>2345</p>');
+    });
+
+    it('should return the a fragment of html when given a range', function() {
+      expect(this.quill.getHTML({index: 2, length: 4})).toEqualHTML('<p>2345</p>');
+    });
+  });
+
   describe('setContents()', function() {
     it('should accept a delta', function() {
       let delta = new Delta().insert('test\n');


### PR DESCRIPTION
This restores 0.20 getHTML functionality with a new twist, adding the ability to give a range and get a fragment of html. To accomplish this I broke the applyDelta function into two functions, one which took a scroll object to make it easier to build out the html. 

Unit tests included