### PR TITLE
Exporting Parchment and Module

### DIFF
--- a/quill.js
+++ b/quill.js
@@ -21,6 +21,8 @@ import Underline from './formats/underline';
 import ImageTooltip from './modules/image';
 import LinkTooltip from './modules/link';
 import ToolbarModule from './modules/toolbar';
+import Parchment from 'parchment';
+import Module from './core/module';
 
 import SnowTheme from './themes/snow';
 
@@ -35,5 +37,7 @@ Quill.register('toolbar', ToolbarModule);
 
 Quill.register('snow', SnowTheme);
 
+Quill.Parchment = Parchment;
+Quill.Module = Module;
 
 module.exports = Quill;


### PR DESCRIPTION
To add custom embeds and modules to quill, I need access to the underlying Parchment and Module instances to properly get past the instanceof checks in the system. This enables that.