### PR TITLE
Adds Quill.imports to get access to the core quill modules

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -6,6 +6,7 @@ import Selection, { Range } from './selection';
 import extend from 'extend';
 import logger from './logger';
 import Theme from './theme';
+import Module from './module';
 
 let debug = logger('[quill]');
 
@@ -13,6 +14,15 @@ let debug = logger('[quill]');
 class Quill {
   static debug(limit) {
     logger.level(limit);
+  }
+
+  static get imports() {
+    return {
+      Delta,
+      Module,
+      Parchment,
+      Theme
+    };
   }
 
   static register(...args) {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -2,11 +2,24 @@ import Quill, { overload } from '../../../core/quill';
 import { Range } from '../../../core/selection';
 import Emitter from '../../../core/emitter';
 import Delta from 'rich-text/lib/delta';
-
+import Theme from '../../../core/theme';
+import Module from '../../../core/module';
+import Parchment from 'parchment';
 
 describe('Quill', function() {
   beforeEach(function() {
     this.quill = this.initialize(Quill, '<p>01234567</p>');
+  });
+
+  describe('imports', function() {
+    it('should expose Theme, Parchment, Delta, Module', function() {
+      expect(Quill.imports).toEqual({
+        Delta,
+        Module,
+        Parchment,
+        Theme
+      });
+    });
   });
 
   describe('deleteText', function() {


### PR DESCRIPTION
Provides hooks into Quill internals for extending and adding custom modules and functionality to quill.