### PR TITLE
Rich Clipboard Support

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -6,33 +6,66 @@ import Module from '../core/module';
 class Clipboard extends Module {
   constructor(quill, options) {
     super(quill, options);
+    this.quill.root.addEventListener('copy', this.onCopy.bind(this));
+    this.quill.root.addEventListener('cut', this.onCut.bind(this));
     this.quill.root.addEventListener('paste', this.onPaste.bind(this));
-    this.container = this.quill.addContainer('ql-clipboard');
-    this.container.setAttribute('contenteditable', true);
   }
 
-  onPaste() {
+  onCopy(e) {
     let range = this.quill.getSelection();
-    if (range == null) return;
-    let updateDelta = new Delta().retain(range.index).delete(range.length);
-    this.container.focus();
-    setTimeout(() => {
-      let pasteDelta = this.options.sanitize(this.container);
-      this.container.innerHTML = '';
-      let lengthAdded = pasteDelta.length();
-      if (lengthAdded > 0) {
-        this.quill.updateContents(updateDelta.concat(pasteDelta), Emitter.sources.USER);
+    if (!range.length || e.defaultPrevented) {
+      return;
+    }
+    e.clipboardData.setData('text', this.quill.getText(range));
+    e.clipboardData.setData('application/json', JSON.stringify(this.quill.getContents(range)));
+    e.preventDefault();
+  }
+
+  onCut(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    this.onCopy(e);
+    this.quill.deleteText(this.quill.getSelection(), Emitter.sources.USER);
+  }
+
+  onPaste(e) {
+    if (e.defaultPrevented) {
+      return;
+    }
+    let range = this.quill.getSelection();
+    let delta = new Delta().retain(range.index);
+    if (range.length > 0) {
+      delta.delete(range.length);
+    }
+    if (e.clipboardData.types.indexOf('application/json') !== -1) {
+      let deltaJsonStr = e.clipboardData.getData('application/json');
+      let deltaJson = JSON.parse(deltaJsonStr);
+      if (Array.isArray(deltaJson.ops)) { // isDelta?
+        delta = delta.concat(deltaJson);
+      } else {
+        delta.insert(deltaJsonStr);
       }
-      this.quill.setSelection(range.index + lengthAdded, Emitter.sources.SILENT);
-      this.quill.selection.scrollIntoView();
+    } else {
+      delta.insert(e.clipboardData.getData('text'));
+    }
+    this.quill.editor.applyDelta(delta, Emitter.sources.USER);
+    this.quill.setSelection(this.length(delta), Emitter.sources.SILENT);
+    this.quill.selection.scrollIntoView();
+    e.preventDefault();
+  }
+
+  length(delta) {
+    return delta.ops.reduce((memo, op) => {
+      if (typeof op['delete'] === 'number') {
+        return memo - op['delete'];
+      } else if (typeof op.retain === 'number') {
+        return memo + op.retain;
+      } else {
+        return memo + (typeof op.insert === 'string' ? op.insert.length : 1);
+      }
     }, 0);
   }
 }
-Clipboard.DEFAULTS = {
-  sanitize: function(container) {
-    return new Delta().insert(container.innerText);
-  }
-};
-
 
 export default Clipboard;


### PR DESCRIPTION
Added support for rich cut/copy and paste of delta json within quill editors. This allows for cool things like copying and pasting of embeds within and between quill editors.