### PR TITLE
Fixing a few bugs, reference error and Array prototype iteration

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -86,7 +86,7 @@ class Keyboard extends Module {
       .retain(range.index)
       .insert('\n', lineFormats);
     if (range.length === 0) {
-      let [line, offset] = quill.scroll.line(range.index);
+      let [line, offset] = this.quill.scroll.line(range.index);
       // Browsers do not display a newline with just <pre>\n</pre>
       if (line.statics.blotName === 'code-block' &&
           offset >= line.length() - 1 &&

--- a/themes/base.js
+++ b/themes/base.js
@@ -18,8 +18,8 @@ class BaseTheme extends Theme {
     buttons.forEach(function(button) {
       let className = button.getAttribute('class') || '';
       let names = className.split(/\s+/);
-      for (let i in names) {
-        let name = names[i].slice('ql-'.length);
+      names.forEach((name) => {
+        name = name.slice('ql-'.length);
         if (icons[name] == null) return;
         if (typeof icons[name] === 'string') {
           button.innerHTML = icons[name];
@@ -29,7 +29,7 @@ class BaseTheme extends Theme {
             button.innerHTML = icons[name][value];
           }
         }
-      }
+      });
     });
   }
 }


### PR DESCRIPTION
This fixes a bug where if you use quill with Arrays have have additional prototyped properties, the iterator loops over those keys and breaks the property lookup. 

Also small reference issue. 