### PR TITLE
Clipboard API

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -1,6 +1,51 @@
 import Delta from 'rich-text/lib/delta';
 import Emitter from '../core/emitter';
 import Module from '../core/module';
+import Parchment from 'parchment';
+
+
+function textSanitize(node, delta) {
+  if (node instanceof Text) {
+    let text = node.data.replace(/\s\s+/g, ' ');
+    delta.insert(text);
+  }
+  return delta;
+}
+
+function newlineSanitize(node, delta) {
+  if (['P', 'DIV', 'VIDEO', 'BR'].indexOf(node.tagName) > -1) {
+    delta.insert('\n');
+  }
+  return delta;
+}
+
+function blotSanitize(node, delta) {
+  let match = Parchment.query(node);
+  if (match == null) return delta;
+  if (match instanceof Parchment.Embed) {
+    let embed = {};
+    embed[match.blotName] = match.value(node);
+    delta.insert(embed, match.formats(node));
+  } else if (typeof match.formats === 'function') {
+    delta = delta.compose(new Delta().retain(delta.length(), match.formats(node)));
+  }
+  return delta;
+}
+
+let matchers = [
+  textSanitize,
+  newlineSanitize,
+  blotSanitize,
+];
+
+function sanitize(node) {  // Post-order traversal
+  return [].reduce.call(node.childNodes || [], function(delta, childNode) {
+    let childrenDelta = matchers.reduce(function(childrenDelta, matcher) {
+      return matcher(childNode, childrenDelta);
+    }, sanitize(childNode));
+    return delta.concat(childrenDelta);
+  }, new Delta());
+}
 
 
 class Clipboard extends Module {
@@ -17,7 +62,7 @@ class Clipboard extends Module {
     let range = this.quill.getSelection();
     if (range == null || range.length === 0 || e.defaultPrevented) return;
     let clipboard = e.clipboardData || window.clipboardData;
-    clipboard.setData('text', this.quill.getText(range))
+    clipboard.setData('text', this.quill.getText(range));
     if (e.clipboardData) {  // IE11 does not let us set non-text data
       clipboard.setData('application/json', JSON.stringify(this.quill.getContents(range)));
     }
@@ -46,7 +91,7 @@ class Clipboard extends Module {
     let intercept = (delta) => {
       this.container.focus();
       setTimeout(() => {
-        delta.insert(this.container.innerText);
+        delta = delta.concat(sanitize(this.container));
         this.container.innerHTML = '';
         callback(delta);
       }, 1);

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -169,9 +169,12 @@ function matchBlot(node, delta) {
 function matchNewline(node, delta) {
   if (!(node instanceof HTMLElement)) return delta;
   if (BLOCK_ELEMENTS[node.tagName] || node.style.display === 'block') {
-    // TODO do not insert when nested
-    delta.insert('\n');
-    if (node.style.paddingBottom) {
+    let lastOp = delta.ops[delta.ops.length - 1];
+    let endText = (lastOp == null || typeof lastOp.insert !== 'string') ? '' : lastOp.insert;
+    if (!endText.endsWith('\n')) {
+      delta.insert('\n');
+    }
+    if (node.style.paddingBottom || (node.style.marginBottom && !endText.endsWith('\n\n'))) {
       delta.insert('\n');
     }
   }

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -49,7 +49,8 @@ class Clipboard extends Module {
     this.matchers = [
       [true, matchText],
       [true, matchNewline],
-      [true, matchBlot]
+      [true, matchBlot],
+      [true, matchAliases]
     ];
   }
 
@@ -137,6 +138,20 @@ class Clipboard extends Module {
   }
 }
 
+
+function matchAliases(node, delta) {
+  let formats = {};
+  switch(node.tagName) {
+    case 'B':
+      formats = { bold: true };
+      break;
+    case 'I':
+      formats = { italic: true };
+      break;
+    default: return delta;
+  }
+  return delta.compose(new Delta().retain(delta.length(), { bold: true }));
+}
 
 function matchBlot(node, delta) {
   let match = Parchment.query(node);

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -150,7 +150,7 @@ function matchAliases(node, delta) {
       break;
     default: return delta;
   }
-  return delta.compose(new Delta().retain(delta.length(), { bold: true }));
+  return delta.compose(new Delta().retain(delta.length(), formats));
 }
 
 function matchBlot(node, delta) {


### PR DESCRIPTION
Here's a proposal and implementation for customizing interpretation of pasted HTML. This centers around a matcher functions with the signature:

    function(Node, Delta): Delta;

The Delta parameter is the representation of the corresponding DOM node's children. A matcher function is to return the Delta representation of the corresponding DOM node and its children. Thus the matcher function simply adds what the DOM node represents, using the provided representation of its children. It also only needs to add one part of what it represents, as other matchers will be called to fill in the rest. It may also just return the given delta, if the corresponding node add no new information.

The way to customize pasted HTML interpretation is to add custom matcher through Clipboard's `addMatcher` which takes a css selector and matcher function. A selector value of true means it will be called on all DOM nodes, including Text nodes. Otherwise the given matcher function is be called on HTMLElements that matches the given selector.

Most of the time a matcher will determine a format the corresponding node represents and will add this to the given delta by `compose()`ing a `retain()` operation. For example:

```js
quill.clipboard.addMatcher('B', function(node, delta) {
  return delta.compose(new Delta().retain(delta.length(), { bold: true }));
});
```

Note the traversal through DOM nodes and calling appropriate matchers is post-order, so the matcher's given delta is always a representation of only its children, and never siblings.

It turns out converting HTML to a Delta can entirely be implemented with a bunch of matchers, but this was not necessarily a design requirement. Also the name matcher and addMatcher is not final. Actually it's somewhat of a bad name since it doesn't match, it more converts or transforms (but converter is pretty generic and transform already has another meaning in OT).