### PR TITLE
Adding static getModules()

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -34,6 +34,10 @@ class Quill {
     }
   }
 
+  static getModule(name) {
+    return Theme.modules[name];
+  }
+
   constructor(container, options = {}) {
     this.container = typeof container === 'string' ? document.querySelector(container) : container;
     if (this.container == null) {
@@ -142,7 +146,7 @@ class Quill {
   }
 
   getModule(name) {
-    return Theme.modules[name];
+    return this.theme.modules[name];
   }
 
   getSelection(focus = false) {


### PR DESCRIPTION
This adds a static getModules() function to augment the instance getModules() function. Static getModules will give you access to all of the modules registered with quill while the instance getModules() function will return the modules loaded for that instance of quill.