### PR TITLE
Added quill/theme destroy method

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -79,6 +79,11 @@ class Quill {
     this.emitter.emit(Emitter.events.READY);
   }
 
+  destroy() {
+    this.scroll.detach();
+    this.theme.destroy();
+  }
+
   addContainer(container, refNode = null) {
     if (typeof container === 'string') {
       let className = container;

--- a/core/theme.js
+++ b/core/theme.js
@@ -21,6 +21,15 @@ class Theme {
     });
   }
 
+  destroy() {
+    Object.keys(this.modules).forEach((name) => {
+      let module = this.modules[name];
+      if (typeof module.destroy === 'function') {
+        module.destroy();
+      }
+    });
+  }
+
   addModule(name) {
     let moduleClass = Theme.modules[name];
     if (moduleClass == null) {

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -44,9 +44,10 @@ const BLOCK_ELEMENTS = {
 class Clipboard extends Module {
   constructor(quill, options) {
     super(quill, options);
-    this.quill.root.addEventListener('copy', this.onCopy.bind(this));
-    this.quill.root.addEventListener('cut', this.onCut.bind(this));
-    this.quill.root.addEventListener('paste', this.onPaste.bind(this));
+    this.onCopy = this.onCopy.bind(this);
+    this.onCut = this.onCut.bind(this);
+    this.onPaste = this.onPaste.bind(this);
+    this.bind();
     this.container = this.quill.addContainer('ql-clipboard');
     this.container.setAttribute('contenteditable', true);
     this.matchers = [
@@ -56,6 +57,22 @@ class Clipboard extends Module {
       [Node.ELEMENT_NODE, matchSpacing],
       ['b, i', matchAliases]
     ];
+  }
+
+  bind() {
+    this.quill.root.addEventListener('copy', this.onCopy);
+    this.quill.root.addEventListener('cut', this.onCut);
+    this.quill.root.addEventListener('paste', this.onPaste);
+  }
+
+  unbind() {
+    this.quill.root.removeEventListener('copy', this.onCopy);
+    this.quill.root.removeEventListener('cut', this.onCut);
+    this.quill.root.removeEventListener('paste', this.onPaste);
+  }
+
+  destroy() {
+    this.unbind();
   }
 
   addMatcher(selector, matcher) {

--- a/modules/image-tooltip.js
+++ b/modules/image-tooltip.js
@@ -13,13 +13,30 @@ class ImageTooltip extends Module {
     this.container.innerHTML = options.template;
     this.preview = this.container.querySelector('.ql-preview');
     this.textbox = this.container.querySelector('input[type=text]');
+    this.save = this.save.bind(this);
+    this.hide = this.hide.bind(this);
+    this.update = this.update.bind(this);
     bindKeys(this.textbox, {
-      'enter': this.save.bind(this),
-      'escape': this.hide.bind(this)
+      'enter': this.save,
+      'escape': this.hide
     });
-    this.container.querySelector('a.ql-action').addEventListener('click', this.save.bind(this));
-    this.container.querySelector('a.ql-cancel').addEventListener('click', this.hide.bind(this));
-    this.textbox.addEventListener('input', this.update.bind(this));
+    this.bind();
+  }
+
+  bind() {
+    this.container.querySelector('a.ql-action').addEventListener('click', this.save);
+    this.container.querySelector('a.ql-cancel').addEventListener('click', this.hide);
+    this.textbox.addEventListener('input', this.update);
+  }
+
+  unbind() {
+    this.container.querySelector('a.ql-action').removeEventListener('click', this.save);
+    this.container.querySelector('a.ql-cancel').removeEventListener('click', this.hide);
+    this.textbox.removeEventListener('input', this.update);
+  }
+
+  destroy() {
+    this.unbind();
   }
 
   center() {

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -25,21 +25,36 @@ class Keyboard extends Module {
     // this.addBinding({ key: Keyboard.keys.BACKSPACE }, this.onDeleteWord.bind(this, true));
     // this.addBinding({ key: Keyboard.keys.DELETE }, this.onDeleteWord.bind(this, false));
     this.addBinding({ key: Keyboard.keys.TAB, shiftKey: null }, this.onTab.bind(this));
-    this.quill.root.addEventListener('keydown', (evt) => {
-      let which = evt.which || evt.keyCode;
-      let handlers = (this.bindings[which] || []).reduce(function(handlers, binding) {
-        let [key, handler] = binding;
-        if (match(evt, key)) handlers.push(handler);
-        return handlers;
-      }, []);
-      if (handlers.length > 0) {
-        let range = this.quill.getSelection();
-        handlers.forEach((handler) => {
-          handler(range, evt);
-        });
-        evt.preventDefault();
-      }
-    });
+    this.keydownHandler = this.keydownHandler.bind(this);
+    this.bind();
+  }
+
+  bind() {
+    this.quill.root.addEventListener('keydown', this.keydownHandler);
+  }
+
+  unbind() {
+    this.quill.root.removeEventListener('keydown', this.keydownHandler);
+  }
+
+  destroy() {
+    this.unbind();
+  }
+
+  keydownHandler(evt) {
+    let which = evt.which || evt.keyCode;
+    let handlers = (this.bindings[which] || []).reduce(function(handlers, binding) {
+      let [key, handler] = binding;
+      if (match(evt, key)) handlers.push(handler);
+      return handlers;
+    }, []);
+    if (handlers.length > 0) {
+      let range = this.quill.getSelection();
+      handlers.forEach((handler) => {
+        handler(range, evt);
+      });
+      evt.preventDefault();
+    }
   }
 
   addBinding(binding, handler) {

--- a/modules/link-tooltip.js
+++ b/modules/link-tooltip.js
@@ -18,14 +18,9 @@ class LinkTooltip extends Module {
       'enter': this.save.bind(this),
       'escape': this.hide.bind(this)
     });
-    this.container.querySelector('a.ql-action').addEventListener('click', () => {
-      if (this.container.classList.contains('ql-editing')) {
-        this.save();
-      } else {
-        this.edit();
-      }
-    });
-    this.container.querySelector('a.ql-remove').addEventListener('click', this.remove.bind(this));
+    this.clickHandler = this.clickHandler.bind(this);
+    this.remove = this.remove.bind(this);
+    this.bind();
     // quill.keyboard.addBinding({ key: 'K', metaKey: true }, this.show.bind(this));
     quill.on(Emitter.events.SELECTION_CHANGE, (range) => {
       if (range != null && range.length === 0) {
@@ -38,6 +33,28 @@ class LinkTooltip extends Module {
       }
       this.hide();
     });
+  }
+
+  bind() {
+    this.container.querySelector('a.ql-action').addEventListener('click', this.clickHandler);
+    this.container.querySelector('a.ql-remove').addEventListener('click', this.remove);
+  }
+
+  unbind() {
+    this.container.querySelector('a.ql-action').removeEventListener('click', this.clickHandler);
+    this.container.querySelector('a.ql-remove').removeEventListener('click', this.remove);
+  }
+
+  destroy() {
+    this.unbind();
+  }
+
+  clickHandler() {
+    if (this.container.classList.contains('ql-editing')) {
+      this.save();
+    } else {
+      this.edit();
+    }
   }
 
   edit() {

--- a/themes/base.js
+++ b/themes/base.js
@@ -2,7 +2,6 @@ import Emitter from '../core/emitter';
 import Theme from '../core/theme';
 import Picker from '../ui/picker';
 import icons from '../ui/icons';
-import { bindKeys } from '../modules/keyboard';
 
 
 class BaseTheme extends Theme {


### PR DESCRIPTION
Allows modules/event handlers/scroll to be cleaned up. Already added most of the event handler cleanups (little stuck on bindKeys() so that'll come later). This is extremely important for single page applications (like mine!)  