### PR TITLE
Fix an issue where we sometimes inserted a non line before a line

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -43,6 +43,15 @@ class Scroll extends Parchment.Scroll {
     this.optimize();
   }
 
+  insertBefore(childBlot, refBlot) {
+    if (!isLine(childBlot)) {
+      let block = Parchment.create(this.statics.childless);
+      block.insertBefore(childBlot);
+      childBlot = block;
+    }
+    super.insertBefore(childBlot, refBlot);
+  }
+
   line(index) {
     return this.descendant(isLine, index);
   }


### PR DESCRIPTION
If an embed is the first item in quill, and you insert text before it, it'll end up getting inserted at the root by accident. This guards against that by wrapping any non-line blocks before line blocks in a block blot.