### PR TITLE
Toolbar div buttons

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -38,7 +38,7 @@ class Toolbar extends Module {
         return true;
       }
     };
-    [].forEach.call(this.container.querySelectorAll('a, button, input[type=button], select'), (input) => {
+    [].forEach.call(this.container.querySelectorAll('a, button, input[type=button], select, span, div'), (input) => {
       this.attach(input);
     });
     this.quill.on(Quill.events.SELECTION_CHANGE, this.update, this);

--- a/themes/base.js
+++ b/themes/base.js
@@ -16,9 +16,8 @@ class BaseTheme extends Theme {
   buildButtons(buttons) {
     buttons.forEach(function(button) {
       let className = button.getAttribute('class') || '';
-      className.split(/\s+/).forEach((name) => {
-        name = name.slice('ql-'.length);
-        if (icons[name] == null) return;
+      className.split(/\s+/).map((n) => n.indexOf('ql-') === 0 ? n.slice('ql-'.length) : null).forEach((name) => {
+        if ((name == null) || (icons[name] == null)) return;
         if (typeof icons[name] === 'string') {
           button.innerHTML = icons[name];
         } else {

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -63,7 +63,7 @@ class SnowTheme extends BaseTheme {
 
   extendToolbar(toolbar) {
     toolbar.container.classList.add('ql-snow');
-    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button')));
+    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button, div, span, a, input[type=button]')));
     this.buildPickers([].slice.call(toolbar.container.querySelectorAll('select')));
     this.imageTooltip = this.addModule('image-tooltip');
     this.linkTooltip = this.addModule('link-tooltip');


### PR DESCRIPTION
I would like my quill toolbar elements to be divs instead of buttons for some legacy reasons (buttons are a pain to format sometimes and the quill stylesheet with a `ql-toolbar > button` selector is hard to override due to specificity (if I want to add my own borders, for example), and I can manually add my own aria stuff to my divs). I expanded the querySelectorAll to include `span` and `div` elements. 

At the same time, I happened to notice that the base theme's `buildButtons` call just slices off the first three characters of the button's class and checks to see if it matches a format. This means `ql-bold` matches (good) but so does `un-bold` (bad). Not that I had any of those classes in my own code, but I felt like this was defensive coding, and I was in there anyway.

Note that I have my own external stylesheet to deal with the fact that a `div > svg` sort of thing needs a height attribute to render correctly.

While the theme stuff could be worked around (it's easy enough for me to make my own theme and deal with calling buildButtons on the appropriate elements), the toolbar code (calling toolbar.attach in particular) is more of a Thing.