### PR TITLE
test for added handlers calling preventDefault()

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -44,6 +44,7 @@ class Keyboard extends Module {
       if (handlers.length > 0) {
         let range = this.quill.getSelection();
         handlers.forEach((handler) => {
+          if (evt.defaultPrevented) return;
           handler(range, evt);
         });
         evt.preventDefault();


### PR DESCRIPTION
Adds a check to the keyboard event dispatcher to see if a handler in the list had previously called evt.preventDefault(). Useful if you add a keyboard handler yourself that overrides the default quill behavior for something.