### PR TITLE
Fixes #656

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -129,5 +129,5 @@ resets(arr)
   color: rgba(0,0,0,0.6)
   content: attr(data-placeholder)
   font-style: italic
+  pointer-events: none
   position: absolute
-  pointer-events:none

--- a/assets/core.styl
+++ b/assets/core.styl
@@ -130,3 +130,4 @@ resets(arr)
   content: attr(data-placeholder)
   font-style: italic
   position: absolute
+  pointer-events:none


### PR DESCRIPTION
Fixes an issue where clicking the placeholder text on a Quill instance won't focus on that instance in Firefox, as described in issue #656.

Pointer-events fit within the browser support scope of Quill. Source: [caniuse.com](http://caniuse.com/#feat=pointer-events)