### PR TITLE
fast fix #665  

### DIFF
--- a/ui/picker.js
+++ b/ui/picker.js
@@ -45,6 +45,11 @@ class Picker {
         this.selectItem(item);
       }
     });
+/**/    	var expand = function expand(event) {//fast fix #665
+/**/	      event.preventDefault();            //to do: maybe need fix this.selectItem(); or other component 
+/**/	    };
+/**/	    options.addEventListener('mousedown', expand);
+/**/	    options.addEventListener('touchstart', expand);
     this.container.appendChild(options);
   }
 


### PR DESCRIPTION
 if do onmousedown on the button, button disappears, mouse doing onmosemove on other element, focus lost, and cant do onmouseup on the button and doing onmouseup on different element

thats magic becouse google debager saw onmousedown event into '.ql-picker-label' but dont saw into '.ql-picker-options' but this patch relay fix #665 problrm)