### PR TITLE
right bug fix #665

### DIFF
--- a/ui/picker.js
+++ b/ui/picker.js
@@ -23,7 +23,8 @@ class Picker {
     if (option.hasAttribute('value')) {
       item.dataset.value = option.getAttribute('value');
     }
-    item.addEventListener('click', this.selectItem.bind(this, item, true));
+    item.addEventListener('mouseup', this.selectItem.bind(this, item, true));
+    item.addEventListener('touchend', this.selectItem.bind(this, item, true));
     return item;
   }
 


### PR DESCRIPTION


item.addEventListener('click', this.selectItem.bind(this, item, true));//bug #665
may be correct to fix the compiler

  its compilate in:
['mousedown', 'touchstart'].forEach(function (name) {
	        item.addEventListener(name, function (event) {
	          _this2.selectItem(item, true);
	          event.preventDefault();
	        });
	      });

what we need:

['mouseup', 'touchend'].forEach(function (name) {
	        item.addEventListener(name, function (event) {
	          _this2.selectItem(item, true);
	          event.preventDefault();
	        });
	      });