### PR TITLE
added blur() convenience method for blurring editor

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -235,6 +235,10 @@ class Quill {
     this.editor.applyDelta(delta);
   }
 
+  blur() {
+    this.setSelection(null);
+  }
+
   setSelection(index, length, source) {
     if (index == null) {
       this.selection.setRange(null, length || Quill.sources.API);


### PR DESCRIPTION
Added a blur() convenience method for blurring/removing focus from editor. More obvious API call than calling setSelection(null).

Addresses https://github.com/quilljs/quill/issues/701