### PR TITLE
Added missing import-statement in modules/formula

### DIFF
--- a/modules/formula.js
+++ b/modules/formula.js
@@ -1,5 +1,5 @@
 import Embed from '../blots/embed';
-
+import Quill from '../core/quill';
 
 class FormulaBlot extends Embed {
   static create(value) {


### PR DESCRIPTION
Causes a 'not-defined' error when Quill is **not** added as a global object.