### PR TITLE
handle align and direction attributes on paste

### DIFF
--- a/formats/align.js
+++ b/formats/align.js
@@ -5,7 +5,8 @@ let config = {
   whitelist: ['right', 'center', 'justify']
 };
 
+let AlignAttribute = new Parchment.Attributor.Attribute('align', 'align', config);
 let AlignClass = new Parchment.Attributor.Class('align', 'ql-align', config);
 let AlignStyle = new Parchment.Attributor.Style('align', 'text-align', config);
 
-export { AlignClass, AlignStyle };
+export { AlignAttribute, AlignClass, AlignStyle };

--- a/formats/direction.js
+++ b/formats/direction.js
@@ -5,7 +5,8 @@ let config = {
   whitelist: ['rtl']
 };
 
+let DirectionAttribute = new Parchment.Attributor.Attribute('direction', 'dir', config);
 let DirectionClass = new Parchment.Attributor.Class('direction', 'ql-direction', config);
 let DirectionStyle = new Parchment.Attributor.Style('direction', 'direction', config);
 
-export { DirectionClass, DirectionStyle };
+export { DirectionAttribute, DirectionClass, DirectionStyle };

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -4,10 +4,10 @@ import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';
 
-import { AlignStyle } from '../formats/align';
+import { AlignAttribute, AlignStyle } from '../formats/align';
 import { BackgroundStyle } from '../formats/background';
 import { ColorStyle } from '../formats/color';
-import { DirectionStyle } from '../formats/direction';
+import { DirectionAttribute, DirectionStyle } from '../formats/direction';
 import { FontStyle } from '../formats/font';
 import { SizeStyle } from '../formats/size';
 
@@ -25,6 +25,14 @@ const CLIPBOARD_CONFIG = [
   ['i', matchAlias.bind(matchAlias, 'italic')],
   ['style', matchIgnore]
 ];
+
+const ATTRIBUTE_ATTRIBUTORS = [
+  AlignAttribute,
+  DirectionAttribute
+].reduce(function(memo, attr) {
+  memo[attr.keyName] = attr;
+  return memo;
+}, {});
 
 const STYLE_ATTRIBUTORS = [
   AlignStyle,
@@ -169,6 +177,10 @@ function matchAttributor(node, delta) {
     if (attr != null) {
       formats[attr.attrName] = attr.value(node);
       if (formats[attr.attrName]) return;
+    }
+    if (ATTRIBUTE_ATTRIBUTORS[name] != null) {
+      attr = ATTRIBUTE_ATTRIBUTORS[name];
+      formats[attr.attrName] = attr.value(node);
     }
     if (STYLE_ATTRIBUTORS[name] != null) {
       attr = STYLE_ATTRIBUTORS[name];

--- a/quill.js
+++ b/quill.js
@@ -1,7 +1,7 @@
 import Quill from './core';
 
-import { AlignClass, AlignStyle } from './formats/align';
-import { DirectionClass, DirectionStyle } from './formats/direction';
+import { AlignAttribute, AlignClass, AlignStyle } from './formats/align';
+import { DirectionAttribute, DirectionClass, DirectionStyle } from './formats/direction';
 import { IndentClass as Indent } from './formats/indent';
 
 import Blockquote from './formats/blockquote';
@@ -40,6 +40,9 @@ import SnowTheme from './themes/snow';
 
 
 Quill.register({
+  'attributors/attribute/align': AlignAttribute,
+  'attributors/attribute/direction': DirectionAttribute,
+
   'attributors/class/align': AlignClass,
   'attributors/class/background': BackgroundClass,
   'attributors/class/color': ColorClass,


### PR DESCRIPTION
LibreOffice and GMail use align and direction attributes.
fix https://github.com/quilljs/quill/issues/912