### PR TITLE
Set the tooltip bounds container to document.body if undefined

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -298,6 +298,7 @@ class Quill {
   }
 }
 Quill.DEFAULTS = {
+  bounds: null,
   formats: null,
   modules: {},
   placeholder: '',

--- a/core/quill.js
+++ b/core/quill.js
@@ -298,7 +298,6 @@ class Quill {
   }
 }
 Quill.DEFAULTS = {
-  bounds: document.body,
   formats: null,
   modules: {},
   placeholder: '',

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -1,7 +1,7 @@
 class Tooltip {
   constructor(quill, boundsContainer) {
     this.quill = quill;
-    this.boundsContainer = boundsContainer;
+    this.boundsContainer = boundsContainer || document.body;
     this.root = quill.addContainer('ql-tooltip');
     this.root.innerHTML = this.constructor.TEMPLATE;
     let offset = parseInt(window.getComputedStyle(this.root).marginTop);


### PR DESCRIPTION
fix https://github.com/quilljs/quill/issues/938