### PR TITLE
feat(formats/image): support blob image src.

### DIFF
--- a/formats/image.js
+++ b/formats/image.js
@@ -31,7 +31,7 @@ class Image extends Embed {
   }
 
   static sanitize(url) {
-    return sanitize(url, ['http', 'https', 'data']) ? url : '//:0';
+    return sanitize(url, ['http', 'https', 'data', 'blob']) ? url : '//:0';
   }
 
   static value(domNode) {


### PR DESCRIPTION
We use an own image upload module for several reasons and it turned out that it doesn't support blob image src when we insert an image via `insertEmbed()`.

This pull request intends to solve this problem.

Currently, when you use for example `insertEmbed(0, 'image', 'blob:http://localhost:3000/fa8b5923-e0a6-4537-8cf3-19c4111cb20b'), it produces `//:0` since blob urls are not supported.