### PR TITLE
Fix documentation

### DIFF
--- a/docs/docs/modules/clipboard.md
+++ b/docs/docs/modules/clipboard.md
@@ -55,7 +55,7 @@ dangerouslyPasteHTML(index: Number, html: String, source: String = 'api')
 ```javascript
 quill.setText('Hello!');
 
-quill.dangerouslyPasteHTML(5, '&nbsp;<b>World</b>');
+quill.clipboard.dangerouslyPasteHTML(5, '&nbsp;<b>World</b>');
 // Editor is now '<p>Hello&nbsp;<strong>World</strong>!</p>';
 ```
 


### PR DESCRIPTION
The method `dangerouslyPasteHTML` does not exists on `quill` itself, its part of the clipboard.