### PR TITLE
Bugfix: toolbar won't render on some condition and toolbar created again when init quill with the same container

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -18,8 +18,10 @@ class Toolbar extends Module {
       this.container = container;
     } else if (typeof this.options.container === 'string') {
       this.container = document.querySelector(this.options.container);
+      addControls(this.container, this.options.controls);
     } else {
       this.container = this.options.container;
+      addControls(this.container, this.options.controls);
     }
     if (!(this.container instanceof HTMLElement)) {
       return debug.error('Container required for toolbar', this.options);

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -12,10 +12,14 @@ class Toolbar extends Module {
   constructor(quill, options) {
     super(quill, options);
     if (Array.isArray(this.options.container)) {
-      let container = document.createElement('div');
-      addControls(container, this.options.container);
-      quill.container.parentNode.insertBefore(container, quill.container);
-      this.container = container;
+      // prevent creating duplicate toolbar
+      if (quill.container.previousSibling && quill.container.previousSibling.classList.contains('ql-toolbar')) {
+        this.container = quill.container.previousSibling;
+      } else {
+        this.container = document.createElement('div');
+        quill.container.parentNode.insertBefore(this.container, quill.container);
+      }
+      addControls(this.container, this.options.container);
     } else if (typeof this.options.container === 'string') {
       this.container = document.querySelector(this.options.container);
       addControls(this.container, this.options.controls);
@@ -163,6 +167,9 @@ function addButton(container, format, value) {
 }
 
 function addControls(container, groups) {
+  while(container.hasChildNodes()) {
+    container.removeChild(container.firstChild);
+  }
   if (!Array.isArray(groups[0])) {
     groups = [groups];
   }


### PR DESCRIPTION
```html
<div id="editor-container">
  <div class="editor-container_toolbar"></div>
  <div class="editor-container__content"></div>
</div>
```
when I init quill editor like this, which according to the document and source code should be valid

```javascript
var quill = new Quill('.editor-container__content', {
  modules: {
    toolbar: {
      container: '.editor-container__toolbar',
      controls: [
        [{ header: [1, 2, false] }],
        ['bold', 'italic', 'underline'],
        ['image', 'code-block']
      ]
    }
  },
  placeholder: 'Compose an epic...',
  theme: 'snow' // or 'bubble'
});
```
editor created but toolbar is empty.

Another problem is when I accidentally initiate quill editor on the same element twice like this
```javascript
var quill = new Quill('.editor-container__content', {
  modules: {
    toolbar: [
      [{ header: [1, 2, false] }],
      ['bold', 'italic', 'underline'],
      ['image', 'code-block']
    ]
  },
  placeholder: 'Compose an epic...',
  theme: 'snow' // or 'bubble'
});
```
another toolbar is inserted before the old toolbar.
Fixed but not sure if it is the right way.
