### PR TITLE
Fix `setContents` erroring when `lastOp` is not an insert

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -252,7 +252,7 @@ class Quill {
     delta = new Delta(delta).slice();
     let lastOp = delta.ops[delta.ops.length - 1];
     // Quill contents must always end with newline
-    if (lastOp == null || lastOp.insert[lastOp.insert.length-1] !== '\n') {
+    if (lastOp == null || lastOp.insert == null || lastOp.insert[lastOp.insert.length-1] !== '\n') {
       delta.insert('\n');
     }
     delta.delete(this.getLength());

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -214,6 +214,12 @@ describe('Quill', function() {
       quill.setContents(new Delta().insert('0123'));
       expect(quill.getContents()).toEqual(new Delta().insert('0123\n'));
     });
+
+    it('no trailing newline and retain', function() {
+      let quill = this.initialize(Quill, '<h1>Welcome</h1>');
+      quill.setContents(new Delta().insert('0123').retain(1));
+      expect(quill.getContents()).toEqual(new Delta().insert('0123W\n'));
+    });
   });
 
   describe('setText()', function() {


### PR DESCRIPTION
I was running into this problem when using ShareDB + Quill. Occasionally, on startup, I would load data where lastOp was a `retain` type instead. I'm not sure this is actually the correct fix, since ending in a `retain` or `delete` op seems wrong, but I'm open to suggestions. For reference, my data looks like so:
```json
{
  "ops": [
    {
      "insert": "Test\\n\\nTesting\\nTesting1"
    },
    {
      "insert": "\\n",
      "attributes": {
        "list": "bullet"
      }
    },
    {
      "insert": "Testing2"
    },
    {
      "attributes": {
        "list": "bullet"
      },
      "insert": "\\n"
    },
    {
      "retain": 1,
      "attributes": {
        "list": "bullet"
      }
    }
  ]
}
```