### PR TITLE
Support <del> tag for strikethrough

### DIFF
--- a/formats/strike.js
+++ b/formats/strike.js
@@ -1,7 +1,7 @@
-import Inline from '../blots/inline';
+import Bold from './bold';
 
-class Strike extends Inline { }
+class Strike extends Bold { }
 Strike.blotName = 'strike';
-Strike.tagName = 'S';
+Strike.tagName = ['DEL', 'S'];
 
 export default Strike;

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -305,7 +305,7 @@ describe('Editor', function() {
     it('insert at format boundary', function() {
       let editor = this.initialize(Editor, '<p><em>0</em><u>1</u></p>');
       editor.applyDelta(new Delta().retain(1).insert('|', { strike: true }));
-      expect(this.container).toEqualHTML('<p><em>0</em><s>|</s><u>1</u></p>');
+      expect(this.container).toEqualHTML('<p><em>0</em><del>|</del><u>1</u></p>');
     });
 
     it('unformatted newline', function() {


### PR DESCRIPTION
Some Markdown dialects (such a [GitHub Flavored Markdown](https://help.github.com/articles/basic-writing-and-formatting-syntax/#styling-text)) actually wrap strikethrough with `<del>` tags instead of `<s>` tags. And in some content `<del>` is actually more semantically correct than `<s>`.

I added support for Quill to recognize both tags as "strikethrough" instead of just the `<s>` tag.