### PR TITLE
Fix #1041 - version bump for parchment

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deep-equal": "~1.0.1",
     "eventemitter3": "~2.0.1",
     "extend": "~3.0.0",
-    "parchment": "1.0.1",
+    "parchment": "1.0.2",
     "quill-delta": "github:quilljs/delta"
   },
   "devDependencies": {


### PR DESCRIPTION
This pull requests bumps the version of the parchment dependency to 1.0.2 rather than 1.0.1. This is to fix #1041. More information can be found here: https://github.com/yarnpkg/yarn/issues/812#issuecomment-253190930