### PR TITLE
Remove unnecessary type attribute in documentation

### DIFF
--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -13,8 +13,8 @@ A globally distributed and available CDN is provided, backed by [Amazon Cloudfro
 
 ```html
 <!-- Main Quill library -->
-<script src="//cdn.quilljs.com/{{site.version}}/quill.js" type="text/javascript"></script>
-<script src="//cdn.quilljs.com/{{site.version}}/quill.min.js" type="text/javascript"></script>
+<script src="//cdn.quilljs.com/{{site.version}}/quill.js"></script>
+<script src="//cdn.quilljs.com/{{site.version}}/quill.min.js"></script>
 
 <!-- Theme included stylesheets -->
 <link href="//cdn.quilljs.com/{{site.version}}/quill.snow.css" rel="stylesheet">
@@ -22,7 +22,7 @@ A globally distributed and available CDN is provided, backed by [Amazon Cloudfro
 
 <!-- Core build with no theme, formatting, non-essential modules -->
 <link href="//cdn.quilljs.com/{{site.version}}/quill.core.css" rel="stylesheet">
-<script src="//cdn.quilljs.com/{{site.version}}/quill.core.js" type="text/javascript"></script>
+<script src="//cdn.quilljs.com/{{site.version}}/quill.core.js"></script>
 ```
 
 

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -22,7 +22,7 @@ The best way to get started is try a simple example. Quill is initialized with a
 <script src="https://cdn.quilljs.com/{{site.version}}/quill.js"></script>
 
 <!-- Initialize Quill editor -->
-<script type="text/javascript">
+<script>
   var quill = new Quill('#editor', {
     theme: 'snow'
   });

--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -29,8 +29,8 @@ Themes allow you to easily make your editor look good with minimal effort. Quill
 <!-- Add the theme's stylesheet -->
 <link rel="stylesheet" href="{{site.cdn}}{{site.version}}/quill.bubble.css">
 
-<script type="text/javascript" src="{{site.cdn}}{{site.version}}/quill.js"></script>
-<script type="text/javascript">
+<script src="{{site.cdn}}{{site.version}}/quill.js"></script>
+<script>
 var quill = new Quill('#editor', {
   theme: 'bubble'   // Specify theme in configuration
 });
@@ -64,10 +64,10 @@ Many other customizations can be done through the respective modules. For exampl
 
 
 <!-- script -->
-<script type="text/javascript" src="{{site.katex}}/katex.min.js"></script>
-<script type="text/javascript" src="{{site.highlightjs}}/highlight.min.js"></script>
-<script type="text/javascript" src="{{site.cdn}}{{site.version}}/{{site.quill}}"></script>
-<script type="text/javascript">
+<script src="{{site.katex}}/katex.min.js"></script>
+<script src="{{site.highlightjs}}/highlight.min.js"></script>
+<script src="{{site.cdn}}{{site.version}}/{{site.quill}}"></script>
+<script>
   var snowQuill = new Quill('#snow-container', {
     placeholder: 'Compose an epic...',
     modules: {


### PR DESCRIPTION
"If this attribute [type] is absent, the script is treated as JavaScript."
Source: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script