### PR TITLE
fix chrome 52+ input file label open slow

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -125,7 +125,7 @@ BaseTheme.DEFAULTS = extend(true, {}, Theme.DEFAULTS, {
           if (fileInput == null) {
             fileInput = document.createElement('input');
             fileInput.setAttribute('type', 'file');
-            fileInput.setAttribute('accept', 'image/*');
+            fileInput.setAttribute('accept', 'image/png, image/gif, image/jpeg, image/bmp, image/x-icon, image/x-quicktime');
             fileInput.classList.add('ql-image');
             fileInput.addEventListener('change', () => {
               if (fileInput.files != null && fileInput.files[0] != null) {


### PR DESCRIPTION
reference: 
[chrome 52 slow](http://stackoverflow.com/questions/39187857/inputfile-accept-image-open-dialog-so-slow-with-chrome)
[input type MIME type](https://www.sitepoint.com/web-foundations/mime-types-complete-list/)