### PR TITLE
Only query the last op's insertion string if it's actually an insert

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -264,7 +264,7 @@ class Quill {
       let deleted = this.editor.deleteText(0, length);
       let applied = this.editor.applyDelta(delta);
       let lastOp = applied.ops[applied.ops.length - 1];
-      if (lastOp != null && lastOp.insert[lastOp.insert.length-1] === '\n') {
+      if (lastOp != null && typeof(lastOp.insert) === 'string' && lastOp.insert[lastOp.insert.length-1] === '\n') {
         this.editor.deleteText(this.getLength() - 1, 1);
         applied.delete(1);
       }


### PR DESCRIPTION
I came across this when attempting to use ShareDB to synchronize two Quill clients on a document that consists entirely of a CodeBlock. But the missing check looks pretty obvious. I think the old CoffeeScript implementation of Quill actually had this check.