### PR TITLE
Fix ordered/unordered lists code in documentation

### DIFF
--- a/docs/_includes/standalone/full.html
+++ b/docs/_includes/standalone/full.html
@@ -39,8 +39,8 @@
       <button class="ql-code-block"></button>
     </span>
     <span class="ql-formats">
-      <button class="ql-list" value="ordered"></button>
-      <button class="ql-list" value="bullet"></button>
+      <button class="ql-list"></button>
+      <button class="ql-bullet"></button>
       <button class="ql-indent" value="-1"></button>
       <button class="ql-indent" value="+1"></button>
     </span>


### PR DESCRIPTION
This commit will fix the ordered/unordered list buttons which respond to the `ql-list` and `ql-bullet` classes rather than the value of said buttons.