### PR TITLE
check that html content exists before trimming

### DIFF
--- a/src/quill.coffee
+++ b/src/quill.coffee
@@ -207,7 +207,7 @@ class Quill extends EventEmitter2
     this.updateContents(delta, source)
 
   setHTML: (html, source = Quill.sources.API) ->
-    html = "<#{dom.DEFAULT_BLOCK_TAG}><#{dom.DEFAULT_BREAK_TAG}></#{dom.DEFAULT_BLOCK_TAG}>" unless html.trim()
+    html = "<#{dom.DEFAULT_BLOCK_TAG}><#{dom.DEFAULT_BREAK_TAG}></#{dom.DEFAULT_BLOCK_TAG}>" unless html or html.trim()
     @editor.doc.setHTML(html)
     @editor.checkUpdate(source)
 


### PR DESCRIPTION
I've run into a strange behavior in my Angular app where we set the content of Quill based on a value  assigned on `$scope`. Despite initially setting this value to an empty string, it's value is `undefined` when the `editorCreated` event fires from Quill. This causes `Quill.prototype.setHTML` to throw an error when it tries to trim `undefined`. I've added a simple short-circuit to the logic of setHTML to only trim if there is content to begin with.