### PR TITLE
Show bubble tooltip outside bounds fixing #1126 with z-index

### DIFF
--- a/assets/base.styl
+++ b/assets/base.styl
@@ -49,11 +49,11 @@ colorItemsPerRow = 7
 
   .ql-hidden
     display: none
-  .ql-out-bottom, .ql-out-top
-    visibility: hidden
 
   .ql-tooltip
     position: absolute
+    &:not(.ql-hidden)
+      z-index: 999
     a
       cursor: pointer
       text-decoration: none


### PR DESCRIPTION
Managed to solve #1126 implementing a `z-index`-based fix in order to avoid the "bounds" check/hiding class and prevent adjacent containers issues.