### PR TITLE
Fixes #1197: Prevent shortcuts for disabled formats

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -340,6 +340,8 @@ function makeFormatHandler(format) {
     key: format[0].toUpperCase(),
     shortKey: true,
     handler: function(range, context) {
+      const isFormatEnabled = (Array.isArray(this.quill.formats) && this.quill.formats.indexOf(format) !== -1);
+      if (!isFormatEnabled) return false;
       this.quill.format(format, !context.format[format], Quill.sources.USER);
     }
   };


### PR DESCRIPTION
This PR address the bug where formatting shortcuts are active whether or not the corresponding formats are enabled.

Fixes #1197 