### PR TITLE
Fix #851: don't hide tooltips that end up partially under the container

### DIFF
--- a/assets/base.styl
+++ b/assets/base.styl
@@ -49,7 +49,7 @@ colorItemsPerRow = 7
 
   .ql-hidden
     display: none
-  .ql-out-bottom, .ql-out-top
+  .ql-out-top
     visibility: hidden
 
   .ql-tooltip


### PR DESCRIPTION
I've seen that #941 is stuck in the pipeline, so I suggest an easier fix until #941 gets a proper implementation.

I think it's better than the alternative of simply not being able to add links to text on the bottom row of a quill editor.