### PR TITLE
Ability to locally mark text (similar to CodeMirror)

### DIFF
--- a/modules/text-marking.js
+++ b/modules/text-marking.js
@@ -41,8 +41,8 @@ class TextMarking extends Module {
     }
 
     mark(markId = String.UUID(), range = this.quill.selection.savedRange) {
-        if (!range) { 
-            return 
+        if (!range) {
+            return
         }
 
         let curSelection = this.quill.getSelection(),

--- a/modules/text-marking.js
+++ b/modules/text-marking.js
@@ -40,7 +40,7 @@ class TextMarking extends Module {
         });
     }
 
-    mark(markId = String.UUID(), range = this.quill.selection.savedRange) {
+    mark(markId = generate_uuid(), range = this.quill.selection.savedRange) {
         if (!range) {
             return
         }
@@ -51,6 +51,9 @@ class TextMarking extends Module {
         this.marks[markId] = true
         this.quill.updateContents(delta, Quill.sources.SILENT);
         this.quill.setSelection(curSelection)
+        
+        // Return the markId given or generated so the developer has the markId to call clear() with
+        return markId
     }
 
     find(markId = null) {
@@ -105,6 +108,16 @@ class TextMarking extends Module {
 TextMarking.DEFAULTS = {
     enabled: true
 };
+
+function generate_uuid() {
+    var d = new Date().getTime();
+    var uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = (d + Math.random()*16)%16 | 0;
+        d = Math.floor(d/16);
+        return (c=='x' ? r : (r&0x3|0x8)).toString(16);
+    });
+    return uuid;
+}
 
 
 export default TextMarking;

--- a/modules/text-marking.js
+++ b/modules/text-marking.js
@@ -1,0 +1,111 @@
+import Parchment from 'parchment';
+import Module from '../core/module';
+import Quill from '../core/quill';
+import Delta from 'quill-delta';
+import Inline from '../blots/inline';
+
+class Mark extends Inline {
+    static create(value) {
+      let node = super.create(value);
+      node.setAttribute('data-mark-id', value);
+      node.setAttribute('class', 'ql-mark ql-mark-' + value);
+      return node;
+    }
+
+    static formats(domNode) {
+      return domNode.getAttribute('data-mark-id');
+    }
+
+}
+Mark.blotName = 'mark';
+Mark.tagName = 'SPAN';
+
+class TextMarking extends Module {
+    constructor(quill, options) {
+        super(quill, options);
+
+        this.marks = {}
+
+        Quill.register(Mark, true);
+
+        this.quill.on(Quill.events.EDITOR_CHANGE, (eventName, delta, oldDelta, source) => {
+            if (eventName == Quill.events.TEXT_CHANGE && source === Quill.sources.USER) {
+                delta.ops.forEach(function(op) {
+                    // Remove any text marks before allowing the delta to be sent out to the server
+                    if (op.attributes && op.attributes.mark) {
+                        delete op.attributes.mark
+                    }
+                });
+            }
+        });
+    }
+
+    mark(markId = String.UUID(), range = this.quill.selection.savedRange) {
+        if (!range) { 
+            return 
+        }
+
+        let curSelection = this.quill.getSelection(),
+            delta = new Delta().retain(range.index).retain(range.length, {mark: markId})
+
+        this.marks[markId] = true
+        this.quill.updateContents(delta, Quill.sources.SILENT);
+        this.quill.setSelection(curSelection)
+    }
+
+    find(markId = null) {
+        if (!markId) {
+            return null
+        }
+
+        let markElem = this.quill.scroll.domNode.querySelector('.ql-mark-' + markId)
+
+        if (!markElem) {
+            return null
+        }
+
+        let markBlot = Parchment.find(markElem)
+
+        if (!markBlot) {
+            return null
+        }
+
+        return {
+            index: markBlot.offset(this.quill.scroll),
+            length: markBlot.length()
+        }
+    }
+
+    clear(markId = null) {
+        if (!markId) {
+            return false
+        }
+
+        let curMark = this.find(markId);
+
+        if (!curMark) {
+            return false
+        }
+
+        let curSelection = this.quill.getSelection(),
+            delta = new Delta().retain(curMark.index).retain(curMark.length, {mark: false});
+
+        this.quill.updateContents(delta, Quill.sources.SILENT);
+        this.quill.setSelection(curSelection)
+        delete this.marks[markId]
+    }
+
+    clearAll() {
+        Object.keys(this.marks).forEach(function(markId) {
+            this.clear(markId)
+        }.bind(this))
+    }
+}
+
+TextMarking.DEFAULTS = {
+    enabled: true
+};
+
+
+export default TextMarking;
+

--- a/quill.js
+++ b/quill.js
@@ -27,6 +27,7 @@ import CodeBlock, { Code as InlineCode } from './formats/code';
 
 import Formula from './modules/formula';
 import Syntax from './modules/syntax';
+import TextMarking from './modules/text-marking';
 import Toolbar from './modules/toolbar';
 
 import Icons from './ui/icons';
@@ -88,6 +89,7 @@ Quill.register({
 
   'modules/formula': Formula,
   'modules/syntax': Syntax,
+  'modules/text-marking': TextMarking,
   'modules/toolbar': Toolbar,
 
   'themes/bubble': BubbleTheme,


### PR DESCRIPTION
This PR adds the ability to programmatically mark text locally and make sure no marks get sent out to other clients. This is useful for scenarios like local (session-only) highlighting within a collaborative document. 

The API for using the module is as follow:

# Marking Text
```js
// Mark the current selection
quill.getModule('text-marking').mark('some-id')
// Mark an arbitrary section of the document
quill.getModule('text-marking').mark('some-id', {index: 0, length: 5} /* Range object */)
```

# Finding Marks
```js
// Finds the mark with the given id and returns a Range object representing 
// the marks range in the current document
quill.getModule('text-marking').find('some-id')
```

# Clearing Marks
```js
// Clear a specific mark
quill.getModule('text-marking').clear('some-id')
// Clear all marks
quill.getModule('text-marking').clearAll()
```