### PR TITLE
Fixes #1256 Don’t create a list when list format is disabled

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -233,6 +233,7 @@ Keyboard.DEFAULTS = {
       format: { list: false },
       prefix: /^(1\.|-)$/,
       handler: function(range, context) {
+        if (this.quill.scroll.whitelist != null && !this.quill.scroll.whitelist['list']) return true;
         let length = context.prefix.length;
         this.quill.scroll.deleteAt(range.index - length, length);
         this.quill.formatLine(range.index - length, 1, 'list', length === 1 ? 'bullet' : 'ordered', Quill.sources.USER);


### PR DESCRIPTION
This fixes #1256 by not running the normal keyboard handler code if the list format is not enabled