### PR TITLE
Use a more common site for URL placeholder

### DIFF
--- a/themes/bubble.js
+++ b/themes/bubble.js
@@ -102,7 +102,7 @@ class BubbleTooltip extends BaseTooltip {
 BubbleTooltip.TEMPLATE = [
   '<span class="ql-tooltip-arrow"></span>',
   '<div class="ql-tooltip-editor">',
-    '<input type="text" data-formula="e=mc^2" data-link="quilljs.com" data-video="Embed URL">',
+    '<input type="text" data-formula="e=mc^2" data-link="https://wikipedia.com/" data-video="Embed URL">',
     '<a class="ql-close"></a>',
   '</div>'
 ].join('');

--- a/themes/bubble.js
+++ b/themes/bubble.js
@@ -102,7 +102,7 @@ class BubbleTooltip extends BaseTooltip {
 BubbleTooltip.TEMPLATE = [
   '<span class="ql-tooltip-arrow"></span>',
   '<div class="ql-tooltip-editor">',
-    '<input type="text" data-formula="e=mc^2" data-link="https://wikipedia.com/" data-video="Embed URL">',
+    '<input type="text" data-formula="e=mc^2" data-link="https://wikipedia.com" data-video="Embed URL">',
     '<a class="ql-close"></a>',
   '</div>'
 ].join('');

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -110,7 +110,7 @@ class SnowTooltip extends BaseTooltip {
 }
 SnowTooltip.TEMPLATE = [
   '<a class="ql-preview" target="_blank" href="about:blank"></a>',
-  '<input type="text" data-formula="e=mc^2" data-link="quilljs.com" data-video="Embed URL">',
+  '<input type="text" data-formula="e=mc^2" data-link="https://wikipedia.com" data-video="Embed URL">',
   '<a class="ql-action"></a>',
   '<a class="ql-remove"></a>'
 ].join('');


### PR DESCRIPTION
As explained on the commit message on the first commit:

>`quilljs.com` is not a common case for URL inserting. It's better to include `https://` or `http://` and use a common site like Wikipedia.
