### PR TITLE
Allow Quill clipboard to preserve all spaces

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -27,6 +27,7 @@ resets(arr)
   overflow-y: hidden
   position: absolute
   top: 50%
+  white-space: pre
   p
     margin: 0
     padding: 0

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -47,11 +47,11 @@ describe('Clipboard', function() {
     });
 
     it('whitespace', function() {
-      let html =
-        '<div> 0 </div> <div> <div> 1 2 <span> 3 </span> 4 </div> </div>' +
-        '<div><span>5 </span><span>6 </span><span> 7</span><span> 8</span></div>';
+      let html = '<div> 0 </div>&nbsp;  1 <span> 2  </span>';
       let delta = this.clipboard.convert(html);
-      expect(delta).toEqual(new Delta().insert('0\n1 2  3  4\n5 6  7 8'));
+      var expected = new Delta().insert(' 0 \n\u00a0  1  2  ');
+
+      expect(delta).toEqual(expected);
     });
 
     it('inline whitespace', function() {


### PR DESCRIPTION
**What:**
- Preserve regular and non-breaking spaces in the quill clipboard
- Fixes #1280 

**Why:**
- Because users may use both of these spaces, (maybe intentionally, but maybe unintentionally via copy/paste) and it is confusing when those messages don’t contain the expected number of spaces when cut/paste

**How:**
- make clipboard preserve whitespace via css

**Other Considerations:**
- I updated the test too