### PR TITLE
Prevent collapse of single spaces surrounding non-breaking spaces

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -284,7 +284,14 @@ function matchText(node, delta) {
   if (!computeStyle(node.parentNode).whiteSpace.startsWith('pre')) {
     // eslint-disable-next-line func-style
     let replacer = function(collapse, match) {
-      match = match.replace(/[^\u00a0]/g, '');    // \u00a0 is nbsp;
+      if (collapse) {
+        // we do not want to eliminate "intentional" whitespace (non-breaking spaces), but we do want to
+        // collapse all other types of white space. However, nbsp is included in the regex whitespace
+        // char set (\s), so in order to exclude it we must specifically choose these whitespace chars
+        match = match.replace(/( \f|\n|\r|\t|\v){2,}/g, ' ');
+      } else {
+        match = match.replace(/[^\u00a0]/g, '');    // \u00a0 is nbsp;
+      }
       return match.length < 1 && collapse ? ' ' : match;
     };
     text = text.replace(/\r\n/g, ' ').replace(/\n/g, ' ');

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -288,7 +288,7 @@ function matchText(node, delta) {
         // we do not want to eliminate "intentional" whitespace (non-breaking spaces), but we do want to
         // collapse all other types of white space. However, nbsp is included in the regex whitespace
         // char set (\s), so in order to exclude it we must specifically choose these whitespace chars
-        match = match.replace(/( \f|\n|\r|\t|\v){2,}/g, ' ');
+        match = match.replace(/[ \f\n\r\t\v]{2,}/g, ' ');
       } else {
         match = match.replace(/[^\u00a0]/g, '');    // \u00a0 is nbsp;
       }


### PR DESCRIPTION
Fixes #1280.

Spaces between `&nbsp;` are not preserved, as they should be according to HTML. For example, if we start with `<tag> _ _ _ &nbsp; _ _ &nbsp; _ _ </tag>`
- HTML reduces this to `<tag> _ &nbsp; _ &nbsp; _ </tag>` 
- Quill reduces this to `<tag>&nbsp;&nbsp;</tag>` 

We do not want to eliminate "intentional" whitespace (non-breaking spaces), but we do want to collapse all other types of white space around them into single spaces (not nothing).