### PR TITLE
Prevent cursor from jumping around on backspace in empty editor

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -46,6 +46,7 @@ class Keyboard extends Module {
     this.addBinding({ key: Keyboard.keys.DELETE }, { ctrlKey: true }, function() {});
     this.addBinding({ key: Keyboard.keys.BACKSPACE }, { collapsed: false }, handleDeleteRange);
     this.addBinding({ key: Keyboard.keys.DELETE }, { collapsed: false }, handleDeleteRange);
+    this.addBinding({ key: Keyboard.keys.BACKSPACE }, { empty: true, shortKey: true }, handleBackspace);
     this.listen();
   }
 
@@ -259,7 +260,7 @@ Keyboard.DEFAULTS = {
 
 
 function handleBackspace(range, context) {
-  if (range.index === 0) return;
+  if (range.index === 0 || this.quill.getLength() <= 1) return;
   let [line, ] = this.quill.getLine(range.index);
   let formats = {};
   if (context.offset === 0) {


### PR DESCRIPTION
This prevents the cursor from jumping around when hitting `CMD+<delete>` in an empty editor. I'm happy to make any necessary changes.

Tested on macOS:
- Safari 10.0.3
- Chrome 56.0.2924.87
- Firefox 51.0.1 

Tested on Windows 10 (Browserstack):
- Edge 14

Fixes #1319