### PR TITLE
Convert a text that is followed by an element to a new line

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -18,6 +18,7 @@ const DOM_KEY = '__ql-matcher';
 
 const CLIPBOARD_CONFIG = [
   [Node.TEXT_NODE, matchText],
+  [Node.TEXT_NODE, matchNewlineText],
   ['br', matchBreak],
   [Node.ELEMENT_NODE, matchNewline],
   [Node.ELEMENT_NODE, matchBlot],
@@ -242,6 +243,13 @@ function matchIgnore() {
 
 function matchNewline(node, delta) {
   if (isLine(node) && !deltaEndsWith(delta, '\n')) {
+    delta.insert('\n');
+  }
+  return delta;
+}
+
+function matchNewlineText(node, delta) {
+  if (node.nextSibling !== null && isLine(node.nextSibling) && node.data.trim().length && !deltaEndsWith(delta, '\n')) {
     delta.insert('\n');
   }
   return delta;

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -242,7 +242,7 @@ function matchIgnore() {
 }
 
 function matchNewline(node, delta) {
-  if (isLine(node) && !deltaEndsWith(delta, '\n')) {
+  if ((isLine(node) || node.nextSibling !== null && isLine(node.nextSibling)) && !deltaEndsWith(delta, '\n')) {
     delta.insert('\n');
   }
   return delta;

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -40,6 +40,14 @@ describe('Quill', function() {
       );
       expect(quill.root).toEqualHTML('<p class="ql-align-center">Test</p>');
     });
+
+    it('non-formatted before formatted', function() {
+      let quill = this.initialize(Quill, '0123<h2>Test</h2>');
+      expect(quill.getContents()).toEqual(
+        new Delta().insert('0123\nTest').insert('\n', { header: 2 })
+      );
+      expect(quill.root).toEqualHTML('<p>0123</p><h2>Test</h2>');
+    });
   });
 
   describe('api', function() {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -48,6 +48,14 @@ describe('Quill', function() {
       );
       expect(quill.root).toEqualHTML('<p>0123</p><h2>Test</h2>');
     });
+
+    it('inline before block', function() {
+      let quill = this.initialize(Quill, '<em>0123</em><h2>Test</h2>');
+      expect(quill.getContents()).toEqual(
+        new Delta().insert('0123', { italic: true }).insert('\nTest').insert('\n', { header: 2 })
+      );
+      expect(quill.root).toEqualHTML('<p><em>0123</em></p><h2>Test</h2>');
+    });
   });
 
   describe('api', function() {


### PR DESCRIPTION
Fixes https://github.com/quilljs/quill/issues/1338