### PR TITLE
support `blob:` objectURLs for images

### DIFF
--- a/formats/image.js
+++ b/formats/image.js
@@ -31,7 +31,7 @@ class Image extends Embed {
   }
 
   static sanitize(url) {
-    return sanitize(url, ['http', 'https', 'data']) ? url : '//:0';
+    return sanitize(url, ['http', 'https', 'data', 'blob']) ? url : '//:0';
   }
 
   static value(domNode) {


### PR DESCRIPTION
That's all there is to it, before this PR, urls like the following: `blob:http://localhost:8080/c493038e-4490-4018-b121-01053675df91`, which are returned from a call to `URL.createObjectURL` were rejected as invalid.