### PR TITLE
Update clone dependency to >=2.1.1 <2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     }
   },
   "dependencies": {
-    "clone": "~2.1.0",
+    "clone": "~2.1.1",
     "deep-equal": "~1.0.1",
     "eventemitter3": "~2.0.2",
     "extend": "~3.0.0",


### PR DESCRIPTION
In version 2.1.1, CloneJS improved support for Internet Explorer. See this pull request for details: https://github.com/pvorb/clone/pull/77

From my limited testing so far, the fixes in CloneJS should enable QuillJS to run on a wider variety of Windows + Internet Explorer systems. For example, I've seen the dependency update fix some crashes of QuillJS on Internet Explorer 10 running on Windows Server 2012 R2.

If you're interested in merging this pull request, we should add some more Windows + Internet Explorer systems to the Saucelabs test matrix for QuillJS and see if we can increase support. Is this something that you'd be interested in doing?