### PR TITLE
Cast classList to Array before filtering

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -48,7 +48,7 @@ class Toolbar extends Module {
   }
 
   attach(input) {
-    let format = [].find.call(input.classList, (className) => {
+    let format = [].slice.call(input.classList).find((className) => {
       return className.indexOf('ql-') === 0;
     });
     if (!format) return;


### PR DESCRIPTION
Rare case appeared in IE11 when `Array.prototype` is extended by third party script. In my case it was extended by Ember (https://guides.emberjs.com/v2.11.0/configuring-ember/disabling-prototype-extensions/) which adds a bit "magic" in native objects (e.g. Array). 

The problem is that automatic casting `Element.classList` to `Array` in `[].find.call()` does not inherit all previously added properties in prototype. To fix that I suggest to cast `classList` to `Array` explicitly before applying further manipulations.