### PR TITLE
(docs update) clearify container types, polish code format

### DIFF
--- a/docs/docs/modules/toolbar.md
+++ b/docs/docs/modules/toolbar.md
@@ -3,18 +3,23 @@ layout: docs
 title: Toolbar Module
 permalink: /docs/modules/toolbar/
 ---
+
+```html
 <!-- head -->
 <link href="{{ site.cdn }}{{ site.version }}/quill.snow.css" rel="stylesheet">
 <!-- head -->
+```
 
 The Toolbar module allow users to easily format Quill's contents.
 
+```html
 <div class="quill-wrapper">
   <div id="toolbar-toolbar" class="toolbar">
   {% include full-toolbar.html %}
   </div>
   <div id="toolbar-editor" class="editor"></div>
 </div>
+```
 
 It can be configured with a custom container and handlers.
 
@@ -22,7 +27,7 @@ It can be configured with a custom container and handlers.
 var quill = new Quill('#editor', {
   modules: {
     toolbar: {
-      container: '#toolbar',  // Selector for toolbar container
+      container: '#toolbar',  // Selector for toolbar container or DOM element
       handlers: {
         'formula': customFormulaHandler
       }
@@ -202,6 +207,7 @@ var toolbar = quill.getModule('toolbar');
 toolbar.addHandler('image', showImageUI);
 ```
 
+```html
 <!-- script -->
 <script type="text/javascript" src="{{site.cdn}}{{site.version}}/{{site.quill}}"></script>
 <script type="text/javascript">
@@ -213,3 +219,4 @@ toolbar.addHandler('image', showImageUI);
   });
 </script>
 <!-- script -->
+```


### PR DESCRIPTION
 - clearify that `container` property can be a DOM element
 - add code sintax tags 