### PR TITLE
Use better polyfill for startsWith to support IE11 11.0.9600.16663

### DIFF
--- a/core/polyfill.js
+++ b/core/polyfill.js
@@ -13,6 +13,9 @@ if (elem.classList.contains('test-class')) {
 
 if (!String.prototype.startsWith) {
   String.prototype.startsWith = function(searchString, position){
+    if (searchString == null) {
+      return false;
+    }
     position = position || 0;
     return this.substr(position, searchString.length) === searchString;
   };


### PR DESCRIPTION
There is one special IE11 version, where sometimes searchString is not defined. Therefore ``undefined.length`` will through a unhandled exception on load. With this fix, everything works fine. 