### PR TITLE
Add guide for customizing built-in formats

### DIFF
--- a/docs/_data/guides.yaml
+++ b/docs/_data/guides.yaml
@@ -6,6 +6,8 @@
   url: /guides/adding-quill-to-your-build-pipeline/
 - title: Building a Custom Module
   url: /guides/building-a-custom-module/
+- title: Customizing Built-In Formats
+  url: /guides/customizing-built-in-formats
 - title: Cloning Medium with Parchment
   url: /guides/cloning-medium-with-parchment/
 - title: Designing the Delta Format

--- a/docs/guides/customizing-builtin-formats.md
+++ b/docs/guides/customizing-builtin-formats.md
@@ -1,0 +1,19 @@
+---
+layout: docs
+title: Customizing Built-in Formats
+permalink: /guides/customizing-built-in-formats/
+---
+
+Default behavior can be changed or overriden by customizing Quill's [built-in formats](https://github.com/quilljs/quill/tree/develop/formats). All formats, built-in or custom, are implemented in [Parchment](https://github.com/quilljs/parchment/).
+
+### Examples
+
+#### Changing the [link sanitizer](https://github.com/quilljs/quill/blob/develop/formats/link.js)
+
+```js
+var Link = Quill.import('formats/link');
+Link.sanitize = function(url) {
+  // change / sanitize url
+  return url;
+};
+```


### PR DESCRIPTION
Adds documentation for overriding default behavior, such as the link handler (relevant to #550, #1107).