### PR TITLE
detect probable urls in link tooltip handler

### DIFF
--- a/themes/snow.js
+++ b/themes/snow.js
@@ -47,7 +47,7 @@ SnowTheme.DEFAULTS = extend(true, {}, BaseTheme.DEFAULTS, {
               preview = 'mailto:' + preview;
             } else if (/^\.?\/[^(\s|\.)]*$/.test(preview)) {
               preview = preview; // likely relative link
-            } else if (/^\S+(\.)\S+[^.]$/.test(preview) && !(/^https?:\/\//.test(preview)) {
+            } else if (/^\S+(\.)\S+[^.]$/.test(preview) && !(/^https?:\/\//.test(preview))) {
               preview = 'https://' + preview; // likely url
             } else {
               preview = 'https://';

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -45,6 +45,12 @@ SnowTheme.DEFAULTS = extend(true, {}, BaseTheme.DEFAULTS, {
             let preview = this.quill.getText(range);
             if (/^\S+@\S+\.\S+$/.test(preview) && preview.indexOf('mailto:') !== 0) {
               preview = 'mailto:' + preview;
+            } else if (/^\.?\/[^(\s|\.)]*$/.test(preview)) {
+              preview = preview; // likely relative link
+            } else if (/^\S+(\.)\S+[^.]$/.test(preview) && !(/^https?:\/\//.test(preview)) {
+              preview = 'https://' + preview; // likely url
+            } else {
+              preview = 'https://';
             }
             let tooltip = this.quill.theme.tooltip;
             tooltip.edit('link', preview);


### PR DESCRIPTION
- keep email address detector as-is
- leave relative links like `./docs` or `/docs` alone
- prepend things like `www.quilljs.com` with `https://`
- completely replace any other strings with `https://`