### PR TITLE
Fix font style attributor

### DIFF
--- a/formats/font.js
+++ b/formats/font.js
@@ -6,13 +6,6 @@ let config = {
 };
 
 let FontClass = new Parchment.Attributor.Class('font', 'ql-font', config);
-
-class FontStyleAttributor extends Parchment.Attributor.Style {
-  value(node) {
-    return super.value(node).replace(/["']/g, '');
-  }
-}
-
-let FontStyle = new FontStyleAttributor('font', 'font-family', config);
+let FontStyle = new Parchment.Attributor.Style('font', 'font-family', config);
 
 export { FontStyle, FontClass };


### PR DESCRIPTION
I've got the same problem as described in #929 but with `Quill.clipboard.dangerouslyPasteHTML`. I've read your comment on this and example on codepen but figured out that if I change version of quill lib to latest it doesn't work. So I started to investigate this issue.

The problem was in font style attributor as it rips quotes from font-family name since https://github.com/quilljs/quill/commit/7da2feb83488c8df2f639a9d90153eb6f4bb6bbf

I've reverted your changes to this module and it seems that everything works fine now.