### PR TITLE
fontWeight '700' is synonymous with 'bold'

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -299,7 +299,7 @@ function matchStyles(node, delta) {
   if (style.fontStyle && computeStyle(node).fontStyle === 'italic') {
     formats.italic = true;
   }
-  if (style.fontWeight && computeStyle(node).fontWeight === 'bold') {
+  if (style.fontWeight && (computeStyle(node).fontWeight === 'bold' || computeStyle(node).fontWeight === '700')) {
     formats.bold = true;
   }
   if (Object.keys(formats).length > 0) {


### PR DESCRIPTION
According to the CSS spec:
The keyword 'normal' is synonymous with '400', and 'bold' is synonymous with '700'.
https://www.w3.org/TR/CSS2/fonts.html#font-boldness

Fixes https://github.com/quilljs/quill/issues/1456