### PR TITLE
fix(tooltip): adds detection for mobile youtube video

### DIFF
--- a/test/unit.js
+++ b/test/unit.js
@@ -27,6 +27,7 @@ import './unit/modules/keyboard';
 import './unit/modules/toolbar';
 
 import './unit/ui/picker';
+import './unit/theme/base/tooltip';
 
 
 export default Quill;

--- a/test/unit/theme/base/tooltip.js
+++ b/test/unit/theme/base/tooltip.js
@@ -1,0 +1,57 @@
+import Quill from '../../../../core';
+import { BaseTooltip } from '../../../../themes/base'
+
+class Tooltip extends BaseTooltip {
+}
+
+Tooltip.TEMPLATE = '<input type="text">';
+
+describe('BaseTooltip', function() {
+  describe('save', function() {
+    beforeEach(function() {
+      this.quill = this.initialize(Quill, '');
+      this.tooltip = new Tooltip(this.quill)
+    });
+
+    it('converts youtube video url to embedded', function() {
+      insertVideo(this.tooltip, 'http://youtube.com/watch?v=QHH3iSeDBLo');
+      expect(this.container.querySelector('.ql-video').src).toContain('http://www.youtube.com/embed/QHH3iSeDBLo');
+    });
+
+    it('converts www.youtube video url to embedded', function() {
+      insertVideo(this.tooltip, 'http://www.youtube.com/watch?v=QHH3iSeDBLo');
+      expect(this.container.querySelector('.ql-video').src).toContain('http://www.youtube.com/embed/QHH3iSeDBLo');
+    });
+
+    it('converts m.youtube video url to embedded', function() {
+      insertVideo(this.tooltip, 'http://m.youtube.com/watch?v=QHH3iSeDBLo');
+      expect(this.container.querySelector('.ql-video').src).toContain('http://www.youtube.com/embed/QHH3iSeDBLo');
+    });
+
+    it('preserves youtube video url protocol', function() {
+      insertVideo(this.tooltip, 'https://m.youtube.com/watch?v=QHH3iSeDBLo');
+      expect(this.container.querySelector('.ql-video').src).toContain('https://www.youtube.com/embed/QHH3iSeDBLo');
+    });
+
+    it('converts vimeo video url to embedded', function() {
+      insertVideo(this.tooltip, 'http://vimeo.com/47762693');
+      expect(this.container.querySelector('.ql-video').src).toContain('http://player.vimeo.com/video/47762693/');
+    });
+
+    it('converts www.vimeo video url to embedded', function() {
+      insertVideo(this.tooltip, 'http://www.vimeo.com/47762693');
+      expect(this.container.querySelector('.ql-video').src).toContain('http://player.vimeo.com/video/47762693/');
+    });
+
+    it('preserves vimeo video url protocol', function() {
+      insertVideo(this.tooltip, 'https://www.vimeo.com/47762693');
+      expect(this.container.querySelector('.ql-video').src).toContain('https://player.vimeo.com/video/47762693/');
+    });
+
+    function insertVideo(tooltip, url) {
+      tooltip.textbox.value = url;
+      tooltip.root.setAttribute('data-mode', 'video');
+      tooltip.save();
+    }
+  });
+});

--- a/themes/base.js
+++ b/themes/base.js
@@ -196,6 +196,21 @@ class BaseTooltip extends Tooltip {
     this.quill.scrollingContainer.scrollTop = scrollTop;
   }
 
+  convertVideoUrlToEmbeded(url) {
+    let match = url.match(/^(https?):\/\/(?:(?:www|m)\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/) ||
+                url.match(/^(https?):\/\/(?:(?:www|m)\.)?youtu\.be\/([a-zA-Z0-9_-]+)/);
+
+    if (match) {
+      return match[1] + '://www.youtube.com/embed/' + match[2] + '?showinfo=0';
+    }
+
+    if (match = url.match(/^(https?):\/\/(?:www\.)?vimeo\.com\/(\d+)/)) {  // eslint-disable-line no-cond-assign
+      return match[1] + '://player.vimeo.com/video/' + match[2] + '/';
+    }
+
+    return url;
+  }
+
   save() {
     let value = this.textbox.value;
     switch(this.root.getAttribute('data-mode')) {
@@ -212,13 +227,7 @@ class BaseTooltip extends Tooltip {
         break;
       }
       case 'video': {
-        let match = value.match(/^(https?):\/\/(www\.)?youtube\.com\/watch.*v=([a-zA-Z0-9_-]+)/) ||
-                    value.match(/^(https?):\/\/(www\.)?youtu\.be\/([a-zA-Z0-9_-]+)/);
-        if (match) {
-          value = match[1] + '://www.youtube.com/embed/' + match[3] + '?showinfo=0';
-        } else if (match = value.match(/^(https?):\/\/(www\.)?vimeo\.com\/(\d+)/)) {  // eslint-disable-line no-cond-assign
-          value = match[1] + '://player.vimeo.com/video/' + match[3] + '/';
-        }
+        value = this.convertVideoUrlToEmbeded(value);
       } // eslint-disable-next-line no-fallthrough
       case 'formula': {
         if (!value) break;


### PR DESCRIPTION
This allows to convert m.youtube.com and www.youtube.com to embedded url (i.e., `www.youtube.com/embed/${videoId}`

Finishes work of #1155