### PR TITLE
Add prePasteHandler option to clipboard module

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -61,6 +61,7 @@ class Clipboard extends Module {
     this.container.setAttribute('contenteditable', true);
     this.container.setAttribute('tabindex', -1);
     this.matchers = [];
+    this.prePasteHandler = this.options.prePasteHandler;
     CLIPBOARD_CONFIG.concat(this.options.matchers).forEach((pair) => {
       this.addMatcher(...pair);
     });
@@ -95,6 +96,7 @@ class Clipboard extends Module {
   }
 
   onPaste(e) {
+    if (this.prePasteHandler) this.prePasteHandler(e);
     if (e.defaultPrevented || !this.quill.isEnabled()) return;
     let range = this.quill.getSelection();
     let delta = new Delta().retain(range.index);

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -33,6 +33,24 @@ describe('Clipboard', function() {
         done();
       }, 2);
     });
+
+    it('can prevent default with pre paste handler', function(done) {
+      this.quill.clipboard.container.innerHTML = '<strong>|</strong>';
+      this.quill.clipboard.prePasteHandler = function(e) {
+        e.preventDefault();
+      }
+      this.quill.clipboard.onPaste({
+        defaultPrevented: false,
+        preventDefault: function() {
+          this.defaultPrevented = true;
+        }
+      });
+      setTimeout(() => {
+        expect(this.quill.root).toEqualHTML('<h1>0123</h1><p>5<em>67</em>8</p>');
+        expect(this.quill.getSelection()).toEqual(new Range(2, 5));
+        done();
+      }, 2);
+    });
   });
 
   describe('convert', function() {


### PR DESCRIPTION
This change allows handling paste events before quill, potentially preventing
quill's default. This enables functionality where things pasted into quill need to be handled by other parts of the app.