### PR TITLE
Fix selection on mobile - selectionchange events are now fired and fo…

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -30,12 +30,15 @@ class Selection {
     this.cursor = Parchment.create('cursor', this);
     // savedRange is last non-null range
     this.lastRange = this.savedRange = new Range(0, 0);
-    ['keyup', 'mouseup', 'mouseleave', 'touchend', 'touchleave', 'focus', 'blur'].forEach((eventName) => {
-      this.root.addEventListener(eventName, () => {
-        // When range used to be a selection and user click within the selection,
-        // the range now being a cursor has not updated yet without setTimeout
-        setTimeout(this.update.bind(this, Emitter.sources.USER), 100);
-      });
+    ['keyup', 'mouseup', 'mouseleave', 'touchend', 'touchleave', 'focus', 'blur', 'selectionchange'].forEach((eventName) => {
+      let element = this.root;
+
+      // selectionchange is a global event, thus bind it to the document instead of this.root
+      if (eventName === 'selectionchange') {
+        element = document;
+      }
+
+      this.handleDOMEvent(element, eventName);
     });
     this.emitter.on(Emitter.events.EDITOR_CHANGE, (type, delta) => {
       if (type === Emitter.events.TEXT_CHANGE && delta.length() > 0) {
@@ -55,6 +58,20 @@ class Selection {
       });
     });
     this.update(Emitter.sources.SILENT);
+  }
+
+  handleDOMEvent(element, eventName) {
+    element.addEventListener(eventName, (event) => {
+
+      // only handle selectionchange if it happened within the editor
+      if (eventName === 'selectionchange' && event.target.activeElement !== this.root) {
+        return;
+      }
+
+      // When range used to be a selection and user click within the selection,
+      // the range now being a cursor has not updated yet without setTimeout
+      setTimeout(this.update.bind(this, Emitter.sources.USER), 100);
+    });
   }
 
   focus() {


### PR DESCRIPTION
### Fix selection on mobile - selectionchange events are now fired and formatted correctly

@jhchen can you look at this PR and see if we can merge it? The issue encountered was that there is selectionchange event missing, which breaks the functionality on mobile. When user drags the cursor selection position is not being updated.

Reproduce bug:
Select a word. Drag the cursor to the end of the sentence. Try to format - fails. I couldn't think of a way to write test for that, cause the failure is actually that the update() method is not being called on `selectionchange`. If you have any ideas how to add tests for that, I'll do it.

Also, fixes #1450

I suspect this fixes other mobile issues such as #1423 or #1374, but can't confirm it yet - since I haven't explicitly tested.

provided by @gutefrage :-)