### PR TITLE
Register themes tooltips

### DIFF
--- a/quill.js
+++ b/quill.js
@@ -35,8 +35,8 @@ import ColorPicker from './ui/color-picker';
 import IconPicker from './ui/icon-picker';
 import Tooltip from './ui/tooltip';
 
-import BubbleTheme from './themes/bubble';
-import SnowTheme from './themes/snow';
+import BubbleTheme, { BubbleTooltip } from './themes/bubble';
+import SnowTheme, { SnowTooltip } from './themes/snow';
 
 
 Quill.register({
@@ -91,7 +91,9 @@ Quill.register({
   'modules/toolbar': Toolbar,
 
   'themes/bubble': BubbleTheme,
+  'themes/bubble/tooltip': BubbleTooltip,
   'themes/snow': SnowTheme,
+  'themes/snow/tooltip': SnowTooltip,
 
   'ui/icons': Icons,
   'ui/picker': Picker,

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -117,4 +117,4 @@ SnowTooltip.TEMPLATE = [
 ].join('');
 
 
-export default SnowTheme;
+export { SnowTooltip, SnowTheme as default };


### PR DESCRIPTION
Hi,

In order to ease existing theme overriding, I desperately need to access the tooltip class. Dunno why, but doing an es6 `import` miserably fails ([Stackoverflow issue here](https://stackoverflow.com/questions/44625868/es6-babel-class-constructor-cannot-be-invoked-without-new?noredirect=1#comment76257314_44625868)), but doing a `Quill.import('themes/bubble')` is doing great. I'll just need to be able to import `Quill.import('themes/bubble/toolitp')` too :)

This PR is simply exporting `snow` and `bubble` ui tooltips classes.

Hope that could reach `develop` one day.

Thanks