### PR TITLE
use DOM API instead of attribute for "selected" option in dropdowns

### DIFF
--- a/ui/picker.js
+++ b/ui/picker.js
@@ -43,7 +43,7 @@ class Picker {
     [].slice.call(this.select.options).forEach((option) => {
       let item = this.buildItem(option);
       options.appendChild(item);
-      if (option.hasAttribute('selected')) {
+      if (option.selected === true) {
         this.selectItem(item);
       }
     });


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement

The Option element exposes a "selected" getter that works even when the "selected" attribute is not set, such as when the element is created by React.

Another way to do this is to provide an alternate data attribute to identify the default.

Codepen link demonstrating what happens when an initial "selected" attribute is not present on any of custom option tags for ql-align: https://codepen.io/alexkrolick/pen/qjMrEN?editors=0010

Fixes zenoamaro/react-quill#226.