### PR TITLE
Fix typo in docs/api/#contents

### DIFF
--- a/docs/docs/api/contents.md
+++ b/docs/docs/api/contents.md
@@ -68,7 +68,7 @@ var text = quill.getText(0, 10);
 
 ### insertEmbed
 
-Insert embedded content into the editor, returing a [Delta](/guides/working-with-deltas/) representing the change. [Source](/docs/api/#events) may be `"user"`, `"api"`, or `"silent"`. Calls where the `source` is `"user"` when the editor is [disabled](#disable) are ignored.
+Insert embedded content into the editor, returning a [Delta](/guides/working-with-deltas/) representing the change. [Source](/docs/api/#events) may be `"user"`, `"api"`, or `"silent"`. Calls where the `source` is `"user"` when the editor is [disabled](#disable) are ignored.
 
 **Methods**
 


### PR DESCRIPTION
Replace "returing" with "returning".