### PR TITLE
Remove unused variable and event propagation from embeds

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -3,7 +3,6 @@ import Emitter from '../core/emitter';
 import Block, { BlockEmbed } from './block';
 import Break from './break';
 import Container from './container';
-import CodeBlock from '../formats/code';
 
 
 function isLine(blot) {

--- a/core/selection.js
+++ b/core/selection.js
@@ -48,7 +48,6 @@ class Selection {
         blot.domNode.classList.add('ql-embed-selected');
         const range = new Range(blot.offset(scroll), blot.length());
         this.setRange(range, Emitter.sources.USER);
-        e.stopPropagation();
       }
     });
     let mouseCount = 0;


### PR DESCRIPTION
Currently, I cannot insert any objects into the EMbeds which are handled by the global JS listeners:
For example: 
   bootstrap dropdowns or any other plugins.


Also removes unused imported variable 