### PR TITLE
Add ontouchstart handler for checkbox.

### DIFF
--- a/formats/list.js
+++ b/formats/list.js
@@ -63,7 +63,7 @@ class List extends Container {
 
   constructor(domNode) {
     super(domNode);
-    domNode.addEventListener('click', (e) => {
+    const listEventHandler = (e) => {
       if (e.target.parentNode !== domNode) return;
       let format = this.statics.formats(domNode);
       let blot = Parchment.find(e.target);
@@ -72,7 +72,9 @@ class List extends Container {
       } else if(format === 'unchecked') {
         blot.format('list', 'checked');
       }
-    });
+    }
+    domNode.addEventListener('click', listEventHandler);
+    domNode.addEventListener('touchstart', listEventHandler);
   }
 
   format(name, value) {


### PR DESCRIPTION
This commit adds a ontouchstart handler to the checkbox format to allow checking and unchecking on a mobile device while focused on editor.

Based on comment by @sferoze on [this issue]([url](https://github.com/quilljs/quill/issues/759#issuecomment-328303747)).