### PR TITLE
show error when parsing with KaTeX

### DIFF
--- a/modules/formula.js
+++ b/modules/formula.js
@@ -7,7 +7,10 @@ class FormulaBlot extends Embed {
   static create(value) {
     let node = super.create(value);
     if (typeof value === 'string') {
-      window.katex.render(value, node);
+      window.katex.render(value, node, {
+        throwOnError: false,
+        errorColor: '#f00'
+      });
       node.setAttribute('data-value', value);
     }
     return node;


### PR DESCRIPTION
* Use KaTeX's built in error reporting instead of throwing an exception and logging to the console.
* For #1737 

I ran into one issue and I'm not sure what standard procedure is to address since is not directly a part of this proposed change. [These lines](https://github.com/quilljs/quill/blob/develop/blots/embed.js#L12-L14) in `EmbedBlot` are throwing an error when I insert any formula, valid or invalid. I took look at git blame and found that `this.contentNode` was introduced in the last two weeks, but `this` is `undefined` because the function has a different context than the constructor. If that function is changed to an arrow function or `.bind(this)` is added to the end, that fixes the issue.