### PR TITLE
Fix blockembed selection

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -10,6 +10,11 @@ const NEWLINE_LENGTH = 1;
 
 
 class BlockEmbed extends Parchment.Embed {
+  constructor(node) {
+    super(node);
+    node.setAttribute('data-blockEmbed', true);
+  }
+
   attach() {
     super.attach();
     this.attributes = new Parchment.Attributor.Store(this.domNode);

--- a/blots/cursor.js
+++ b/blots/cursor.js
@@ -99,7 +99,7 @@ class Cursor extends Parchment.Embed {
       return mutation.type === 'characterData' && mutation.target === this.textNode;
     })) {
       let range = this.restore();
-      if (range) context.range = range;
+      if (range && context) context.range = range;
     }
   }
 

--- a/core/selection.js
+++ b/core/selection.js
@@ -161,6 +161,7 @@ class Selection {
     if (selection == null || selection.rangeCount <= 0) return null;
     let nativeRange = selection.getRangeAt(0);
     if (nativeRange == null) return null;
+    if (parentIsEmbedBlock(nativeRange.startContainer, this.root)) return null;
     let range = this.normalizeNative(nativeRange);
     debug.info('getNativeRange', range);
     return range;
@@ -335,6 +336,18 @@ class Selection {
   }
 }
 
+function parentIsEmbedBlock (node, rootElement) {
+  let parent = '';
+  try {
+    parent = node.parentNode;
+  } catch (e) {
+    return false;
+  }
+  if(!parent) return false;
+  if (parent.isEqualNode(rootElement) || parent.isEqualNode(document)) return false;
+  if (parent.hasAttribute('data-blockembed')) return true;
+  return parentIsEmbedBlock(parent, rootElement);
+}
 
 function contains(parent, descendant) {
   try {

--- a/test/unit/blots/block-embed.js
+++ b/test/unit/blots/block-embed.js
@@ -7,7 +7,7 @@ describe('Block Embed', function() {
     scroll.insertAt(2, 'video', '#');
     expect(scroll.domNode).toEqualHTML(`
       <p>01</p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
       <p>23</p>
     `);
   });
@@ -17,7 +17,7 @@ describe('Block Embed', function() {
     scroll.insertAt(4, 'video', '#');
     expect(scroll.domNode).toEqualHTML(`
       <p>0123</p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
       <p><br></p>
     `);
   });
@@ -27,90 +27,90 @@ describe('Block Embed', function() {
     scroll.insertAt(5, 'video', '#');
     expect(scroll.domNode).toEqualHTML(`
       <p>0123</p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert text before', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(0, 'Test');
     expect(scroll.domNode).toEqualHTML(`
       <p>Test</p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert text after', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(1, 'Test');
     expect(scroll.domNode).toEqualHTML(`
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
       <p>Test</p>
     `);
   });
 
   it('insert inline embed before', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(0, 'image', '/assets/favicon.png');
     expect(scroll.domNode).toEqualHTML(`
       <p><img src="/assets/favicon.png"></p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert inline embed after', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(1, 'image', '/assets/favicon.png');
     expect(scroll.domNode).toEqualHTML(`
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
       <p><img src="/assets/favicon.png"></p>
     `);
   });
 
   it('insert block embed before', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(0, 'video', '#1');
     expect(scroll.domNode).toEqualHTML(`
-      <iframe src="#1" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#1" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert block embed after', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(1, 'video', '#1');
     expect(scroll.domNode).toEqualHTML(`
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
-      <iframe src="#1" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
+      <iframe src="#1" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert newline before', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(0, '\n');
     scroll.optimize();
     expect(scroll.domNode).toEqualHTML(`
       <p><br></p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 
   it('insert newline after', function() {
-    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.insertAt(1, '\n');
     scroll.optimize();
     expect(scroll.domNode).toEqualHTML(`
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
       <p><br></p>
     `);
   });
 
   it('delete preceding newline', function() {
-    let scroll = this.initialize(Scroll, '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>');
+    let scroll = this.initialize(Scroll, '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>');
     scroll.deleteAt(4, 1);
     expect(scroll.domNode).toEqualHTML(`
       <p>0123</p>
-      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>
+      <iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe>
     `);
   });
 });

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -334,7 +334,7 @@ describe('Editor', function() {
     it('improper block embed insert', function() {
       let editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(2).insert({ video: '#' }));
-      expect(this.container).toEqualHTML('<p>01</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe><p>23</p>');
+      expect(this.container).toEqualHTML('<p>01</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe><p>23</p>');
     });
 
     it('append formatted block embed', function() {
@@ -343,7 +343,7 @@ describe('Editor', function() {
         .retain(5)
         .insert({ video: '#' }, { align: 'right' })
       );
-      expect(this.container).toEqualHTML('<p>0123</p><iframe src="#" class="ql-video ql-align-right" frameborder="0" allowfullscreen="true"></iframe><p><br></p>');
+      expect(this.container).toEqualHTML('<p>0123</p><iframe src="#" class="ql-video ql-align-right" frameborder="0" allowfullscreen="true" data-blockEmbed="true"></iframe><p><br></p>');
     });
 
     it('append', function() {

--- a/test/unit/formats/list.js
+++ b/test/unit/formats/list.js
@@ -318,7 +318,7 @@ describe('List', function() {
     editor.insertEmbed(2, 'video', 'https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0');
     expect(this.container).toEqualHTML(`
       <ol><li>Te</li></ol>
-      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
+      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0" data-blockEmbed="true"></iframe>
       <ol><li>st</li></ol>
     `);
   });
@@ -327,7 +327,7 @@ describe('List', function() {
     let editor = this.initialize(Editor, '<ol><li>Test</li></ol>');
     editor.insertEmbed(0, 'video', 'https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0');
     expect(this.container).toEqualHTML(`
-      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
+      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0" data-blockEmbed="true"></iframe>
       <ol><li>Test</li></ol>
     `);
   });
@@ -337,7 +337,7 @@ describe('List', function() {
     editor.insertEmbed(4, 'video', 'https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0');
     expect(this.container).toEqualHTML(`
       <ol><li>Test</li></ol>
-      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0"></iframe>
+      <iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0" data-blockEmbed="true"></iframe>
       <ol><li><br></li></ol>
     `);
   });


### PR DESCRIPTION
Hi there,

Thanks to @benbro in #1740, I finally managed to get Quill working in my build pipeline, and here is my first PR here 🎉 

This is related to #1720 : when you have rich elements (let's say a complex React element that is inserted inside a quill BlockEmbed blot) and you do something **inside** them (writing in a textarea, an input, etc..), Quill keeps a wrong selection that induce many problems (focus, scroll, etc..) during collaboration with others.

This PR aim is to clear Quill selection when the user clicks on a BlockEmbed element (Philosophy is, even if the BlockEmbed is inside Quill root element, it should be inert, inactive like if we were somewhere else on the page but in the editor).

I basically made two changes:

- in `blots/block/embed` (or `BlockEmbed` blot), I've added a DOM attribute `data-blockEmbed="true"` to distinguish in the DOM that we are dealing with a block embed element
- in `core/selection` I added a test that checks if the current selection is **inside** a BlockEmbed, and if so, it returns `null` like if we were outside the root container

I updated the tests to add `data-blockEmbed` but did not added new tests to ensure this behaviour.

Please, let me know If you have any feedbacks or thoughts about this PR, I'd be glad to quickly help (as I desperately need this PR to fix many collaboration issue I have in my project :) )

Best




