### PR TITLE
Update README examples with the latest version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Instantiate a new Quill object with a css selector for the div that should becom
 
 ```html
 <!-- Include Quill stylesheet -->
-<link href="https://cdn.quilljs.com/1.0.0/quill.snow.css" rel="stylesheet">
+<link href="https://cdn.quilljs.com/1.3.3/quill.snow.css" rel="stylesheet">
 
 <!-- Create the toolbar container -->
 <div id="toolbar">
@@ -57,7 +57,7 @@ Instantiate a new Quill object with a css selector for the div that should becom
 </div>
 
 <!-- Include the Quill library -->
-<script src="https://cdn.quilljs.com/1.0.0/quill.js"></script>
+<script src="https://cdn.quilljs.com/1.3.3/quill.js"></script>
 
 <!-- Initialize Quill editor -->
 <script>
@@ -81,16 +81,16 @@ Take a look at the [Quill website](https://quilljs.com/) for more documentation,
 
 ```html
 <!-- Main Quill library -->
-<script src="//cdn.quilljs.com/1.0.0/quill.js"></script>
-<script src="//cdn.quilljs.com/1.0.0/quill.min.js"></script>
+<script src="//cdn.quilljs.com/1.3.3/quill.js"></script>
+<script src="//cdn.quilljs.com/1.3.3/quill.min.js"></script>
 
 <!-- Theme included stylesheets -->
-<link href="//cdn.quilljs.com/1.0.0/quill.snow.css" rel="stylesheet">
-<link href="//cdn.quilljs.com/1.0.0/quill.bubble.css" rel="stylesheet">
+<link href="//cdn.quilljs.com/1.3.3/quill.snow.css" rel="stylesheet">
+<link href="//cdn.quilljs.com/1.3.3/quill.bubble.css" rel="stylesheet">
 
 <!-- Core build with no theme, formatting, non-essential modules -->
-<link href="//cdn.quilljs.com/1.0.0/quill.core.css" rel="stylesheet">
-<script src="//cdn.quilljs.com/1.0.0/quill.core.js"></script>
+<link href="//cdn.quilljs.com/1.3.3/quill.core.css" rel="stylesheet">
+<script src="//cdn.quilljs.com/1.3.3/quill.core.js"></script>
   ```
 
 


### PR DESCRIPTION
I've updated the CDN links to point to the latest version (1.3.3)