### PR TITLE
Treat as * as another trigger for bullet lists

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -250,7 +250,7 @@ Keyboard.DEFAULTS = {
       key: ' ',
       collapsed: true,
       format: { list: false },
-      prefix: /^\s*?(\d+\.|-|\[ ?\]|\[x\])$/,
+      prefix: /^\s*?(\d+\.|-|\*|\[ ?\]|\[x\])$/,
       handler: function(range, context) {
         let length = context.prefix.length;
         let [line, offset] = this.quill.getLine(range.index);
@@ -263,7 +263,7 @@ Keyboard.DEFAULTS = {
           case '[x]':
             value = 'checked';
             break;
-          case '-':
+          case '-': case '*':
             value = 'bullet';
             break;
           default:


### PR DESCRIPTION
Taking on https://github.com/quilljs/quill/issues/1808, treating `*` the same as `-` to trigger a bullet list quicker than going through the toolbar.