### PR TITLE
Expose tooltips so they can be customized

### DIFF
--- a/quill.js
+++ b/quill.js
@@ -35,8 +35,8 @@ import ColorPicker from './ui/color-picker';
 import IconPicker from './ui/icon-picker';
 import Tooltip from './ui/tooltip';
 
-import BubbleTheme from './themes/bubble';
-import SnowTheme from './themes/snow';
+import BubbleTheme, { BubbleTooltip } from './themes/bubble';
+import SnowTheme, { SnowTooltip } from './themes/snow';
 
 
 Quill.register({
@@ -91,7 +91,9 @@ Quill.register({
   'modules/toolbar': Toolbar,
 
   'themes/bubble': BubbleTheme,
+  'themes/bubble-tooltip': BubbleTooltip,
   'themes/snow': SnowTheme,
+  'themes/snow-tooltip': SnowTooltip,
 
   'ui/icons': Icons,
   'ui/picker': Picker,

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -117,4 +117,4 @@ SnowTooltip.TEMPLATE = [
 ].join('');
 
 
-export default SnowTheme;
+export { SnowTooltip, SnowTheme as default };


### PR DESCRIPTION
We are currently trying to implement some custom behavior in the link tooltip. In order to do this, we wanted to extend the BubbleTheme and BubbleTooltip with some custom behavior. In our case we need show to remove an additional class we are adding. As best I can test, BubbleTooltip is not exposed. This PR would expose it. If it is exposed, then I apologize for not finding it and you can close this PR.