### PR TITLE
Fix for #1376. Up to date history stack on 'editor change'

### DIFF
--- a/modules/history.js
+++ b/modules/history.js
@@ -27,13 +27,13 @@ class History extends Module {
   change(source, dest) {
     if (this.stack[source].length === 0) return;
     let delta = this.stack[source].pop();
+    this.stack[dest].push(delta);
     this.lastRecorded = 0;
     this.ignoreChange = true;
     this.quill.updateContents(delta[source], Quill.sources.USER);
     this.ignoreChange = false;
     let index = getLastChangeIndex(delta[source]);
     this.quill.setSelection(index);
-    this.stack[dest].push(delta);
   }
 
   clear() {


### PR DESCRIPTION
This is a fix for #1376 **undo the first time,but the history.stack.redo.length = 0?**

The destination stack is currently updated after any `editor-change` events. This makes it hard to e.g. reactively enable/disable undo redo buttons. With this change, the stack is updated first, and the quill contents and selection is updated after, ensuring that the stack is up to date when any events are fired.