### PR TITLE
fix script tag markdown

### DIFF
--- a/docs/docs/modules/toolbar.md
+++ b/docs/docs/modules/toolbar.md
@@ -202,7 +202,6 @@ var quill = new Quill('#editor', {
 // Handlers can also be added post initialization
 var toolbar = quill.getModule('toolbar');
 toolbar.addHandler('image', showImageUI);
-```
 
 <!-- script -->
 <script src="{{site.cdn}}{{site.version}}/{{site.quill}}"></script>
@@ -215,3 +214,4 @@ toolbar.addHandler('image', showImageUI);
   });
 </script>
 <!-- script -->
+```


### PR DESCRIPTION
The script tag and it's content wasn't displaying properly

fixed the markdown syntax to display correctly on README