### PR TITLE
make sure ql-active gets set on toolbar checklist buttons

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -6,6 +6,10 @@ import Module from '../core/module';
 
 let debug = logger('quill:toolbar');
 
+let formatLookup = {
+  unchecked: 'check',
+  checked: 'check',
+};
 
 class Toolbar extends Module {
   constructor(quill, options) {
@@ -133,11 +137,13 @@ class Toolbar extends Module {
         if (range == null) {
           input.classList.remove('ql-active');
         } else if (input.hasAttribute('value')) {
+          // lookup correct format for checklists, which don't match the toolbar value
+          let normalizedFormat = formatLookup[formats[format]] || formats[format];
           // both being null should match (default values)
           // '1' should match with 1 (headers)
-          let isActive = formats[format] === input.getAttribute('value') ||
-                         (formats[format] != null && formats[format].toString() === input.getAttribute('value')) ||
-                         (formats[format] == null && !input.getAttribute('value'));
+          let isActive = normalizedFormat === input.getAttribute('value') ||
+                         (normalizedFormat != null && normalizedFormat.toString() === input.getAttribute('value')) ||
+                         (normalizedFormat == null && !input.getAttribute('value'));
           input.classList.toggle('ql-active', isActive);
         } else {
           input.classList.toggle('ql-active', formats[format] != null);

--- a/test/unit/modules/toolbar.js
+++ b/test/unit/modules/toolbar.js
@@ -105,13 +105,15 @@ describe('Toolbar', function() {
         <p><a href="http://quilljs.com/">0123</a></p>
         <p class="ql-align-center">5678</p>
         <p><span class="ql-size-small">01</span><span class="ql-size-large">23</span></p>
+        <ul data-checked="false"><li>27</li></ul>
       `);
       this.quill = new Quill(container, {
         modules: {
           toolbar: [
             ['bold', 'link'],
             [{ 'size': ['small', false, 'large'] }],
-            [{ 'align': '' }, { 'align': 'center' }]
+            [{ 'align': '' }, { 'align': 'center' }],
+            [{ 'list': 'check' }]
           ]
         },
         theme: 'snow'
@@ -158,6 +160,14 @@ describe('Toolbar', function() {
       this.quill.blur();
       expect(centerButton.classList.contains('ql-active')).toBe(false);
       expect(leftButton.classList.contains('ql-active')).toBe(false);
+    });
+
+    it('check list', function() {
+      let checkListButton = this.container.parentNode.querySelector('button.ql-list[value="check"]');
+      this.quill.setSelection(27);
+      expect(checkListButton.classList.contains('ql-active')).toBe(true);
+      this.quill.setSelection(2);
+      expect(checkListButton.classList.contains('ql-active')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Currently, `{list: 'check'}` toolbar buttons don't get `.ql-active` when the selection is over a checklist. This is because the format of checklists is either `checked` or `unchecked`, rather than matching the toolbar button value like most other formats.

This PR fixes this issue by looking up the correct format value before checking against the button value.

Thanks for your awesome work on Quill ✨🌟