### PR TITLE
Detect if browser supports touchstart

### DIFF
--- a/formats/list.js
+++ b/formats/list.js
@@ -74,8 +74,11 @@ class List extends Container {
       }
     }
 
-    domNode.addEventListener('touchstart', listEventHandler);
-    domNode.addEventListener('mousedown', listEventHandler);
+    if ('ontouchstart' in document.documentElement) {
+      domNode.addEventListener('touchstart', listEventHandler);
+    } else {
+      domNode.addEventListener('mousedown', listEventHandler);
+    }
   }
 
   format(name, value) {


### PR DESCRIPTION
This is related to https://github.com/quilljs/quill/pull/1693, however I can't find any pull request for that. Hence here I added the check if touchstart is supported in the browser, so that it prevent the issue check box become unchecked twice when quill is not focused