### PR TITLE
Fix image attribute stripping

### DIFF
--- a/formats/image.js
+++ b/formats/image.js
@@ -39,6 +39,7 @@ class Image extends Parchment.Embed {
   }
 
   format(name, value) {
+    debugger;
     if (ATTRIBUTES.indexOf(name) > -1) {
       if (value) {
         this.domNode.setAttribute(name, value);

--- a/package.json
+++ b/package.json
@@ -73,10 +73,10 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/quilljs/quill"
+    "url": "https://github.com/levous/quill"
   },
   "bugs": {
-    "url": "https://github.com/quilljs/quill/issues"
+    "url": "https://github.com/levous/quill/issues"
   },
   "scripts": {
     "build": "webpack --config _develop/webpack.config.js; rm dist/quill.core dist/quill.bubble dist/quill.snow;",


### PR DESCRIPTION
Greetings...  I wondered if what I've done here could be accomplished another way.  I understand that what I've done here could not be merged but I thought this is the best way to clearly communicate.

The editor is stripping the attributes upon initialization.  I understand why that is important.  I was hoping you could point me to some documentation that explains how to extend the clipboard matchers so that they can recognize specific html attributes and convert them to proper delta attributes, then convert back when presenting html again.