### PR TITLE
Add missing h3..h6 icons

### DIFF
--- a/ui/icons.js
+++ b/ui/icons.js
@@ -25,7 +25,11 @@ module.exports = {
   'formula'   : require('../assets/icons/formula.svg'),
   'header': {
     '1'       : require('../assets/icons/header.svg'),
-    '2'       : require('../assets/icons/header-2.svg')
+    '2'       : require('../assets/icons/header-2.svg'),
+    '3'       : require('../assets/icons/header-3.svg'),
+    '4'       : require('../assets/icons/header-4.svg'),
+    '5'       : require('../assets/icons/header-5.svg'),
+    '6'       : require('../assets/icons/header-6.svg')
   },
   'italic'    : require('../assets/icons/italic.svg'),
   'image'     : require('../assets/icons/image.svg'),


### PR DESCRIPTION
See #1730

The SVGs were added, but not included in the list of icons.
![image](https://user-images.githubusercontent.com/986170/36922811-87e4b0d0-1e69-11e8-9686-6590a3434efa.png)
