### PR TITLE
#issue-801 Allow updating of formula

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -217,6 +217,9 @@ class BaseTooltip extends Tooltip {
       } // eslint-disable-next-line no-fallthrough
       case 'formula': {
         if (!value) break;
+        if (this.linkRange && this.linkRange.length) {
+          this.quill.deleteText(this.linkRange.index, this.linkRange.length);
+        }
         let range = this.quill.getSelection(true);
         if (range != null) {
           let index = range.index + range.length;

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -4,6 +4,7 @@ import BaseTheme, { BaseTooltip } from './base';
 import LinkBlot from '../formats/link';
 import { Range } from '../core/selection';
 import icons from '../ui/icons';
+import { FormulaBlot } from '../modules/formula';
 
 
 const TOOLBAR_CONFIG = [
@@ -97,6 +98,18 @@ class SnowTooltip extends BaseTooltip {
           this.position(this.quill.getBounds(this.linkRange));
           return;
         }
+        let [formula, foffset] = this.quill.scroll.descendant(FormulaBlot, range.index);
+        if (formula != null) {
+          this.linkRange = new Range(range.index - foffset, formula.length());
+          let fpreview = FormulaBlot.value(formula.domNode);
+          let inputpreview = this.root.querySelector('a.ql-preview');
+          inputpreview.value = fpreview;
+          this.show();
+          this.edit('formula', fpreview);
+          this.position(this.quill.getBounds(this.linkRange));
+          return;
+        }
+
       } else {
         delete this.linkRange;
       }


### PR DESCRIPTION
This is a patch for #801, a few notes.

- I looked into doing unit tests but that would add a dependency on for katex and did not add any
- With this modification the tool tip does not have a preview, it goes straight to editing. There is some pro's and cons to this
- On chrome the area which triggers the selection event does not cover the entire formula, this is likely a separate issue, on larger formula's it is about 80% on smaller formula's it's the first character.

The following is the configuration I used for testing.

````
<!DOCTYPE html>
<html lang="en">
<head>
<title>Formula Module - Quill Rich Text Editor</title>
<meta charset="utf-8">
</head>
<body>
<!-- Include Quill stylesheet -->
<link href="dist/quill.snow.css" rel="stylesheet">
<link href="node_modules/katex/dist/katex.css" rel="stylesheet">

<!-- Create the editor container -->
<div id="editor">
  <p>Hello World!</p>
</div>

<!-- Include the Quill library -->
<script src="node_modules/katex/dist/katex.js"></script>
<script src="dist/quill.js"></script>

<!-- Initialize Quill editor -->
<script>
  var editor = new Quill('#editor', {
    modules: {
      formula: true,          // Include formula module
      toolbar: [['formula', 'link']]  // Include button in toolbar
    },
    theme: 'snow'
  });
</script>
</body></html>

````