### PR TITLE
Checklist: fix duplicate trigger on Chrome Mobile

### DIFF
--- a/formats/list.js
+++ b/formats/list.js
@@ -73,8 +73,12 @@ class List extends Container {
         blot.format('list', 'checked');
       }
     }
+    const listTouchEventHandler = (e) => {
+      e.preventDefault();
+      return listEventHandler(e);
+    }
 
-    domNode.addEventListener('touchstart', listEventHandler);
+    domNode.addEventListener('touchstart', listTouchEventHandler);
     domNode.addEventListener('mousedown', listEventHandler);
   }
 


### PR DESCRIPTION
Fixes #2031

Both `mousedown` and `touchstart` are being triggered on Chrome Mobile. We can prevent the `mousedown` event from triggering on touch devices by calling `e.preventDefault()` on the `touchstart` event. Citing [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent):

> if an application does not want mouse events fired on a specific touch target element, the element's touch event handlers should call `preventDefault()` and no additional mouse events will be dispatched.

More details at #2031 and https://github.com/quilljs/quill/issues/759#issuecomment-372505017

cc @patleeman