### PR TITLE
Add normalizeDelta option

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -14,8 +14,9 @@ const ASCII = /^[ -~]*$/;
 
 
 class Editor {
-  constructor(scroll) {
+  constructor(scroll, options) {
     this.scroll = scroll;
+    this.options = options;
     this.delta = this.getDelta();
   }
 
@@ -24,7 +25,9 @@ class Editor {
     this.scroll.update();
     let scrollLength = this.scroll.length();
     this.scroll.batchStart();
-    delta = normalizeDelta(delta);
+    if (this.options.normalizeDelta) {
+      delta = normalizeDelta(delta);
+    }
     delta.reduce((index, op) => {
       let length = op.retain || op.delete || op.insert.length || 1;
       let attributes = op.attributes || {};

--- a/core/quill.js
+++ b/core/quill.js
@@ -78,7 +78,7 @@ class Quill {
       emitter: this.emitter,
       whitelist: this.options.formats
     });
-    this.editor = new Editor(this.scroll);
+    this.editor = new Editor(this.scroll, this.options);
     this.selection = new Selection(this.scroll, this.emitter);
     this.theme = new this.options.theme(this, this.options);
     this.keyboard = this.theme.addModule('keyboard');
@@ -353,7 +353,8 @@ Quill.DEFAULTS = {
   readOnly: false,
   scrollingContainer: null,
   strict: true,
-  theme: 'default'
+  theme: 'default',
+  normalizeDelta: true
 };
 Quill.events = Emitter.events;
 Quill.sources = Emitter.sources;


### PR DESCRIPTION
I am working to upgrade my app from a pre-1.0 version of quill. I have a lot of documents stored in my database as rich-text, using the pre-1.0 versions of the `bullet` and `list` formats. I would like to not have to migrate those in order to update to the latest version of quill, and instead define my own `list` and `bullet` blots to handle those formats (borrowing heavily from the `list` blot in core). However, because I cannot opt-out of the `normalizeDelta` function (which transforms the old `bullet: true` / `list: true` attributes into the new `list` attribute), I have no choice in the matter.

This adds a `normalizeDelta` boolean option that allows one to opt-out of that parsing, for when it's not required, or not relevant.