### PR TITLE
Add merge & mergeInto hooks for custom behavior when deleting across newlines

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -117,6 +117,16 @@ class Block extends Parchment.Block {
     return this.cache.length;
   }
 
+  merge(source) {
+    let ref = this.children.head instanceof Break ? null : this.children.head;
+    source.moveChildren(this, ref);
+    source.remove();
+  }
+
+  mergeInto(target) {
+    target.merge(this);
+  }
+
   moveChildren(target, ref) {
     super.moveChildren(target, ref);
     this.cache = {};

--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -1,8 +1,6 @@
 import Parchment from 'parchment';
 import Emitter from '../core/emitter';
 import Block, { BlockEmbed } from './block';
-import Break from './break';
-import CodeBlock from '../formats/code';
 import Container from './container';
 
 
@@ -45,24 +43,7 @@ class Scroll extends Parchment.Scroll {
         this.optimize();
         return;
       }
-      if (first instanceof CodeBlock) {
-        let newlineIndex = first.newlineIndex(first.length(), true);
-        if (newlineIndex > -1) {
-          first = first.split(newlineIndex + 1);
-          if (first === last) {
-            this.optimize();
-            return;
-          }
-        }
-      } else if (last instanceof CodeBlock) {
-        let newlineIndex = last.newlineIndex(0);
-        if (newlineIndex > -1) {
-          last.split(newlineIndex + 1);
-        }
-      }
-      let ref = last.children.head instanceof Break ? null : last.children.head;
-      first.moveChildren(last, ref);
-      first.remove();
+      first.mergeInto(last);
     }
     this.optimize();
   }

--- a/formats/code.js
+++ b/formats/code.js
@@ -72,6 +72,28 @@ class CodeBlock extends Block {
     return length;
   }
 
+  merge(source) {
+    let newlineIndex = this.newlineIndex(0);
+    if (newlineIndex > -1) {
+      this.split(newlineIndex + 1);
+    }
+    super.merge(source);
+  }
+
+  mergeInto(target) {
+    let newlineIndex = this.newlineIndex(this.length(), true);
+    if (newlineIndex > -1) {
+      let after = this.split(newlineIndex + 1);
+      if (after === target) {
+        this.optimize();
+      } else {
+        after.mergeInto(target);
+      }
+    } else {
+      super.mergeInto(target);
+    }
+  }
+
   newlineIndex(searchIndex, reverse = false) {
     if (!reverse) {
       let offset = this.domNode.textContent.slice(searchIndex).indexOf('\n');


### PR DESCRIPTION
I noticed that `blots/scroll.js` imported `CodeBlock` in order to set up some custom behavior in `deleteAt`. I am working on a blot that needs similar custom behavior, so I extracted that logic into `Block#merge` and `Block#mergeInto`. These methods are guaranteed to only be called on `Block` blots, with a `Block` blot argument by the surrounding code in `Scroll#deleteAt`. We have both `merge` and `mergeInto` in order for a blots to provide custom logic both for when they are either the source or target of the merge. Open to suggestions on improved names for these methods.

Does this seem like a good idea? Should this be build into parchment instead? Are any additional tests needed?