### PR TITLE
Improve keyboard docs

### DIFF
--- a/docs/docs/modules/keyboard.md
+++ b/docs/docs/modules/keyboard.md
@@ -161,6 +161,8 @@ Some bindings are essential to preventing dangerous browser defaults, such as th
 
 Adding a binding with `quill.keyboard.addBinding` will not run before Quill's because the defaults bindings will have been added by that point.
 
+Pass the `bindings` option to the keyboard module, as an object of handler names to binding config objects. Each binding config must contain `key` and `handler` options, and may optionally include any of the `context` options.
+
 ```javascript
 var bindings = {
   // This will overwrite the default binding also named 'tab'
@@ -183,9 +185,7 @@ var bindings = {
 
   list: {
     key: 'backspace',
-    context: {
-      format: ['list']
-    },
+    format: ['list'],
     handler: function(range, context) {
       if (context.offset === 0) {
         // When backspace on the first character of a list,


### PR DESCRIPTION
I noticed that the documentation for the [keyboard module] was a little inaccurate w.r.t. the format of config passed to quill at init (the `context` sub-object is not unwrapped as expected). I've amended the example code, and added a few sentences describing the expected config object format.