### PR TITLE
Support attributor that is scoped for both block + inline blots

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -40,8 +40,8 @@ class Block extends Parchment.Block {
       }
     }
     if (Parchment.query(name, Parchment.Scope.INLINE)) {
-      this.children.forEachAt(index, Math.min(length, this.length() - index - 1), function(child, offset, length) {
-        child.formatAt(offset, length, name, value);
+      this.children.forEachAt(index, Math.min(length, this.length() - index - 1), (child, offset, len) => {
+        child.formatAt(offset, len, name, value);
       });
     }
     this.cache = {};

--- a/blots/block.js
+++ b/blots/block.js
@@ -39,9 +39,11 @@ class Block extends Parchment.Block {
         this.format(name, value);
       }
     }
-    this.children.forEachAt(index, Math.min(length, this.length() - index - 1), function(child, offset, length) {
-      child.formatAt(offset, length, name, value);
-    });
+    if (Parchment.query(name, Parchment.Scope.INLINE)) {
+      this.children.forEachAt(index, Math.min(length, this.length() - index - 1), function(child, offset, length) {
+        child.formatAt(offset, length, name, value);
+      });
+    }
     this.cache = {};
   }
 

--- a/blots/block.js
+++ b/blots/block.js
@@ -38,14 +38,10 @@ class Block extends Parchment.Block {
       if (index + length === this.length()) {
         this.format(name, value);
       }
-    } else {
-      super.formatAt(
-        index,
-        Math.min(length, this.length() - index - 1),
-        name,
-        value,
-      );
     }
+    this.children.forEachAt(index, Math.min(length, this.length() - index - 1), function(child, offset, length) {
+      child.formatAt(offset, length, name, value);
+    });
     this.cache = {};
   }
 

--- a/formats/author.js
+++ b/formats/author.js
@@ -1,0 +1,3 @@
+import Parchment from 'parchment';
+
+export default new Parchment.Attributor.Attribute('author', 'data-author');

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "deep-equal": "^1.0.1",
     "eventemitter3": "^3.0.0",
     "extend": "^3.0.1",
-    "parchment": "quilljs/parchment#f56bca0be455e84e03999fb005ffb2af81fdeba8",
+    "parchment": "voxmedia/parchment#38fbeeb",
     "quill-delta": "^3.6.2"
   },
   "devDependencies": {

--- a/test/unit.js
+++ b/test/unit.js
@@ -2,6 +2,7 @@
 
 import Quill from '../quill.js';
 import CodeBlock, { CodeBlockContainer } from '../formats/code';
+import Author from '../formats/author';
 
 import './helpers/unit';
 
@@ -24,6 +25,7 @@ import './unit/formats/indent';
 import './unit/formats/list';
 import './unit/formats/bold';
 import './unit/formats/table';
+import './unit/formats/author';
 
 import './unit/modules/clipboard';
 import './unit/modules/history';
@@ -37,5 +39,6 @@ import './unit/theme/base/tooltip';
 // Syntax version will otherwise be registered
 Quill.register(CodeBlockContainer, true);
 Quill.register(CodeBlock, true);
+Quill.register(Author);
 
 export default Quill;

--- a/test/unit/formats/author.js
+++ b/test/unit/formats/author.js
@@ -1,0 +1,19 @@
+import Delta from 'quill-delta';
+import Editor from '../../../core/editor';
+
+
+describe('Author', function() {
+  it('add block + inline', function() {
+    let editor = this.initialize(Editor, '<p>0123</p>');
+    editor.formatText(0, 5, { author: 'test' });
+    expect(editor.getDelta()).toEqual(new Delta().insert('0123\n', { author: 'test' }));
+    expect(editor.scroll.domNode).toEqualHTML('<p data-author="test"><span data-author="test">0123</span></p>');
+  });
+
+  it('remove block + inline', function() {
+    let editor = this.initialize(Editor, '<p data-author="test">0<span data-author="test">12</span>3</p>');
+    editor.formatText(0, 5, { author: false });
+    expect(editor.getDelta()).toEqual(new Delta().insert('0123\n'));
+    expect(editor.scroll.domNode).toEqualHTML('<p>0123</p>');
+  });
+});

--- a/test/unit/formats/author.js
+++ b/test/unit/formats/author.js
@@ -4,14 +4,14 @@ import Editor from '../../../core/editor';
 
 describe('Author', function() {
   it('add block + inline', function() {
-    let editor = this.initialize(Editor, '<p>0123</p>');
+    const editor = this.initialize(Editor, '<p>0123</p>');
     editor.formatText(0, 5, { author: 'test' });
     expect(editor.getDelta()).toEqual(new Delta().insert('0123\n', { author: 'test' }));
     expect(editor.scroll.domNode).toEqualHTML('<p data-author="test"><span data-author="test">0123</span></p>');
   });
 
   it('remove block + inline', function() {
-    let editor = this.initialize(Editor, '<p data-author="test">0<span data-author="test">12</span>3</p>');
+    const editor = this.initialize(Editor, '<p data-author="test">0<span data-author="test">12</span>3</p>');
     editor.formatText(0, 5, { author: false });
     expect(editor.getDelta()).toEqual(new Delta().insert('0123\n'));
     expect(editor.scroll.domNode).toEqualHTML('<p>0123</p>');


### PR DESCRIPTION
This is the quill counterpart to https://github.com/quilljs/parchment/pull/55, which adds support for attributors that may be scoped to _both_ BLOCK and INLINE levels.

I've added an `author` format and corresponding tests as an example of how I'd expect such an attributor to behave, when applied to a combination of inline and block blots. These tests would not pass without the change to `Block.prototype.formatAt`.