### PR TITLE
Invalid `}` on line 171 in api/contents.md

### DIFF
--- a/docs/docs/api/contents.md
+++ b/docs/docs/api/contents.md
@@ -168,7 +168,7 @@ quill.updateContents(new Delta()
   .delete(5)                  // 'World' is deleted
   .insert('Quill')
   .retain(1, { bold: true })  // Apply bold to exclamation mark
-});
+);
 // Editor should now be [
 //  { insert: 'Hello Quill' },
 //  { insert: '!', attributes: { bold: true} }


### PR DESCRIPTION
remove invalid closing parenthesis `}` in docs/contents.md on line 171.