### PR TITLE
Consider guard position for the range offset

### DIFF
--- a/blots/embed.js
+++ b/blots/embed.js
@@ -45,18 +45,27 @@ class Embed extends Parchment.Embed {
         };
       }
     } else if (node === this.rightGuard) {
+      let startOffset = text.length;
+
+      if (node.data[node.data.length - 1] === GUARD_TEXT) {
+        // If the guard is on the right of the inserted text we need to
+        // compensate that extra space.
+        startOffset += 1;
+      }
+
       if (this.next instanceof TextBlot) {
         this.next.insertAt(0, text);
+
         range = {
           startNode: this.next.domNode,
-          startOffset: text.length
+          startOffset: startOffset
         }
       } else {
         textNode = document.createTextNode(text);
         this.parent.insertBefore(Parchment.create(textNode), this.next);
         range = {
           startNode: textNode,
-          startOffset: text.length
+          startOffset: startOffset
         };
       }
     }


### PR DESCRIPTION
When you click right after an embed there's a chance of the cursor getting between the inner `contenteditable=false` tag and the `GUARD_TEXT` and when the user enters text, the cursor is positioned incorrectly because the guard not being taken into account.

Here's an example of this problem happening on https://quilljs.com/

![may-10-2018 14-34-53](https://user-images.githubusercontent.com/806502/39884274-b4454c3a-545f-11e8-9df8-223de5e11138.gif)

It seems that this problem is only reproducible clicking with the mouse, you can't get there using the arrow keys.

It seems to be a problem just for the right side, so there's no change needed when `node === this.leftGuard`.
Note that we may need a fix the left side when the user is using left to right (LTR) writing. I'm not sure how to test it.

I've ran the unit tests and checked that the code passes `eslint`, but please do tell me if you want me to adjust something to better fit the project conventions.