### PR TITLE
Use clipboardData in Firefox to work around bug with pasting iframes

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -110,7 +110,18 @@ class Clipboard extends Module {
     let range = this.quill.getSelection();
     let delta = new Delta().retain(range.index);
     let scrollTop = this.quill.scrollingContainer.scrollTop;
-    this.container.focus();
+
+    if (
+      /Firefox/i.test(navigator.userAgent) &&
+      e.clipboardData &&
+      e.clipboardData.getData('text/html')
+    ) {
+      e.preventDefault();
+      this.container.innerHTML = e.clipboardData.getData('text/html');
+    } else {
+      this.container.focus();
+    }
+
     this.quill.selection.update(Quill.sources.SILENT);
     setTimeout(() => {
       delta = delta.concat(this.convert()).delete(range.length);


### PR DESCRIPTION
For some reason, Firefox strips iframe elements from content pasted into a contentEditable div. You can observe this on quilljs.com by selecting the full contents of the editor, the cut/pasting over itself. In Firefox, you will notice that the video embed disappears, while it remains in other browsers (today's versions of Chrome, Safari, and Edge at least).

I believe this is a browser bug that manifests in all contentEditables, not just Quill. Try pasting the contents from quilljs.com into this plain contentEditable codepen: https://codepen.io/thomsbg/full/VxGBXE/

I make use of iframes for videos and other embed types in my application, and being able to copy/paste these is an important part of my UX. So, I've made a browser-specific exception in the clipboard module's `onPaste` method, in order to manually set the contents of the clipboard container div with the value of `e.clipboardData.getData('text/html')`. This seems to solve the problem in my app.

I explored adding steps to the functional test for inserting an embed and ensuring it survives a cut & paste operation, but wasn't quite able to make it work. I gave up since it looks like the project is only configured to test against Chrome anyway. Let me know if you'd like me to explore that further.