### PR TITLE
Corrected delta displayed in video code block in Medium clone guide

### DIFF
--- a/docs/guides/cloning-medium-with-parchment.md
+++ b/docs/guides/cloning-medium-with-parchment.md
@@ -257,9 +257,7 @@ Note if you open your console and call [`getContents`](/docs/api/#getcontents), 
 {
   ops: [{
     insert: {
-      video: {
-        src: 'https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0'
-      }
+      video: 'https://www.youtube.com/embed/QHH3iSeDBLo?showinfo=0'
     },
     attributes: {
       height: '170',


### PR DESCRIPTION
If you actually look at the result of `getContents()` at the codepen example for adding the VideoBlot, you'll see that there is no src key within the video, it's just a string. This makes the code block that is supposed to be the outputted delta match what it's expected to be on Codepen.