### PR TITLE
Remove Globals - Support ShadowDom for modern browsers and ShadyDOM polyfill for IE

### DIFF
--- a/core/emitter.js
+++ b/core/emitter.js
@@ -5,30 +5,41 @@ let debug = logger('quill:events');
 
 const EVENTS = [ 'selectionchange', 'mousedown', 'mouseup', 'click' ];
 
-const setGlobalListeners = (emitter, doc) => {
+const setGlobalListeners = (emitter, documentOrShadow) => {
+  const selectionRoot = resolveSelectionRoot(documentOrShadow);
+
   return EVENTS.reduce((acc, eventName) => {
     const handler = (...args) => emitter.handleDOM(...args);
 
     // set the listener on the correctly scoped document. This allows callers to pass the correct document to the emitter b/c document can be window.document or shadowRoot
     // In addition, this fixes a hack where the quill instance was being stored in the DOM instead of closure scope.
-    doc.addEventListener(eventName, handler);
+    selectionRoot.addEventListener(eventName, handler);
 
-    return acc.concat({ eventName, doc, handler });
-  });
+    return acc.concat({ eventName, target: selectionRoot, handler });
+  }, []);
 };
 
+const resolveSelectionRoot = (selectionRoot) => {
+  if (selectionRoot && typeof selectionRoot.getSelection === 'function') {
+    return selectionRoot;
+  } else if (selectionRoot) {
+    return selectionRoot.ownerDocument || window.document;
+  }
+
+  return window.document;
+}
 
 class Emitter extends EventEmitter {
-  constructor({ document = window.document }) {
+  constructor({ selectionRoot = window.document }) {
     super();
     this.listeners = {};
     this.on('error', debug.error);
-    this.document = document;
-    this.globalListeners = setGlobalListeners(this, document);
+    this.selectionRoot = selectionRoot;
+    this.globalListeners = setGlobalListeners(this, selectionRoot);
   }
 
   destroy() {
-    this.globalListeners.forEach(({ eventName, doc, handler }) => doc.removeEventListener(eventName, handler));
+    this.globalListeners.forEach(({ eventName, target, handler }) => target.removeEventListener(eventName, handler));
   }
 
   emit() {

--- a/core/quill.js
+++ b/core/quill.js
@@ -58,9 +58,11 @@ class Quill {
 
   constructor(container, options = {}) {
     const document = options.document || window.document;
-    this.document = document;
+    const selectionRoot = options.selectionRoot || document;
 
-    this.options = expandConfig(container, options, document);
+    this.document = document;
+    this.selectionRoot = selectionRoot;
+    this.options = expandConfig(container, options, selectionRoot);
     this.container = this.options.container;
     if (this.container == null) {
       return debug.error('Invalid Quill container', container);
@@ -76,7 +78,7 @@ class Quill {
     this.root.classList.add('ql-blank');
     this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;
-    this.emitter = new Emitter({ document });
+    this.emitter = new Emitter({ selectionRoot });
     this.scroll = Parchment.create(this.root, {
       emitter: this.emitter,
       whitelist: this.options.formats
@@ -373,7 +375,7 @@ Quill.imports = {
 };
 
 
-function expandConfig(container, userConfig, document) {
+function expandConfig(container, userConfig, selectionRoot) {
 
   userConfig = extend(true, {
     container: container,
@@ -420,7 +422,7 @@ function expandConfig(container, userConfig, document) {
   userConfig = extend(true, {}, Quill.DEFAULTS, { modules: moduleConfig }, themeConfig, userConfig);
   ['bounds', 'container', 'scrollingContainer'].forEach(function(key) {
     if (typeof userConfig[key] === 'string') {
-      userConfig[key] = document.querySelector(userConfig[key]);
+      userConfig[key] = selectionRoot.querySelector(userConfig[key]);
     }
   });
   userConfig.modules = Object.keys(userConfig.modules).reduce(function(config, name) {

--- a/core/quill.js
+++ b/core/quill.js
@@ -57,7 +57,10 @@ class Quill {
   }
 
   constructor(container, options = {}) {
-    this.options = expandConfig(container, options);
+    const document = options.document || window.document;
+    this.document = document;
+
+    this.options = expandConfig(container, options, document);
     this.container = this.options.container;
     if (this.container == null) {
       return debug.error('Invalid Quill container', container);
@@ -73,7 +76,7 @@ class Quill {
     this.root.classList.add('ql-blank');
     this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;
-    this.emitter = new Emitter();
+    this.emitter = new Emitter({ document });
     this.scroll = Parchment.create(this.root, {
       emitter: this.emitter,
       whitelist: this.options.formats
@@ -109,6 +112,8 @@ class Quill {
   }
 
   addContainer(container, refNode = null) {
+    const document = this.document;
+
     if (typeof container === 'string') {
       let className = container;
       container = document.createElement('div');
@@ -368,7 +373,8 @@ Quill.imports = {
 };
 
 
-function expandConfig(container, userConfig) {
+function expandConfig(container, userConfig, document) {
+
   userConfig = extend(true, {
     container: container,
     modules: {

--- a/core/selection.js
+++ b/core/selection.js
@@ -17,6 +17,8 @@ class Range {
 
 class Selection {
   constructor(scroll, emitter) {
+    this.document = emitter.document;
+
     this.emitter = emitter;
     this.scroll = scroll;
     this.composing = false;
@@ -75,6 +77,8 @@ class Selection {
   }
 
   handleDragging() {
+    const document = this.document;
+
     this.emitter.listenDOM('mousedown', document.body, () => {
       this.mouseDown = true;
     });
@@ -114,6 +118,8 @@ class Selection {
   }
 
   getBounds(index, length = 0) {
+    const document = this.document;
+
     let scrollLength = this.scroll.length();
     index = Math.min(index, scrollLength - 1);
     length = Math.min(index + length, scrollLength - 1) - index;
@@ -157,6 +163,8 @@ class Selection {
   }
 
   getNativeRange() {
+    const document = this.document;
+
     let selection = document.getSelection();
     if (selection == null || selection.rangeCount <= 0) return null;
     let nativeRange = selection.getRangeAt(0);
@@ -174,6 +182,8 @@ class Selection {
   }
 
   hasFocus() {
+    const document = this.document;
+
     return document.activeElement === this.root;
   }
 
@@ -265,6 +275,9 @@ class Selection {
 
   setNativeRange(startNode, startOffset, endNode = startNode, endOffset = startOffset, force = false) {
     debug.info('setNativeRange', startNode, startOffset, endNode, endOffset);
+
+    const document = this.document;
+
     if (startNode != null && (this.root.parentNode == null || startNode.parentNode == null || endNode.parentNode == null)) {
       return;
     }

--- a/core/selection.js
+++ b/core/selection.js
@@ -14,10 +14,20 @@ class Range {
   }
 }
 
+const resolveSelectionRoot = (selectionRoot) => {
+  if (selectionRoot && typeof selectionRoot.getSelection === 'function' && !selectionRoot.isShady) {
+    return selectionRoot;
+  } else if (selectionRoot) {
+    return selectionRoot.ownerDocument || window.document;
+  }
+
+  return window.document;
+}
 
 class Selection {
   constructor(scroll, emitter) {
-    this.document = emitter.document;
+    const selectionRoot = resolveSelectionRoot(emitter.selectionRoot);
+    this.selectionRoot = selectionRoot;
 
     this.emitter = emitter;
     this.scroll = scroll;
@@ -29,7 +39,7 @@ class Selection {
     this.lastRange = this.savedRange = new Range(0, 0);
     this.handleComposition();
     this.handleDragging();
-    this.emitter.listenDOM('selectionchange', document, () => {
+    this.emitter.listenDOM('selectionchange', selectionRoot, () => {
       if (!this.mouseDown) {
         setTimeout(this.update.bind(this, Emitter.sources.USER), 1);
       }
@@ -77,12 +87,12 @@ class Selection {
   }
 
   handleDragging() {
-    const document = this.document;
+    const selectionRoot = this.selectionRoot;
 
-    this.emitter.listenDOM('mousedown', document.body, () => {
+    this.emitter.listenDOM('mousedown', selectionRoot, () => {
       this.mouseDown = true;
     });
-    this.emitter.listenDOM('mouseup', document.body, () => {
+    this.emitter.listenDOM('mouseup', selectionRoot, () => {
       this.mouseDown = false;
       this.update(Emitter.sources.USER);
     });
@@ -118,7 +128,8 @@ class Selection {
   }
 
   getBounds(index, length = 0) {
-    const document = this.document;
+    const selectionRoot = this.selectionRoot;
+    const document = selectionRoot.ownerDocument || selectionRoot;
 
     let scrollLength = this.scroll.length();
     index = Math.min(index, scrollLength - 1);
@@ -163,9 +174,9 @@ class Selection {
   }
 
   getNativeRange() {
-    const document = this.document;
+    const selectionRoot = this.selectionRoot;
 
-    let selection = document.getSelection();
+    let selection = selectionRoot.getSelection();
     if (selection == null || selection.rangeCount <= 0) return null;
     let nativeRange = selection.getRangeAt(0);
     if (nativeRange == null) return null;
@@ -182,9 +193,9 @@ class Selection {
   }
 
   hasFocus() {
-    const document = this.document;
+    const selectionRoot = this.selectionRoot;
 
-    return document.activeElement === this.root;
+    return selectionRoot.activeElement === this.root;
   }
 
   normalizedToRange(range) {
@@ -276,12 +287,13 @@ class Selection {
   setNativeRange(startNode, startOffset, endNode = startNode, endOffset = startOffset, force = false) {
     debug.info('setNativeRange', startNode, startOffset, endNode, endOffset);
 
-    const document = this.document;
+    const selectionRoot = this.selectionRoot;
+    const document = selectionRoot.ownerDocument || selectionRoot;
 
     if (startNode != null && (this.root.parentNode == null || startNode.parentNode == null || endNode.parentNode == null)) {
       return;
     }
-    let selection = document.getSelection();
+    let selection = selectionRoot.getSelection();
     if (selection == null) return;
     if (startNode != null) {
       if (!this.hasFocus()) this.root.focus();

--- a/themes/base.js
+++ b/themes/base.js
@@ -29,11 +29,11 @@ const SIZES = [ 'small', false, 'large', 'huge' ];
 class BaseTheme extends Theme {
   constructor(quill, options) {
     super(quill, options);
-    const document = quill.document;
+    const selectionRoot = quill.selectionRoot;
 
     let listener = (e) => {
-      if (!document.body.contains(quill.root)) {
-        return document.body.removeEventListener('click', listener);
+      if (!selectionRoot.contains(quill.root)) {
+        return selectionRoot.removeEventListener('click', listener);
       }
       if (this.tooltip != null && !this.tooltip.root.contains(e.target) &&
           document.activeElement !== this.tooltip.textbox && !this.quill.hasFocus()) {
@@ -47,7 +47,7 @@ class BaseTheme extends Theme {
         });
       }
     };
-    quill.emitter.listenDOM('click', document.body, listener);
+    quill.emitter.listenDOM('click', selectionRoot, listener);
   }
 
   addModule(name) {

--- a/themes/base.js
+++ b/themes/base.js
@@ -29,6 +29,8 @@ const SIZES = [ 'small', false, 'large', 'huge' ];
 class BaseTheme extends Theme {
   constructor(quill, options) {
     super(quill, options);
+    const document = quill.document;
+
     let listener = (e) => {
       if (!document.body.contains(quill.root)) {
         return document.body.removeEventListener('click', listener);
@@ -119,6 +121,7 @@ BaseTheme.DEFAULTS = extend(true, {}, Theme.DEFAULTS, {
           this.quill.theme.tooltip.edit('formula');
         },
         image: function() {
+          const document = this.container.ownerDocument;
           let fileInput = this.container.querySelector('input.ql-image[type=file]');
           if (fileInput == null) {
             fileInput = document.createElement('input');
@@ -249,6 +252,7 @@ function extractVideoUrl(url) {
 }
 
 function fillSelect(select, values, defaultValue = false) {
+  const document = select.ownerDocument;
   values.forEach(function(value) {
     let option = document.createElement('option');
     if (value === defaultValue) {

--- a/themes/bubble.js
+++ b/themes/bubble.js
@@ -46,6 +46,7 @@ BubbleTheme.DEFAULTS = extend(true, {}, BaseTheme.DEFAULTS, {
 class BubbleTooltip extends BaseTooltip {
   constructor(quill, bounds) {
     super(quill, bounds);
+    const document = quill.document;
     this.quill.on(Emitter.events.EDITOR_CHANGE, (type, range, oldRange, source) => {
       if (type !== Emitter.events.SELECTION_CHANGE) return;
       if (range != null && range.length > 0 && source === Emitter.sources.USER) {

--- a/ui/picker.js
+++ b/ui/picker.js
@@ -9,6 +9,9 @@ function toggleAriaAttribute(element, attribute) {
 
 class Picker {
   constructor(select) {
+    const document = select.ownerDocument;
+    this.document = document;
+
     this.select = select;
     this.container = document.createElement('span');
     this.buildPicker();
@@ -44,6 +47,8 @@ class Picker {
   }
 
   buildItem(option) {
+    const document = this.document;
+
     let item = document.createElement('span');
     item.tabIndex = '0';
     item.setAttribute('role', 'button');
@@ -79,6 +84,8 @@ class Picker {
   }
 
   buildLabel() {
+    const document = this.document;
+
     let label = document.createElement('span');
     label.classList.add('ql-picker-label');
     label.innerHTML = DropdownIcon;
@@ -90,6 +97,8 @@ class Picker {
   }
 
   buildOptions() {
+    const document = this.document;
+
     let options = document.createElement('span');
     options.classList.add('ql-picker-options');
 
@@ -138,6 +147,8 @@ class Picker {
   }
 
   selectItem(item, trigger = false) {
+    const document = this.document;
+
     let selected = this.container.querySelector('.ql-selected');
     if (item === selected) return;
     if (selected != null) {

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -1,5 +1,7 @@
 class Tooltip {
   constructor(quill, boundsContainer) {
+    const document = quill.document;
+
     this.quill = quill;
     this.boundsContainer = boundsContainer || document.body;
     this.root = quill.addContainer('ql-tooltip');


### PR DESCRIPTION
### Overview
I'm wrapping quill with a webcomponent so it can be used with common diff/patch libraries (we are using Elm, but this should be possible with any diff/patch implementation). In order to make things work correctly with ShadowDOM, all of the global stuff needs to be refactored. This is what I attempted to do here.  

### Changes

* Remove all assumptions that there is only 1 document and that document is global.
* Separate the assumption that document is the only thing that implements `getSelection()` [ see MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/getSelection)
* Initialize with sensible defaults that do not change the current global assumptions
* Refactor the global listeners so they avoid using the DOM to store the quill instance `node.__quill` it assumes things that break ShadowDOM and the separation which is intended.

### How do we ge this published?
I'm not sure how to trigger all of the build/test stuff in this library or what processes y'all use to get a release published. If there is anything I can do to help with getting this published, please LMK.  