### PR TITLE
Allow updating formula

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -252,6 +252,9 @@ function matchBlot(node, delta) {
     let value = match.value(node);
     if (value != null) {
       embed[match.blotName] = value;
+      if (match.blotName === 'formula') {
+        embed.length = match.value(node).length;
+      }
       delta = new Delta().insert(embed, match.formats(node));
     }
   } else if (typeof match.formats === 'function') {

--- a/modules/formula.js
+++ b/modules/formula.js
@@ -19,6 +19,19 @@ class FormulaBlot extends Embed {
   static value(domNode) {
     return domNode.getAttribute('data-value');
   }
+
+  constructor(node) {
+    super(node);
+    this.text = this.statics.value(node);
+  }
+
+  length() {
+    return this.text.length;
+  }
+
+  value() {
+    return this.text;
+  }
 }
 FormulaBlot.blotName = 'formula';
 FormulaBlot.className = 'ql-formula';

--- a/themes/base.js
+++ b/themes/base.js
@@ -177,7 +177,7 @@ class BaseTooltip extends Tooltip {
     this.hide();
   }
 
-  edit(mode = 'link', preview = null) {
+  edit(mode = 'link', preview = null, options = { create: true }) {
     this.root.classList.remove('ql-hidden');
     this.root.classList.add('ql-editing');
     if (preview != null) {
@@ -186,7 +186,9 @@ class BaseTooltip extends Tooltip {
       this.textbox.value = '';
     }
     this.position(this.quill.getBounds(this.quill.selection.savedRange));
-    this.textbox.select();
+    if (options.create) {
+      this.textbox.select();
+    }
     this.textbox.setAttribute('placeholder', this.textbox.getAttribute(`data-${mode}`) || '');
     this.root.setAttribute('data-mode', mode);
   }

--- a/themes/base.js
+++ b/themes/base.js
@@ -217,6 +217,9 @@ class BaseTooltip extends Tooltip {
       } // eslint-disable-next-line no-fallthrough
       case 'formula': {
         if (!value) break;
+        if (this.linkRange && this.linkRange.length) {
+          this.quill.deleteText(this.linkRange.index, this.linkRange.length);
+        }
         let range = this.quill.getSelection(true);
         if (range != null) {
           let index = range.index + range.length;

--- a/themes/base.js
+++ b/themes/base.js
@@ -187,6 +187,9 @@ class BaseTooltip extends Tooltip {
     }
     this.position(this.quill.getBounds(this.quill.selection.savedRange));
     if (options.create) {
+      if (mode === 'formula') {
+        this.textbox.value = '';
+      }
       this.textbox.select();
     }
     this.textbox.setAttribute('placeholder', this.textbox.getAttribute(`data-${mode}`) || '');

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -4,6 +4,7 @@ import BaseTheme, { BaseTooltip } from './base';
 import LinkBlot from '../formats/link';
 import { Range } from '../core/selection';
 import icons from '../ui/icons';
+import { FormulaBlot } from '../modules/formula';
 
 
 const TOOLBAR_CONFIG = [
@@ -97,6 +98,18 @@ class SnowTooltip extends BaseTooltip {
           this.position(this.quill.getBounds(this.linkRange));
           return;
         }
+        let [formula, foffset] = this.quill.scroll.descendant(FormulaBlot, range.index);
+        if (formula != null) {
+          this.linkRange = new Range(range.index - foffset, formula.length());
+          let fpreview = FormulaBlot.value(formula.domNode);
+          let inputpreview = this.root.querySelector('a.ql-preview');
+          inputpreview.value = fpreview;
+          this.show();
+          this.edit('formula', fpreview);
+          this.position(this.quill.getBounds(this.linkRange));
+          return;
+        }
+
       } else {
         delete this.linkRange;
       }

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -105,7 +105,7 @@ class SnowTooltip extends BaseTooltip {
           let inputpreview = this.root.querySelector('a.ql-preview');
           inputpreview.value = fpreview;
           this.show();
-          this.edit('formula', fpreview);
+          this.edit('formula', fpreview, { create: false });
           this.position(this.quill.getBounds(this.linkRange));
           return;
         }


### PR DESCRIPTION
This is a continuation of @charlesverge's work on #1992 (issue #801).

I added a commit that adds a `length()` method to `FormulaBlot`, so selection inside a formula will work properly.

There's still a number of issues though:

- It's impossible to add text before a formula, because the formula popup opens and steals focus. I imagine the solution is to disable that behavior.
- I get an error inside `ContainerBlot.insertBefore` when the editor is initialized with a formula (such as on [quilljs.com](http://quilljs.com)). The error I get is `TypeError: Cannot read property 'statics' of null`. I'm pretty new to Quill and Parchment's internals, so any tips on how to fix that would be very welcome.