### PR TITLE
Add toolbar setting for custom theme unset select option

### DIFF
--- a/docs/docs/modules/toolbar.md
+++ b/docs/docs/modules/toolbar.md
@@ -22,6 +22,7 @@ It can be configured with a custom container and handlers.
 var quill = new Quill('#editor', {
   modules: {
     toolbar: {
+      unsetSelectValue: 'normal',   // Optional string representing a custom option value
       container: '#toolbar',  // Selector for toolbar container
       handlers: {
         'formula': customFormulaHandler
@@ -215,3 +216,18 @@ toolbar.addHandler('image', showImageUI);
   });
 </script>
 <!-- script -->
+
+## unsetSelectValue option
+
+When using a custom toolbar with and custom quill theme, the `unsetSelectValue` option can optionally be set to a string of your custom select option's value used in the case where the format is unset or false. e.g:
+
+```html
+<option value='normal'>Normal</option>
+```
+
+Note: this is only necessary when using a custom theme (e.g. setting the `theme: null` option). For other cases just add the recommended falsy option and omit the unsetSelectValue option:
+
+```html
+  <!-- Note a missing, thus falsy value, is used to reset to default -->
+  <option selected></option>
+```

--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -108,6 +108,7 @@ class Toolbar extends Module {
 
   update(range) {
     let formats = range == null ? {} : this.quill.getFormat(range);
+    const unsetVal = this.options.unsetSelectValue;
     this.controls.forEach(function(pair) {
       let [format, input] = pair;
       if (input.tagName === 'SELECT') {
@@ -123,8 +124,11 @@ class Toolbar extends Module {
           }
           option = input.querySelector(`option[value="${value}"]`);
         }
+        if (option == null && unsetVal) {
+          option = input.querySelector(`option[value="${unsetVal}"]`);
+        }
         if (option == null) {
-          input.value = '';   // TODO make configurable?
+          input.value = '';
           input.selectedIndex = -1;
         } else {
           option.selected = true;
@@ -199,6 +203,7 @@ function addSelect(container, format, values) {
 }
 
 Toolbar.DEFAULTS = {
+  unsetValue: null,
   container: null,
   handlers: {
     clean: function() {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -429,6 +429,7 @@ describe('Quill', function() {
         }
       });
       expect(config.modules.toolbar).toEqual({
+        unsetValue: null,
         container: '#test-container',
         handlers: Toolbar.DEFAULTS.handlers
       });
@@ -441,6 +442,7 @@ describe('Quill', function() {
         }
       });
       expect(config.modules.toolbar).toEqual({
+        unsetValue: null,
         container: document.querySelector('#test-container'),
         handlers: Toolbar.DEFAULTS.handlers
       });
@@ -453,6 +455,7 @@ describe('Quill', function() {
         }
       });
       expect(config.modules.toolbar).toEqual({
+        unsetValue: null,
         container: ['bold'],
         handlers: Toolbar.DEFAULTS.handlers
       });


### PR DESCRIPTION
I saw the `// TODO make configurable?` comment and needed it for a current project, so decided to implement.

This PR adds a new toolbar configuration setting, `unsetSelectValue` (null by default) to allow quill to set a custom theme's select element to an option representing an unset or unapplied format.

Example: a custom toolbar (with a custom quill theme) may have a format dropdown with an option element to be used in the case of a unset format like so:

`<option value='normal'>Normal</option>`

When the select's format is unset or unapplied and the option's `value` is supplied in `unsetSelectValue`, quill can now set the select's selected option to this option instead of setting the selectedIndex to -1 and causing the select to show blank.
