### PR TITLE
Interpret font-weight > 500 as bold

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -313,7 +313,7 @@ function matchStyles(node, delta) {
     formats.italic = true;
   }
   if (style.fontWeight && (computeStyle(node).fontWeight.startsWith('bold') ||
-                           parseInt(computeStyle(node).fontWeight) >= 700)) {
+                           parseInt(computeStyle(node).fontWeight) > 500)) {
     formats.bold = true;
   }
   if (Object.keys(formats).length > 0) {


### PR DESCRIPTION
According to the [MDN docs for font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Fallback_weights), any value > 500 should be interpreted as the next higher value if that exact weight is not found.

For Quill's purposes, I interpret this as any weight > 500 should imply the `bold` format. In my app, I have styled `<em>` tags with a font-weight of 600, since that is what is appropriate for my typeface. Unfortunately, the current cutoff of `font-weight: 700` means that the bold format is lost when copy/pasting bold text inside of the editor.

I _could_ have fixed this by using a custom clipboard matcher for just my app, but after reading the MDN docs, I thought it would be more appropriate to specify here for the benefit of others.