### PR TITLE
Use DOMParser to safely parse html without script execution

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -84,8 +84,11 @@ class Clipboard extends Module {
     } else if (!html) {
       return new Delta().insert(text || '');
     }
-    const container = this.quill.root.ownerDocument.createElement('div');
-    container.innerHTML = html.replace(/>\r?\n +</g, '><'); // Remove spaces between tags
+    const doc = new DOMParser().parseFromString(
+      html.replace(/>\r?\n +</g, '><'), // Remove spaces between tags
+      'text/html',
+    );
+    const container = doc.body;
     const nodeMatches = new WeakMap();
     const [elementMatchers, textMatchers] = this.prepareMatching(
       container,

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -262,11 +262,20 @@ describe('Clipboard', function() {
       expect(delta).toEqual(expected);
     });
 
+    it('does not execute javascript', function() {
+      window.unsafeFunction = jasmine.createSpy('unsafeFunction');
+      const html =
+        "<img src='/assets/favicon.png' onload='window.unsafeFunction()'/>";
+      this.clipboard.convert({ html });
+      expect(window.unsafeFunction).not.toHaveBeenCalled();
+      delete window.unsafeFunction;
+    });
+
     it('xss', function() {
       const delta = this.clipboard.convert({
         html: '<script>alert(2);</script>',
       });
-      expect(delta).toEqual(new Delta().insert('alert(2);'));
+      expect(delta).toEqual(new Delta().insert(''));
     });
   });
 });


### PR DESCRIPTION
Fix for [#2224](https://github.com/quilljs/quill/issues/2224)

DOMParser will safely parse html without executing scripts or inline javascript handlers.  It will also automatically put script tags in the head of the document which we should be able to safely ignore. 
This implementation does change the resulting delta of the paste by not the script content as text.

Issue [#2224](https://github.com/quilljs/quill/issues/2224) identifies another issue where inline event handlers can execute javascript from non script tags.  I was unable to create a failing test with an `img.onerror` handler defined even though the failed img src request can be seen in the test report.  I can continue to work on this if necessary.  Here is the test:

```js
it('does not execute javascript', function() {
    window.unsafeFunction = jasmine.createSpy('unsafeFunction');
    const html = "<img src='a' onerror='window.unsafeFunction()'/>";
    this.clipboard.convert({ html });
    expect(window.unsafeFunction).not.toHaveBeenCalled();
    delete window.unsafeFunction;
});
```