### PR TITLE
bypass uploader if clipboardData has rich text

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -134,8 +134,11 @@ class Clipboard extends Module {
     e.preventDefault();
     const range = this.quill.getSelection(true);
     if (range == null) return;
+    const hasRichText =
+      e.clipboardData.getData('text/html') &&
+      e.clipboardData.getData('text/plain');
     const files = Array.from(e.clipboardData.files || []);
-    if (files.length > 0) {
+    if (!hasRichText && files.length > 0) {
       this.quill.uploader.upload(range, files);
     } else {
       this.onPaste(e, range);


### PR DESCRIPTION
Fix for [#2222](https://github.com/quilljs/quill/issues/2222)

This fix only delegates responsibility to uploader if there is no rich text in clipboardData.