### PR TITLE
Update #toEqualHTML matcher to check structure before nodes.

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -234,7 +234,7 @@ function convertListHTML(items, lastIndent, types) {
   const [{ child, offset, length, indent, type }, ...rest] = items;
   const [tag, attribute] = getListType(type);
   if (indent > lastIndent) {
-    types.push(tag);
+    types.push(type);
     return `<${tag}><li${attribute}>${convertHTML(
       child,
       offset,

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -353,7 +353,7 @@ describe('Editor', function() {
         new Delta().insert({ image: '/assets/favicon.png' }, { italic: true }),
       );
       expect(this.container).toEqualHTML(
-        '<p><em><img src="/assets/favicon.png"></em>',
+        '<p><em><img src="/assets/favicon.png"></em></p>',
       );
     });
 

--- a/test/unit/formats/table.js
+++ b/test/unit/formats/table.js
@@ -59,7 +59,7 @@ describe('Table', function() {
     const editor = this.initialize(Editor, '<p>Test</p>');
     editor.formatLine(0, 5, { table: 'a' });
     expect(this.container).toEqualHTML(
-      '<table><tr><td data-row="a">Test</td></tr></table>',
+      '<table><tbody><tr><td data-row="a">Test</td></tr></tbody></table>',
     );
   });
 
@@ -67,7 +67,7 @@ describe('Table', function() {
     const editor = this.initialize(Editor, '<h1>Test</h1>');
     editor.formatLine(0, 5, { table: 'a' });
     expect(this.container).toEqualHTML(
-      '<table><tr><td data-row="a">Test</td></tr></table>',
+      '<table><tbody><tr><td data-row="a">Test</td></tr></tbody></table>',
     );
   });
 


### PR DESCRIPTION
see https://github.com/quilljs/quill/issues/2241.

@jhchen this test now correctly fails.  This code change will be necessary to write a proper test for https://github.com/quilljs/quill/issues/2195

I chose to keep the same toEqualHTML matcher, but to run a basic string match on the html structure first before comparing the DOM through parsing.