### PR TITLE
Add normalizePasteData option to clipboard module

### DIFF
--- a/docs/docs/modules/clipboard.md
+++ b/docs/docs/modules/clipboard.md
@@ -78,3 +78,21 @@ var quill = new Quill('#editor', {
   }
 });
 ```
+
+### normalizePasteData
+
+A function allowing you to provide custom html normalization or sanitization of pasted text and/or html data.
+
+```javascript
+var quill = new Quill('#editor', {
+  modules: {
+    clipboard: {
+      normalizePasteData(clipboardData) {
+        const pastedHTML = clipboardData.get('text/html')
+        const normalizedHTMLString = myNormalizationFn(pastedHTML)
+        return normalizedHTMLString // or return null to fallback to default implementation
+      }
+    }
+  }
+}
+```

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -154,7 +154,7 @@ class Clipboard extends Module {
   }
 
   onPaste(e, range) {
-    const html = e.clipboardData.getData('text/html');
+    let html = e.clipboardData.getData('text/html');
     const text = e.clipboardData.getData('text/plain');
     const files = Array.from(e.clipboardData.files || []);
     if (!html && files.length > 0) {
@@ -162,6 +162,12 @@ class Clipboard extends Module {
       return;
     }
     const formats = this.quill.getFormat(range.index);
+    if (this.options.normalizePasteData) {
+      const normalized = this.options.normalizePasteData(e.clipboardData);
+      if (typeof normalized === 'string') {
+        html = normalized;
+      }
+    }
     const pastedDelta = this.convert({ text, html }, formats);
     debug.log('onPaste', pastedDelta, { text, html });
     const delta = new Delta()


### PR DESCRIPTION
https://github.com/quilljs/quill/issues/2246

Add normalizePasteData option to clipboard module to allow user to preprocess pasted html data.

This feature still needs to be discussed, but this is a simple implementation for a start.