### PR TITLE
Generate more accurate deltas from typing

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -204,8 +204,14 @@ class Editor {
       const oldText = new Delta().insert(oldValue);
       const newText = new Delta().insert(textBlot.value());
       const relativeSelectionInfo = selectionInfo && [
-        { index: selectionInfo[0].index - index, length: selectionInfo[0].length },
-        { index: selectionInfo[1].index - index, length: selectionInfo[1].length },
+        {
+          index: selectionInfo[0].index - index,
+          length: selectionInfo[0].length,
+        },
+        {
+          index: selectionInfo[1].index - index,
+          length: selectionInfo[1].length,
+        },
       ];
       const diffDelta = new Delta()
         .retain(index)
@@ -337,7 +343,6 @@ function splitDelta(delta, index) {
 }
 
 function diffDeltas(oldDelta, newDelta, selectionInfo = undefined) {
-
   if (selectionInfo) {
     // generate better diffs than Delta#diff by taking into account the
     // old and new selection.  for example, a text change from "xxx" to "xx"
@@ -357,30 +362,54 @@ function diffDeltas(oldDelta, newDelta, selectionInfo = undefined) {
         const [newPrefix, newMiddle] = splitDelta(newBefore, prefixLength);
         if (equal(oldPrefix, newPrefix)) {
           // insert or delete right before cursor
-          return new Delta().retain(prefixLength).concat(oldMiddle.diff(newMiddle));
+          return new Delta()
+            .retain(prefixLength)
+            .concat(oldMiddle.diff(newMiddle));
         }
       } else if (equal(oldBefore, newBefore)) {
-        const suffixLength = Math.min(oldDeltaLength - oldCursor, newDeltaLength - newCursor);
-        const [oldMiddle, oldSuffix] = splitDelta(oldAfter, oldDeltaLength - oldCursor - suffixLength);
-        const [newMiddle, newSuffix] = splitDelta(newAfter, newDeltaLength - newCursor - suffixLength);
+        const suffixLength = Math.min(
+          oldDeltaLength - oldCursor,
+          newDeltaLength - newCursor,
+        );
+        const [oldMiddle, oldSuffix] = splitDelta(
+          oldAfter,
+          oldDeltaLength - oldCursor - suffixLength,
+        );
+        const [newMiddle, newSuffix] = splitDelta(
+          newAfter,
+          newDeltaLength - newCursor - suffixLength,
+        );
         if (equal(oldSuffix, newSuffix)) {
           // insert or delete right after cursor
-          return new Delta().retain(oldCursor).concat(oldMiddle.diff(newMiddle));
+          return new Delta()
+            .retain(oldCursor)
+            .concat(oldMiddle.diff(newMiddle));
         }
       }
     } else if (oldSelection.length > 0 && newSelection.length === 0) {
       // see if diff could be a splice of the old selection range
       const oldPrefix = oldDelta.slice(0, oldSelection.index);
-      const oldSuffix = oldDelta.slice(oldSelection.index + oldSelection.length);
+      const oldSuffix = oldDelta.slice(
+        oldSelection.index + oldSelection.length,
+      );
       const prefixLength = oldPrefix.length();
       const suffixLength = oldSuffix.length();
       if (newDeltaLength >= prefixLength + suffixLength) {
         const newPrefix = newDelta.slice(0, prefixLength);
         const newSuffix = newDelta.slice(newDeltaLength - suffixLength);
         if (equal(oldPrefix, newPrefix) && equal(oldSuffix, newSuffix)) {
-          const oldMiddle = oldDelta.slice(prefixLength, oldDeltaLength - suffixLength);
-          const newMiddle = newDelta.slice(prefixLength, newDeltaLength - suffixLength);
-          return new Delta().retain(prefixLength).concat(newMiddle).delete(oldMiddle.length());
+          const oldMiddle = oldDelta.slice(
+            prefixLength,
+            oldDeltaLength - suffixLength,
+          );
+          const newMiddle = newDelta.slice(
+            prefixLength,
+            newDeltaLength - suffixLength,
+          );
+          return new Delta()
+            .retain(prefixLength)
+            .concat(newMiddle)
+            .delete(oldMiddle.length());
         }
       }
     }

--- a/core/editor.js
+++ b/core/editor.js
@@ -188,7 +188,7 @@ class Editor {
     return this.applyDelta(delta);
   }
 
-  update(change, mutations = [], cursorIndex = undefined) {
+  update(change, mutations = [], selectionInfo = undefined) {
     const oldDelta = this.delta;
     if (
       mutations.length === 1 &&
@@ -203,9 +203,13 @@ class Editor {
       const oldValue = mutations[0].oldValue.replace(CursorBlot.CONTENTS, '');
       const oldText = new Delta().insert(oldValue);
       const newText = new Delta().insert(textBlot.value());
+      const relativeSelectionInfo = selectionInfo && [
+        { index: selectionInfo[0].index - index, length: selectionInfo[0].length },
+        { index: selectionInfo[1].index - index, length: selectionInfo[1].length },
+      ];
       const diffDelta = new Delta()
         .retain(index)
-        .concat(oldText.diff(newText, cursorIndex));
+        .concat(diffDeltas(oldText, newText, relativeSelectionInfo));
       change = diffDelta.reduce((delta, op) => {
         if (op.insert) {
           return delta.insert(op.insert, formats);
@@ -216,7 +220,7 @@ class Editor {
     } else {
       this.delta = this.getDelta();
       if (!change || !equal(oldDelta.compose(change), this.delta)) {
-        change = oldDelta.diff(this.delta, cursorIndex);
+        change = diffDeltas(oldDelta, this.delta, selectionInfo);
       }
     }
     return change;
@@ -326,6 +330,63 @@ function normalizeDelta(delta) {
     }
     return normalizedDelta.push(op);
   }, new Delta());
+}
+
+function splitDelta(delta, index) {
+  return [delta.slice(0, index), delta.slice(index)];
+}
+
+function diffDeltas(oldDelta, newDelta, selectionInfo = undefined) {
+
+  if (selectionInfo) {
+    // generate better diffs than Delta#diff by taking into account the
+    // old and new selection.  for example, a text change from "xxx" to "xx"
+    // could be a delete or forwards-delete of any one of the x's, or the
+    // result of selecting two of the x's and typing "x".
+    const [oldSelection, newSelection] = selectionInfo;
+    const oldDeltaLength = oldDelta.length();
+    const newDeltaLength = newDelta.length();
+    if (oldSelection.length === 0 && newSelection.length === 0) {
+      const oldCursor = oldSelection.index;
+      const newCursor = newSelection.index;
+      const [oldBefore, oldAfter] = splitDelta(oldDelta, oldCursor);
+      const [newBefore, newAfter] = splitDelta(newDelta, newCursor);
+      if (equal(oldAfter, newAfter)) {
+        const prefixLength = Math.min(oldCursor, newCursor);
+        const [oldPrefix, oldMiddle] = splitDelta(oldBefore, prefixLength);
+        const [newPrefix, newMiddle] = splitDelta(newBefore, prefixLength);
+        if (equal(oldPrefix, newPrefix)) {
+          // insert or delete right before cursor
+          return new Delta().retain(prefixLength).concat(oldMiddle.diff(newMiddle));
+        }
+      } else if (equal(oldBefore, newBefore)) {
+        const suffixLength = Math.min(oldDeltaLength - oldCursor, newDeltaLength - newCursor);
+        const [oldMiddle, oldSuffix] = splitDelta(oldAfter, oldDeltaLength - oldCursor - suffixLength);
+        const [newMiddle, newSuffix] = splitDelta(newAfter, newDeltaLength - newCursor - suffixLength);
+        if (equal(oldSuffix, newSuffix)) {
+          // insert or delete right after cursor
+          return new Delta().retain(oldCursor).concat(oldMiddle.diff(newMiddle));
+        }
+      }
+    } else if (oldSelection.length > 0 && newSelection.length === 0) {
+      // see if diff could be a splice of the old selection range
+      const oldPrefix = oldDelta.slice(0, oldSelection.index);
+      const oldSuffix = oldDelta.slice(oldSelection.index + oldSelection.length);
+      const prefixLength = oldPrefix.length();
+      const suffixLength = oldSuffix.length();
+      if (newDeltaLength >= prefixLength + suffixLength) {
+        const newPrefix = newDelta.slice(0, prefixLength);
+        const newSuffix = newDelta.slice(newDeltaLength - suffixLength);
+        if (equal(oldPrefix, newPrefix) && equal(oldSuffix, newSuffix)) {
+          const oldMiddle = oldDelta.slice(prefixLength, oldDeltaLength - suffixLength);
+          const newMiddle = newDelta.slice(prefixLength, newDeltaLength - suffixLength);
+          return new Delta().retain(prefixLength).concat(newMiddle).delete(oldMiddle.length());
+        }
+      }
+    }
+  }
+
+  return oldDelta.diff(newDelta);
 }
 
 export default Editor;

--- a/core/editor.js
+++ b/core/editor.js
@@ -4,6 +4,7 @@ import extend from 'extend';
 import Delta from 'quill-delta';
 import DeltaOp from 'quill-delta/lib/op';
 import { LeafBlot } from 'parchment';
+import { Range } from './selection';
 import CursorBlot from '../blots/cursor';
 import Block, { bubbleFormats } from '../blots/block';
 import Break from '../blots/break';
@@ -204,14 +205,8 @@ class Editor {
       const oldText = new Delta().insert(oldValue);
       const newText = new Delta().insert(textBlot.value());
       const relativeSelectionInfo = selectionInfo && [
-        {
-          index: selectionInfo[0].index - index,
-          length: selectionInfo[0].length,
-        },
-        {
-          index: selectionInfo[1].index - index,
-          length: selectionInfo[1].length,
-        },
+        new Range(selectionInfo[0].index - index, selectionInfo[0].length),
+        new Range(selectionInfo[1].index - index, selectionInfo[1].length),
       ];
       const diffDelta = new Delta()
         .retain(index)
@@ -343,74 +338,74 @@ function splitDelta(delta, index) {
 }
 
 function diffDeltas(oldDelta, newDelta, selectionInfo = undefined) {
-  if (selectionInfo) {
-    // generate better diffs than Delta#diff by taking into account the
-    // old and new selection.  for example, a text change from "xxx" to "xx"
-    // could be a delete or forwards-delete of any one of the x's, or the
-    // result of selecting two of the x's and typing "x".
-    const [oldSelection, newSelection] = selectionInfo;
-    const oldDeltaLength = oldDelta.length();
-    const newDeltaLength = newDelta.length();
-    if (oldSelection.length === 0 && newSelection.length === 0) {
-      const oldCursor = oldSelection.index;
-      const newCursor = newSelection.index;
-      const [oldBefore, oldAfter] = splitDelta(oldDelta, oldCursor);
-      const [newBefore, newAfter] = splitDelta(newDelta, newCursor);
-      if (equal(oldAfter, newAfter)) {
-        const prefixLength = Math.min(oldCursor, newCursor);
-        const [oldPrefix, oldMiddle] = splitDelta(oldBefore, prefixLength);
-        const [newPrefix, newMiddle] = splitDelta(newBefore, prefixLength);
-        if (equal(oldPrefix, newPrefix)) {
-          // insert or delete right before cursor
-          return new Delta()
-            .retain(prefixLength)
-            .concat(oldMiddle.diff(newMiddle));
-        }
-      } else if (equal(oldBefore, newBefore)) {
-        const suffixLength = Math.min(
-          oldDeltaLength - oldCursor,
-          newDeltaLength - newCursor,
-        );
-        const [oldMiddle, oldSuffix] = splitDelta(
-          oldAfter,
-          oldDeltaLength - oldCursor - suffixLength,
-        );
-        const [newMiddle, newSuffix] = splitDelta(
-          newAfter,
-          newDeltaLength - newCursor - suffixLength,
-        );
-        if (equal(oldSuffix, newSuffix)) {
-          // insert or delete right after cursor
-          return new Delta()
-            .retain(oldCursor)
-            .concat(oldMiddle.diff(newMiddle));
-        }
+  if (selectionInfo == null) {
+    return oldDelta.diff(newDelta);
+  }
+
+  // generate better diffs than Delta#diff by taking into account the
+  // old and new selection.  for example, a text change from "xxx" to "xx"
+  // could be a delete or forwards-delete of any one of the x's, or the
+  // result of selecting two of the x's and typing "x".
+  const [oldSelection, newSelection] = selectionInfo;
+  const oldDeltaLength = oldDelta.length();
+  const newDeltaLength = newDelta.length();
+  if (oldSelection.length === 0 && newSelection.length === 0) {
+    // see if we have an insert or delete before or after cursor
+    const oldCursor = oldSelection.index;
+    const newCursor = newSelection.index;
+    const [oldBefore, oldAfter] = splitDelta(oldDelta, oldCursor);
+    const [newBefore, newAfter] = splitDelta(newDelta, newCursor);
+    if (equal(oldAfter, newAfter)) {
+      const prefixLength = Math.min(oldCursor, newCursor);
+      const [oldPrefix, oldMiddle] = splitDelta(oldBefore, prefixLength);
+      const [newPrefix, newMiddle] = splitDelta(newBefore, prefixLength);
+      if (equal(oldPrefix, newPrefix)) {
+        // insert or delete right before cursor
+        return new Delta()
+          .retain(prefixLength)
+          .concat(oldMiddle.diff(newMiddle));
       }
-    } else if (oldSelection.length > 0 && newSelection.length === 0) {
-      // see if diff could be a splice of the old selection range
-      const oldPrefix = oldDelta.slice(0, oldSelection.index);
-      const oldSuffix = oldDelta.slice(
-        oldSelection.index + oldSelection.length,
+    } else if (equal(oldBefore, newBefore)) {
+      const suffixLength = Math.min(
+        oldDeltaLength - oldCursor,
+        newDeltaLength - newCursor,
       );
-      const prefixLength = oldPrefix.length();
-      const suffixLength = oldSuffix.length();
-      if (newDeltaLength >= prefixLength + suffixLength) {
-        const newPrefix = newDelta.slice(0, prefixLength);
-        const newSuffix = newDelta.slice(newDeltaLength - suffixLength);
-        if (equal(oldPrefix, newPrefix) && equal(oldSuffix, newSuffix)) {
-          const oldMiddle = oldDelta.slice(
-            prefixLength,
-            oldDeltaLength - suffixLength,
-          );
-          const newMiddle = newDelta.slice(
-            prefixLength,
-            newDeltaLength - suffixLength,
-          );
-          return new Delta()
-            .retain(prefixLength)
-            .concat(newMiddle)
-            .delete(oldMiddle.length());
-        }
+      const [oldMiddle, oldSuffix] = splitDelta(
+        oldAfter,
+        oldDeltaLength - oldCursor - suffixLength,
+      );
+      const [newMiddle, newSuffix] = splitDelta(
+        newAfter,
+        newDeltaLength - newCursor - suffixLength,
+      );
+      if (equal(oldSuffix, newSuffix)) {
+        // insert or delete right after cursor
+        return new Delta().retain(oldCursor).concat(oldMiddle.diff(newMiddle));
+      }
+    }
+  }
+  if (oldSelection.length > 0 && newSelection.length === 0) {
+    // see if diff could be a splice of the old selection range
+    const oldPrefix = oldDelta.slice(0, oldSelection.index);
+    const oldSuffix = oldDelta.slice(oldSelection.index + oldSelection.length);
+    const prefixLength = oldPrefix.length();
+    const suffixLength = oldSuffix.length();
+    if (newDeltaLength >= prefixLength + suffixLength) {
+      const newPrefix = newDelta.slice(0, prefixLength);
+      const newSuffix = newDelta.slice(newDeltaLength - suffixLength);
+      if (equal(oldPrefix, newPrefix) && equal(oldSuffix, newSuffix)) {
+        const oldMiddle = oldDelta.slice(
+          prefixLength,
+          oldDeltaLength - suffixLength,
+        );
+        const newMiddle = newDelta.slice(
+          prefixLength,
+          newDeltaLength - suffixLength,
+        );
+        return new Delta()
+          .retain(prefixLength)
+          .concat(newMiddle)
+          .delete(oldMiddle.length());
       }
     }
   }

--- a/core/quill.js
+++ b/core/quill.js
@@ -104,7 +104,8 @@ class Quill {
     this.emitter.on(Emitter.events.SCROLL_UPDATE, (source, mutations) => {
       const oldRange = this.selection.lastRange;
       const [newRange] = this.selection.getRange();
-      const selectionInfo = (oldRange && newRange) ? [oldRange, newRange] : undefined;
+      const selectionInfo =
+        oldRange && newRange ? [oldRange, newRange] : undefined;
       modify.call(
         this,
         () => this.editor.update(null, mutations, selectionInfo),

--- a/core/quill.js
+++ b/core/quill.js
@@ -102,11 +102,12 @@ class Quill {
       }
     });
     this.emitter.on(Emitter.events.SCROLL_UPDATE, (source, mutations) => {
-      const range = this.selection.lastRange;
-      const index = range && range.length === 0 ? range.index : undefined;
+      const oldRange = this.selection.lastRange;
+      const [newRange] = this.selection.getRange();
+      const selectionInfo = (oldRange && newRange) ? [oldRange, newRange] : undefined;
       modify.call(
         this,
-        () => this.editor.update(null, mutations, index),
+        () => this.editor.update(null, mutations, selectionInfo),
         source,
       );
     });

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -234,9 +234,15 @@ describe('Quill', function() {
       }, 1);
     });
 
-    function editTest(oldText, oldSelection, newText, newSelection, expectedDelta) {
+    function editTest(
+      oldText,
+      oldSelection,
+      newText,
+      newSelection,
+      expectedDelta,
+    ) {
       return function(done) {
-        this.quill.setText(oldText + '\n');
+        this.quill.setText(`${oldText}\n`);
         this.quill.setSelection(oldSelection); // number or {index, length}
         this.quill.update();
         const oldContents = this.quill.getContents();
@@ -246,12 +252,17 @@ describe('Quill', function() {
           this.quill.selection.setNativeRange(textNode, newSelection);
         } else {
           this.quill.selection.setNativeRange(
-            textNode, newSelection.index,
-            textNode, newSelection.index + newSelection.length);
+            textNode,
+            newSelection.index,
+            textNode,
+            newSelection.index + newSelection.length,
+          );
         }
         setTimeout(() => {
           const calls = this.quill.emitter.emit.calls.all();
-          if (calls[calls.length - 1].args[1] === Emitter.events.SELECTION_CHANGE) {
+          if (
+            calls[calls.length - 1].args[1] === Emitter.events.SELECTION_CHANGE
+          ) {
             calls.pop();
           }
           const { args } = calls.pop();
@@ -263,39 +274,83 @@ describe('Quill', function() {
           ]);
           done();
         }, 1);
-      }
+      };
     }
 
     describe('insert a in aaaa', function() {
-      it('at index 0', editTest('aaaa', 0, 'aaaaa', 1, new Delta().insert('a')));
-      it('at index 1', editTest('aaaa', 1, 'aaaaa', 2, new Delta().retain(1).insert('a')));
-      it('at index 2', editTest('aaaa', 2, 'aaaaa', 3, new Delta().retain(2).insert('a')));
-      it('at index 3', editTest('aaaa', 3, 'aaaaa', 4, new Delta().retain(3).insert('a')));
+      it(
+        'at index 0',
+        editTest('aaaa', 0, 'aaaaa', 1, new Delta().insert('a')),
+      );
+      it(
+        'at index 1',
+        editTest('aaaa', 1, 'aaaaa', 2, new Delta().retain(1).insert('a')),
+      );
+      it(
+        'at index 2',
+        editTest('aaaa', 2, 'aaaaa', 3, new Delta().retain(2).insert('a')),
+      );
+      it(
+        'at index 3',
+        editTest('aaaa', 3, 'aaaaa', 4, new Delta().retain(3).insert('a')),
+      );
     });
 
     describe('insert a in xaa', function() {
-      it('at index 1', editTest('xaa', 1, 'xaaa', 2, new Delta().retain(1).insert('a')));
-      it('at index 2', editTest('xaa', 2, 'xaaa', 3, new Delta().retain(2).insert('a')));
-      it('at index 3', editTest('xaa', 3, 'xaaa', 4, new Delta().retain(3).insert('a')));
+      it(
+        'at index 1',
+        editTest('xaa', 1, 'xaaa', 2, new Delta().retain(1).insert('a')),
+      );
+      it(
+        'at index 2',
+        editTest('xaa', 2, 'xaaa', 3, new Delta().retain(2).insert('a')),
+      );
+      it(
+        'at index 3',
+        editTest('xaa', 3, 'xaaa', 4, new Delta().retain(3).insert('a')),
+      );
     });
 
     describe('insert aa in ax', function() {
       it('at index 0', editTest('ax', 0, 'aaax', 2, new Delta().insert('aa')));
-      it('at index 1', editTest('ax', 1, 'aaax', 3, new Delta().retain(1).insert('aa')));
+      it(
+        'at index 1',
+        editTest('ax', 1, 'aaax', 3, new Delta().retain(1).insert('aa')),
+      );
     });
 
     describe('delete a in xaa', function() {
-      it('at index 1', editTest('xaa', 2, 'xa', 1, new Delta().retain(1).delete(1)));
-      it('at index 2', editTest('xaa', 3, 'xa', 2, new Delta().retain(2).delete(1)));
+      it(
+        'at index 1',
+        editTest('xaa', 2, 'xa', 1, new Delta().retain(1).delete(1)),
+      );
+      it(
+        'at index 2',
+        editTest('xaa', 3, 'xa', 2, new Delta().retain(2).delete(1)),
+      );
     });
 
     describe('forward-delete a in xaa', function() {
-      it('at index 1', editTest('xaa', 1, 'xa', 1, new Delta().retain(1).delete(1)));
-      it('at index 2', editTest('xaa', 2, 'xa', 2, new Delta().retain(2).delete(1)));
+      it(
+        'at index 1',
+        editTest('xaa', 1, 'xa', 1, new Delta().retain(1).delete(1)),
+      );
+      it(
+        'at index 2',
+        editTest('xaa', 2, 'xa', 2, new Delta().retain(2).delete(1)),
+      );
     });
 
-    it('replace yay with y',
-      editTest('yay', { index: 0, length: 3 }, 'y', 1, new Delta().insert('y').delete(3)));
+    it(
+      'replace yay with y',
+      editTest(
+        'yay',
+        { index: 0, length: 3 },
+        'y',
+        1,
+        new Delta().insert('y').delete(3),
+      ),
+    );
   });
 
   describe('setContents()', function() {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -234,28 +234,68 @@ describe('Quill', function() {
       }, 1);
     });
 
-    it('insert same character', function(done) {
-      this.quill.setText('aaaa\n');
-      this.quill.setSelection(2);
-      this.quill.update();
-      const old = this.quill.getContents();
-      const textNode = this.container.firstChild.firstChild.firstChild;
-      textNode.data = 'aaaaa';
-      this.quill.selection.setNativeRange(textNode.data, 3);
-      const delta = new Delta().retain(2).insert('a');
-      setTimeout(() => {
-        const calls = this.quill.emitter.emit.calls.all();
-        calls.pop();
-        const { args } = calls.pop();
-        expect(args).toEqual([
-          Emitter.events.TEXT_CHANGE,
-          delta,
-          old,
-          Emitter.sources.USER,
-        ]);
-        done();
-      }, 1);
+    function editTest(oldText, oldSelection, newText, newSelection, expectedDelta) {
+      return function(done) {
+        this.quill.setText(oldText + '\n');
+        this.quill.setSelection(oldSelection); // number or {index, length}
+        this.quill.update();
+        const oldContents = this.quill.getContents();
+        const textNode = this.container.firstChild.firstChild.firstChild;
+        textNode.data = newText;
+        if (typeof newSelection === 'number') {
+          this.quill.selection.setNativeRange(textNode, newSelection);
+        } else {
+          this.quill.selection.setNativeRange(
+            textNode, newSelection.index,
+            textNode, newSelection.index + newSelection.length);
+        }
+        setTimeout(() => {
+          const calls = this.quill.emitter.emit.calls.all();
+          if (calls[calls.length - 1].args[1] === Emitter.events.SELECTION_CHANGE) {
+            calls.pop();
+          }
+          const { args } = calls.pop();
+          expect(args).toEqual([
+            Emitter.events.TEXT_CHANGE,
+            expectedDelta,
+            oldContents,
+            Emitter.sources.USER,
+          ]);
+          done();
+        }, 1);
+      }
+    }
+
+    describe('insert a in aaaa', function() {
+      it('at index 0', editTest('aaaa', 0, 'aaaaa', 1, new Delta().insert('a')));
+      it('at index 1', editTest('aaaa', 1, 'aaaaa', 2, new Delta().retain(1).insert('a')));
+      it('at index 2', editTest('aaaa', 2, 'aaaaa', 3, new Delta().retain(2).insert('a')));
+      it('at index 3', editTest('aaaa', 3, 'aaaaa', 4, new Delta().retain(3).insert('a')));
     });
+
+    describe('insert a in xaa', function() {
+      it('at index 1', editTest('xaa', 1, 'xaaa', 2, new Delta().retain(1).insert('a')));
+      it('at index 2', editTest('xaa', 2, 'xaaa', 3, new Delta().retain(2).insert('a')));
+      it('at index 3', editTest('xaa', 3, 'xaaa', 4, new Delta().retain(3).insert('a')));
+    });
+
+    describe('insert aa in ax', function() {
+      it('at index 0', editTest('ax', 0, 'aaax', 2, new Delta().insert('aa')));
+      it('at index 1', editTest('ax', 1, 'aaax', 3, new Delta().retain(1).insert('aa')));
+    });
+
+    describe('delete a in xaa', function() {
+      it('at index 1', editTest('xaa', 2, 'xa', 1, new Delta().retain(1).delete(1)));
+      it('at index 2', editTest('xaa', 3, 'xa', 2, new Delta().retain(2).delete(1)));
+    });
+
+    describe('forward-delete a in xaa', function() {
+      it('at index 1', editTest('xaa', 1, 'xa', 1, new Delta().retain(1).delete(1)));
+      it('at index 2', editTest('xaa', 2, 'xa', 2, new Delta().retain(2).delete(1)));
+    });
+
+    it('replace yay with y',
+      editTest('yay', { index: 0, length: 3 }, 'y', 1, new Delta().insert('y').delete(3)));
   });
 
   describe('setContents()', function() {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -243,7 +243,7 @@ describe('Quill', function() {
     ) {
       return function(done) {
         this.quill.setText(`${oldText}\n`);
-        this.quill.setSelection(oldSelection); // number or {index, length}
+        this.quill.setSelection(oldSelection); // number or Range
         this.quill.update();
         const oldContents = this.quill.getContents();
         const textNode = this.container.firstChild.firstChild.firstChild;
@@ -345,7 +345,7 @@ describe('Quill', function() {
       'replace yay with y',
       editTest(
         'yay',
-        { index: 0, length: 3 },
+        new Range(0, 3),
         'y',
         1,
         new Delta().insert('y').delete(3),


### PR DESCRIPTION
This PR fixes issue #746 for real this time, adds tests, and also handles a wider variety of cases.  Fast-diff's cursor-position hint is no longer used; instead, the editor looks at both the old and new selection (cursor or range) to determine the best delta to represent the change.

There are many examples of ambiguous diffs that can only be disambiguated using selection information.  For example, the minimal insertion in `aaa` to `aaaa` could be at index 0, 1, 2, or 3.  The same is true for the two-character insertion in `bob` to `bobob`, or the single-character deletion in `aaaa` to `aaa`.  Because of backwards deletion (control-D or fn-delete on a Mac), both the old and new cursor are needed to get the delta right.  In order to handle the case where `foo` is selected and the letter `f` is typed (as distinct from deleting `oo`), the full selection range for the old selection is required.

There were a few issues with the previous implementation:
* The cursor position passed to fast-diff was not correctly calculated for the mutation fast path (so typing on the first line of the document might work but typing on the second line wouldn't)
* Fast-diff did not correctly take the cursor position into account for some outputs of the diff optimizer, sometimes as simple as deleting and re-inserting the middle character in strings like `aab` or `abb`.  An extra character before or after the repeated character causes the diff optimizer to bias towards a different repeated character.  This proved hard to fix in fast-diff.
* Only the old cursor position was taken into account, not the new position or old selection range

This new solution is implemented at the editor level rather than the diff level, because it's not clear what taking a cursor location into account for an arbitrary diff ultimately means; a lot of edge cases come up that probably aren't of any practical importance in Quill, but it's hard to be certain of, and capture, this fact.

For Slab, there will be a direct benefit for displaying remote collaborator cursors and selections more accurately.  For example, if selecting `foo` and typing `f` is considered to be a deletion of `oo`, it will look to collaborators afterwards as if you have selected the `f`.  In other cases, collaborator cursors will be shown in a slightly wrong location after typing.  Author attributes will also be more accurate.