### PR TITLE
Prevent code-token attribute in deltas

### DIFF
--- a/blots/block.js
+++ b/blots/block.js
@@ -178,12 +178,15 @@ function blockDelta(blot) {
 
 function bubbleFormats(blot, formats = {}) {
   if (blot == null) return formats;
-  if (typeof blot.formats === 'function') {
+  if (
+    typeof blot.formats === 'function' &&
+    blot.statics.blotName !== 'code-token'
+  ) {
     formats = extend(formats, blot.formats());
   }
   if (
     blot.parent == null ||
-    blot.parent.blotName === 'scroll' ||
+    blot.parent.statics.blotName === 'scroll' ||
     blot.parent.statics.scope !== blot.statics.scope
   ) {
     return formats;

--- a/blots/block.js
+++ b/blots/block.js
@@ -178,11 +178,10 @@ function blockDelta(blot) {
 
 function bubbleFormats(blot, formats = {}) {
   if (blot == null) return formats;
-  if (
-    typeof blot.formats === 'function' &&
-    blot.statics.blotName !== 'code-token'
-  ) {
+  if (typeof blot.formats === 'function') {
     formats = extend(formats, blot.formats());
+    // exclude syntax highlighting from deltas and getFormat()
+    delete formats['code-token'];
   }
   if (
     blot.parent == null ||

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -65,18 +65,6 @@ class SyntaxCodeBlock extends CodeBlock {
 
   static register() {} // Syntax module will register
 
-  delta() {
-    if (this.cache.delta == null) {
-      const delta = super.delta();
-      this.cache.delta = delta.compose(
-        new Delta().retain(delta.length(), {
-          [CodeToken.blotName]: null,
-        }),
-      );
-    }
-    return this.cache.delta;
-  }
-
   format(name, value) {
     if (name === this.statics.blotName && value) {
       this.domNode.setAttribute('data-language', value);


### PR DESCRIPTION
Fixes #2178.

While it feels a bit odd to make a function called `bubbleFormats` always exclude a particular format from its result, this function could really be called something like `collectFormatsForDelta`; it is only called to get the formats for a delta (or the public Quill API, `quill.getFormat()`).

It follows (I believe) that SyntaxCodeBlock no longer needs a custom `delta()` method.