### PR TITLE
Emit single change when typing enter on empty list line

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -260,10 +260,16 @@ Keyboard.DEFAULTS = {
       format: ['list'],
       empty: true,
       handler(range, context) {
-        this.quill.format('list', false, Quill.sources.USER);
+        const formats = { list: false };
         if (context.format.indent) {
-          this.quill.format('indent', false, Quill.sources.USER);
+          formats.indent = false;
         }
+        this.quill.formatLine(
+          range.index,
+          range.length,
+          formats,
+          Quill.sources.USER,
+        );
       },
     },
     'checklist enter': {


### PR DESCRIPTION
When typing enter on an empty list line, it removes the list formatting and the indent (if there is one). This PR updates the behavior to emit a single change that removes both the list and indent formats rather than two distinct changes.