### PR TITLE
Test style.fontWeight before using it

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -443,8 +443,9 @@ function matchStyles(node, delta) {
     formats.italic = true;
   }
   if (
-    style.fontWeight.startsWith('bold') ||
-    parseInt(style.fontWeight, 10) >= 700
+    style.fontWeight &&
+    (style.fontWeight.startsWith('bold') ||
+      parseInt(style.fontWeight, 10) >= 700)
   ) {
     formats.bold = true;
   }


### PR DESCRIPTION
The code in clipboard.js matchStyles() provides the possibility of creating a "style" object that has no fontWeight property but it uses the fontWeight.startsWith() method without previously testing for its existence .
Using clipboard.dangerouslyPasteHTML() to manipulate the content of the editor with values as added by the kaTeX input fails for this reason when it processes elements like: 
`<mn>1</mn>`
