### PR TITLE
Keyboard addBinding prepend

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -77,7 +77,7 @@ class Keyboard extends Module {
     this.listen();
   }
 
-  addBinding(keyBinding, context = {}, handler = {}) {
+  addBinding(keyBinding, context = {}, handler = {}, prepend = false) {
     const binding = normalize(keyBinding);
     if (binding == null) {
       debug.warn('Attempted to add invalid keyboard binding', binding);
@@ -93,7 +93,11 @@ class Keyboard extends Module {
     keys.forEach(key => {
       const singleBinding = extend({}, binding, { key }, context, handler);
       this.bindings[singleBinding.key] = this.bindings[singleBinding.key] || [];
-      this.bindings[singleBinding.key].push(singleBinding);
+      if (prepend) {
+        this.bindings[singleBinding.key].unshift(singleBinding);
+      } else {
+        this.bindings[singleBinding.key].push(singleBinding);
+      }
     });
   }
 


### PR DESCRIPTION
Enables adding keyboard bindings after init by adding support for prepending keyboard bindings.

This makes it possible to make use of enter, tab etc in custom modules without requiring client configuration options and resolves #1967 for example