### PR TITLE
Skip updatting editor when composing charcter

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -106,6 +106,7 @@ class Quill {
       const [newRange] = this.selection.getRange();
       const selectionInfo =
         oldRange && newRange ? [oldRange, newRange] : undefined;
+      if (this.selection.composing) return;
       modify.call(
         this,
         () => this.editor.update(null, mutations, selectionInfo),

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -99,6 +99,7 @@ class Keyboard extends Module {
   listen() {
     this.quill.root.addEventListener('keydown', evt => {
       if (evt.defaultPrevented) return;
+      if (this.quill.selection.composing) return;
       const bindings = (this.bindings[evt.key] || []).concat(
         this.bindings[evt.which] || [],
       );


### PR DESCRIPTION
This PR solves this issue. https://github.com/quilljs/quill/issues/2323

The problem happens when compositionstart event is triggered, and [getDelta() in this line](https://github.com/quilljs/quill/blob/c44241b65484c19cefb5e690cfc29e4019197f94/core/editor.js#L225) returns delta including characters which are now compositing, not current whole line. For example, when user types `pokemon` and then types `マ`, this character is composed by typing `m` + `a` with Japanese input, `getDelta()` function returns delta including only `マ`, not `pokemonマ`.

This PR is not a fundamental solution, but I think it's fine because it seems that this problem is caused by browser implementation and hard to fix it.