### PR TITLE
Fix Cursor blot restoration and selection preservation

### DIFF
--- a/blots/cursor.js
+++ b/blots/cursor.js
@@ -83,25 +83,42 @@ class Cursor extends EmbedBlot {
         this.domNode,
       );
     }
-    const { parentNode } = this.domNode;
     if (this.textNode.data !== Cursor.CONTENTS) {
       const text = this.textNode.data.split(Cursor.CONTENTS).join('');
-      if (this.next instanceof TextBlot) {
-        restoreText = this.next.domNode;
-        this.next.insertAt(0, text);
-        this.textNode.data = Cursor.CONTENTS;
+      // Take text out of the cursor blot and add it to parchment and the DOM
+      // before removing the cursor blot (which will be reused in the future).
+      // Selection preservation note:  After we return the selection range we
+      // want from this function, and before it is applied, TextBlots are
+      // optimized, with any TextBlot that follows another TextBlot being
+      // removed and its contents inserted into the previous one, and same with
+      // the underlying text nodes.  Therefore, restoreText should not be a text
+      // node that will be optimized away.  Another consideration here is that
+      // we don't want the optimization in editor.update to run, because it
+      // won't be able to figure out this change based on looking at the value
+      // of the mutated text node. Therefore, we don't insert this.textNode into
+      // the document, we keep it in the blot which is removed.
+      if (this.prev instanceof TextBlot) {
+        this.prev.insertAt(this.prev.length(), text);
+        if (restoreText) {
+          restoreText = this.prev.domNode;
+          start += this.prev.length();
+          end += this.prev.length();
+        }
       } else {
-        this.textNode.data = text;
-        this.parent.insertBefore(this.scroll.create(this.textNode), this);
-        this.textNode = document.createTextNode(Cursor.CONTENTS);
-        this.domNode.appendChild(this.textNode);
+        const newTextNode = document.createTextNode(text);
+        this.parent.insertBefore(this.scroll.create(newTextNode), this);
+        if (restoreText) {
+          restoreText = newTextNode;
+          start -= 1;
+          end -= 1;
+        }
       }
+      this.textNode.data = Cursor.CONTENTS;
     }
     this.remove();
-    parentNode.normalize();
-    if (start != null) {
+    if (restoreText) {
       [start, end] = [start, end].map(offset => {
-        return Math.max(0, Math.min(restoreText.data.length, offset - 1));
+        return Math.max(0, Math.min(restoreText.data.length, offset));
       });
       return {
         startNode: restoreText,

--- a/core/selection.js
+++ b/core/selection.js
@@ -380,7 +380,15 @@ class Selection {
         nativeRange.native.collapsed &&
         nativeRange.start.node !== this.cursor.textNode
       ) {
-        this.cursor.restore();
+        const range = this.cursor.restore();
+        if (range) {
+          this.setNativeRange(
+            range.startNode,
+            range.startOffset,
+            range.endNode,
+            range.endOffset,
+          );
+        }
       }
       const args = [
         Emitter.events.SELECTION_CHANGE,

--- a/test/functional/epic.js
+++ b/test/functional/epic.js
@@ -224,8 +224,35 @@ describe('quill', function() {
     await page.type('.ql-editor', 'B');
     html = await page.$$eval('.ql-editor p', paras => paras[2].innerHTML);
     expect(html).toBe('ABA');
+    await page.keyboard.down(SHORTKEY);
+    await page.keyboard.press('b');
+    await page.keyboard.up(SHORTKEY);
+    await page.type('.ql-editor', 'C');
+    await page.keyboard.down(SHORTKEY);
+    await page.keyboard.press('b');
+    await page.keyboard.up(SHORTKEY);
+    await page.type('.ql-editor', 'D');
+    html = await page.$$eval('.ql-editor p', paras => paras[2].innerHTML);
+    expect(html).toBe('AB<strong>C</strong>DA');
+    const selection = await page.evaluate(getSelectionInTextNode);
+    expect(selection).toBe('["DA",1,"DA",1]');
 
     // await page.waitFor(1000000);
     await browser.close();
   });
 });
+
+function getSelectionInTextNode() {
+  const {
+    anchorNode,
+    anchorOffset,
+    focusNode,
+    focusOffset,
+  } = document.getSelection();
+  return JSON.stringify([
+    anchorNode.data,
+    anchorOffset,
+    focusNode.data,
+    focusOffset,
+  ]);
+}

--- a/test/functional/epic.js
+++ b/test/functional/epic.js
@@ -210,6 +210,21 @@ describe('quill', function() {
     const header = await page.$('.ql-toolbar .ql-header.ql-active[value="1"]');
     expect(header).not.toBe(null);
 
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('Enter');
+    await page.keyboard.press('ArrowUp');
+    await page.type('.ql-editor', 'AA');
+    await page.keyboard.press('ArrowLeft');
+    await page.keyboard.down(SHORTKEY);
+    await page.keyboard.press('b');
+    await page.keyboard.press('b');
+    await page.keyboard.up(SHORTKEY);
+    await page.type('.ql-editor', 'B');
+    html = await page.$$eval('.ql-editor p', paras => paras[2].innerHTML);
+    expect(html).toBe('ABA');
+
     // await page.waitFor(1000000);
     await browser.close();
   });


### PR DESCRIPTION
This PR refixes issue #1019 and de0d564c7e69ee2e1cc3831d6b94ae1fbe8d2e5b.

Repros for bugs addressed:
1. The repro in #1019
2. Type `aa`, click between the two A's, then do command-B, command-B, then type `b`.  You should get a plain `aba` with the cursor after the `b`.  Added a functional test for this.
3.  Type `aa`, click between the two A's, then do command-B, type `b`, command-B, type `c`.  You should get `abca` with a bold `b`.  Added a functional test for a case similar to this.
4.  Type a string of text (e.g. `asdfasdf`), click in the middle of it, then do command-B, command-B, and then click somewhere else in the text, before or after the first position.  The text cursor should stay where you planted it (instead of e.g. jumping to the end of the line).  This is equivalent to the unit test that was failing.

Basically, to be correct, `cursor.restore` has to take a number of things into account:
* It returns a new native selection range to apply, but before this range is applied, TextBlot optimization happens, so the returned range should not reference any text nodes that will be removed by this optimization.
* The cause of the `cursor.restore` may be a selection change from the user clicking in a different text node, such as that of an adjacent TextBlot, which may be optimized away.  Therefore, selection preservation must operate even if the selection isn't in the Cursor blot's own textNode.  This is the subject of repro 4 above.  In this case, I also had to make sure that the return value of `cursor.restore` is always used by the caller!
* The fix to #1019 partly accounted for the optimization hack in `editor.update`, but for full correctness there mustn't be any case of `cursor.restore` that uses the Cursor blot's own textNode, mutated by the user, as part of the document (outside of the Cursor blot which is removed), because then the "hack path" in `editor.update` will think it has a green light and try to generate a delta based on the current value of the text node, which is not going to come out properly.

The solution is for `cursor.restore` to optimize the surrounding text nodes on the spot and calculate an appropriate selection range if the old selection is anywhere in those text nodes.