### PR TITLE
add blob to white-listed protocols

### DIFF
--- a/formats/link.js
+++ b/formats/link.js
@@ -27,7 +27,7 @@ class Link extends Inline {
 Link.blotName = 'link';
 Link.tagName = 'A';
 Link.SANITIZED_URL = 'about:blank';
-Link.PROTOCOL_WHITELIST = ['http', 'https', 'mailto', 'tel'];
+Link.PROTOCOL_WHITELIST = ['http', 'https', 'mailto', 'tel', 'blob'];
 
 function sanitize(url, protocols) {
   const anchor = document.createElement('a');


### PR DESCRIPTION
I'm proposing to add `blob` to the list of white-listed protocols.

I'm using quill from a blob resource and trying to insert a link like `<a href="#paragraphId" />`, but it gets sanitized and replaced by `about:blank`.

I'm not sure why urls need to be sanitized in the first place, I suppose there are some security related issues behind it. Is it to prevent javascript injection?

Example of a blob url: `blob:http://localhost:3000/9a0af3b5-3aea-4b24-b138-8ad9a08033b7`. I think the current implementation would work by only adding the `blob` to the white-list.