### PR TITLE
Homepage: Fix links to documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@ redirect_from: /latest/
         <div class="details">
           <h2>Built for Developers</h2>
           <span>Granular access to the editor's content, changes and events through a simple API. Works consistently and deterministically with JSON as both input and output.</span>
-          <a class="action-link" href="/docs/">View documentation</a>
+          <a class="action-link" href="/docs">View documentation</a>
         </div>
       </div>
       <div class="feature columns">
@@ -183,7 +183,7 @@ redirect_from: /latest/
       <div class="columns details">
         <h2>Fits Like a Glove</h2>
         <span>Used in small projects and giant Fortune 500s alike. Start simple with the Quill core then easily customize or add your own extensions later if your product needs grow.</span>
-        <a class="action-link" href="/docs/">Learn More</a>
+        <a class="action-link" href="/docs">Learn More</a>
       </div>
       <div class="columns">
         {% include svg/features/scale.svg %}


### PR DESCRIPTION
Remove trailing slash from links to documentation, i.e. `/docs/` becomes `/docs`.
When [`/docs/`](https://quilljs.com/docs/) is used, it leads to a "Not Found" page.
When [`/docs`](https://quilljs.com/docs) is used, it correctly redirects to the Quickstart page.