### PR TITLE
Fix the transforms in undo/redo

### DIFF
--- a/test/unit/modules/history.js
+++ b/test/unit/modules/history.js
@@ -214,5 +214,23 @@ describe('History', function() {
       this.quill.history.redo();
       expect(this.quill.getText()).toEqual('abcd\n');
     });
+
+    it('correctly transform against remote changes', function() {
+      this.quill.history.options.delay = 0;
+      this.quill.history.options.userOnly = true;
+      this.quill.setText('b\n');
+      this.quill.insertText(1, 'd', Quill.sources.USER);
+      this.quill.insertText(0, 'a', Quill.sources.USER);
+      this.quill.insertText(2, 'c', Quill.sources.API);
+      expect(this.quill.getText()).toEqual('abcd\n');
+      this.quill.history.undo();
+      expect(this.quill.getText()).toEqual('bcd\n');
+      this.quill.history.undo();
+      expect(this.quill.getText()).toEqual('bc\n');
+      this.quill.history.redo();
+      expect(this.quill.getText()).toEqual('bcd\n');
+      this.quill.history.redo();
+      expect(this.quill.getText()).toEqual('abcd\n');
+    });
   });
 });


### PR DESCRIPTION
fixes #2105 

Added test that fails with previous implementation. Initially in the issue I added a simple way to fix the transforms - however this is not sufficient to fix things. The undo of an undo needs to be calculated when it is applied - you can't just save the initial operation as a redo and transform. This is because position information is lost when a delete is made and you apply transforms. So instead undos and redos are passed through the normal record (this is so the state is available for calculating diffs)