### PR TITLE
Fix tabnabbing vulnerability in Snow theme

### DIFF
--- a/themes/snow.js
+++ b/themes/snow.js
@@ -70,7 +70,7 @@ class SnowTooltip extends BaseTooltip {
   }
 }
 SnowTooltip.TEMPLATE = [
-  '<a class="ql-preview" rel="noopener noreferrer nofollow" target="_blank" href="about:blank"></a>',
+  '<a class="ql-preview" rel="noopener noreferrer" target="_blank" href="about:blank"></a>',
   '<input type="text" data-formula="e=mc^2" data-link="https://quilljs.com" data-video="Embed URL">',
   '<a class="ql-action"></a>',
   '<a class="ql-remove"></a>',

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -70,7 +70,7 @@ class SnowTooltip extends BaseTooltip {
   }
 }
 SnowTooltip.TEMPLATE = [
-  '<a class="ql-preview" target="_blank" href="about:blank"></a>',
+  '<a class="ql-preview" rel="noopener noreferrer nofollow" target="_blank" href="about:blank"></a>',
   '<input type="text" data-formula="e=mc^2" data-link="https://quilljs.com" data-video="Embed URL">',
   '<a class="ql-action"></a>',
   '<a class="ql-remove"></a>',


### PR DESCRIPTION
Fixes #2438

The link has the target attribute set to _blank but has no rel property. This means that documents containing untrusted links make the page they are embedded in susceptible to tabnabbing https://www.owasp.org/index.php/Reverse_Tabnabbing.
This PR sets the rel property to noopener (also norefferer and nofollow)