### PR TITLE
fix access on possible null element

### DIFF
--- a/core/emitter.js
+++ b/core/emitter.js
@@ -30,7 +30,7 @@ class Emitter extends EventEmitter {
 
   handleDOM(event, ...args) {
     (this.listeners[event.type] || []).forEach(({ node, handler }) => {
-      if (event.target === node || node.contains(event.target)) {
+      if (node && (event.target === node || node.contains(event.target))) {
         handler(event, ...args);
       }
     });


### PR DESCRIPTION
I found this possible bug when using quill inside a `customElement`.
In my case the `node` was `null` hence the call to `.contains` would result in a runtime error:

```
Uncaught TypeError: Cannot read property 'contains' of null
```

----

Just for completeness' sake a minimal example of what I tried to do, just in case there is something else going wrong that I'm unaware of:

```
import Quill from "quill";

customElements.define(
  "quill-editor",
  class extends HTMLElement {
    constructor() {
      super();

      this._container = document.createElement("div");
      this._editor = document.createElement("div");

      this._editor.appendChild(document.createTextNode("Hello World"));
      this._container.appendChild(this._editor);
    }

    connectedCallback() {
      this._editor = new Quill(this._editor, {
        theme: "snow"
      });

      this.appendChild(this._container);
    }
  }
);
```

Thanks! 🙂 