### PR TITLE
Add link table to dev setup guide

### DIFF
--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -32,6 +32,7 @@ Once the terminal settles (with messages indicating success from `jekyll`, `karm
 | Service                      | URL                                                                          |
 | :--------------------------- | :--------------------------------------------------------------------------- |
 | Jekyll Documentation Site    | [localhost:9000](http://localhost:9000)                                      |
+| Standalone Editor (Full)     | [localhost:9000/standalone/full](http://localhost:9000/standalone/full/)     |
 | Standalone Editor (Snow)     | [localhost:9000/standalone/snow](http://localhost:9000/standalone/snow/)     |
 | Standalone Editor (Bubble)   | [localhost:9000/standalone/bubble](http://localhost:9000/standalone/bubble/) |
 | Karma Test Runner            | [localhost:9000/karma](http://localhost:9000/karma)                          |

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -27,6 +27,16 @@ All four services can be run with a single command thanks to [foreman](http://dd
 
     npm start
 
+Once the terminal settles (with messages indicating success from `jekyll`, `karma`, `proxy`, and `webpack`), you may access the different services as follows:
+
+| Service                      | URL                                                                          |
+| :--------------------------- | :--------------------------------------------------------------------------- |
+| Jekyll Documentation Site    | [localhost:9000](http://localhost:9000)                                      |
+| Standalone Editor (Snow)     | [localhost:9000/standalone/snow](http://localhost:9000/standalone/snow/)     |
+| Standalone Editor (Bubble)   | [localhost:9000/standalone/bubble](http://localhost:9000/standalone/bubble/) |
+| Karma Test Runner            | [localhost:9000/karma](http://localhost:9000/karma)                          |
+| Webpack Locally Hosted Build | [localhost:9080](http://localhost:9080)                                      |
+
 
 ### Testing
 


### PR DESCRIPTION
Hello! I've been using Quill for about two years now, and I'd like to start contributing back. This is my first PR on the project.

I found it super easy to set up the development environment and get up and running. During the process, I found it difficult to figure out where to go once `npm start` was run - so I added this table of links.

Please let me know if any of those table entries are incorrect and/or if I'm missing anything that should be there! :-)