### PR TITLE
[issue-2364] Adding default value for font-weight

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -40,6 +40,7 @@ resets(arr)
 .ql-editor
   box-sizing: border-box
   counter-reset: list-0
+  font-weight: normal
   line-height: 1.42
   height: 100%
   outline: none


### PR DESCRIPTION
Hey Quill team,

I've been using Quill for a while now and thought it would be cool to try and give something back. I saw this ticket that seemed kind of ambiguous in what it meant, https://github.com/quilljs/quill/issues/2364 

I'm thinking if what they want is to have everything automatically wrapped in a `<strong>` until you turn it off that that doesn't really seem realistic, so I thought maybe a better solution would just be to apply a default value of font-weight so that Quill won't have it's style changed due to some kind of nesting problem (which should be easy enough to override if anyone wants an editor to be displayed bold without actually having the content be bold.)

Feel free to close this if you don't think it's useful or goes against Quill's css philosophy or whatever else.

Thanks for making such a great editor!