### PR TITLE
[Issue 2151] Add error for malformed keyboard bindings.

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -28,7 +28,7 @@ class Keyboard extends Module {
     this.bindings = {};
 
     if (this.options.bindings) {
-      if (Object.prototype.toString.call(this.options.bindings) === `[object Object]`) {
+      if (Object.prototype.toString.call(this.options.bindings) === '[object Object]') {
         Object.keys(this.options.bindings).forEach(name => {
           if (this.options.bindings[name]) {
             this.addBinding(this.options.bindings[name]);

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -28,7 +28,10 @@ class Keyboard extends Module {
     this.bindings = {};
 
     if (this.options.bindings) {
-      if (Object.prototype.toString.call(this.options.bindings) === '[object Object]') {
+      if (
+        Object.prototype.toString.call(this.options.bindings) ===
+        '[object Object]'
+      ) {
         Object.keys(this.options.bindings).forEach(name => {
           if (this.options.bindings[name]) {
             this.addBinding(this.options.bindings[name]);
@@ -38,7 +41,6 @@ class Keyboard extends Module {
         throw new Error('Provided keyboard bindings should be an object.');
       }
     }
-    
     this.addBinding({ key: 'Enter', shiftKey: null }, handleEnter);
     this.addBinding(
       { key: 'Enter', metaKey: null, ctrlKey: null, altKey: null },

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -26,15 +26,19 @@ class Keyboard extends Module {
   constructor(quill, options) {
     super(quill, options);
     this.bindings = {};
-    if (Array.isArray(this.options.bindings)) {
-      throw new Error('Provided keyboard bindings should be an object (not an array).');
-    } else {
-      Object.keys(this.options.bindings).forEach(name => {
-        if (this.options.bindings[name]) {
-          this.addBinding(this.options.bindings[name]);
-        }
-      });
+
+    if (this.options.bindings) {
+      if (Object.prototype.toString.call(this.options.bindings) === `[object Object]`) {
+        Object.keys(this.options.bindings).forEach(name => {
+          if (this.options.bindings[name]) {
+            this.addBinding(this.options.bindings[name]);
+          }
+        });
+      } else {
+        throw new Error('Provided keyboard bindings should be an object.');
+      }
     }
+    
     this.addBinding({ key: 'Enter', shiftKey: null }, handleEnter);
     this.addBinding(
       { key: 'Enter', metaKey: null, ctrlKey: null, altKey: null },

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -26,11 +26,15 @@ class Keyboard extends Module {
   constructor(quill, options) {
     super(quill, options);
     this.bindings = {};
-    Object.keys(this.options.bindings).forEach(name => {
-      if (this.options.bindings[name]) {
-        this.addBinding(this.options.bindings[name]);
-      }
-    });
+    if (Array.isArray(this.options.bindings)) {
+      throw new Error('Provided keyboard bindings should be an object (not an array).');
+    } else {
+      Object.keys(this.options.bindings).forEach(name => {
+        if (this.options.bindings[name]) {
+          this.addBinding(this.options.bindings[name]);
+        }
+      });
+    }
     this.addBinding({ key: 'Enter', shiftKey: null }, handleEnter);
     this.addBinding(
       { key: 'Enter', metaKey: null, ctrlKey: null, altKey: null },


### PR DESCRIPTION
So while investigating #2151 I found that it's **_not_** an issue with Quill at all ... and that I'm an idiot. 😂 

When configuring the editor, I was passing an _Array_ of key bindings instead of an _Object_ of key bindings. In doing so, some of Quill's default behavior broke silently.

To protect myself and future idiots from making the same mistake, I propose the change in this PR - which throws an error upon receiving an Array of key bindings.

You can see this in action on the (now closed) #2493 or on branch `Percipient24/quill:dev-2151-key-bindings` - which has a failing test case that shows the error being thrown. This PR should be used instead of #2493 since it's just the requested change and nothing else.

If you feel this error is not needed, feel free to close this PR along with #2151.

Thank you! 😅 