### PR TITLE
Allow optional drag event enabling

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -75,9 +75,11 @@ class Quill {
     this.container.innerHTML = '';
     instances.set(this.container, this);
     this.root = this.addContainer('ql-editor');
-    this.root.addEventListener('dragstart', e => {
-      e.preventDefault();
-    });
+    if (!this.options.enableDragging) {
+      this.root.addEventListener('dragstart', e => {
+        e.preventDefault();
+      });
+    }
     this.root.classList.add('ql-blank');
     this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -89,3 +89,9 @@ DOM Element or a CSS selector for a DOM Element, specifying which container has 
 #### theme
 
 Name of theme to use. The builtin options are "bubble" or "snow". An invalid or falsy value will load a default minimal theme. Note the theme's specific stylesheet still needs to be included manually. See [Themes](/docs/themes/) for more information.
+
+#### enableDragging
+
+Default: `false`
+
+By default, Quill disables all [drag events](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API). These can be enabled for writing custom modules by setting this flag to `true`.

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -891,4 +891,35 @@ describe('Quill', function() {
       expect(this.quill.root.classList).not.toContain('ql-blank');
     });
   });
+
+  describe('dragging', function() {
+    it('disables dragging by default', function(done) {
+      this.quill = this.initialize(Quill, '');
+
+      const dragstart = new Event('dragstart');
+      spyOn(dragstart, 'preventDefault');
+
+      this.quill.root.addEventListener('dragstart', function() {
+        expect(dragstart.preventDefault).toHaveBeenCalledTimes(1);
+        done();
+      });
+
+      this.quill.root.dispatchEvent(dragstart);
+    });
+
+    it('can enable drag events with configuration', function(done) {
+      const options = { enableDragging: true };
+      this.quill = this.initialize(Quill, '', this.container, options);
+
+      const dragstart = new Event('dragstart');
+      spyOn(dragstart, 'preventDefault');
+
+      this.quill.root.addEventListener('dragstart', function() {
+        expect(dragstart.preventDefault).not.toHaveBeenCalled();
+        done();
+      });
+
+      this.quill.root.dispatchEvent(dragstart);
+    });
+  });
 });


### PR DESCRIPTION
This change allows consumers to enable drag events by configuring Quill
with an `enableDragging` flag.

This is useful for writing custom modules that want to use drag
behaviour.