### PR TITLE
Correctly convert mixed lists

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -249,7 +249,8 @@ function convertListHTML(items, lastIndent, types) {
       length,
     )}${convertListHTML(rest, indent, types)}`;
   }
-  if (indent === lastIndent) {
+  const previousType = types[types.length - 1];
+  if (indent === lastIndent && type === previousType) {
     return `</li><li${attribute}>${convertHTML(
       child,
       offset,

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -597,6 +597,30 @@ describe('Editor', function() {
       );
     });
 
+    it('mixed list', function() {
+      const editor = this.initialize(
+        Editor,
+        `
+          <ol>
+            <li data-list="ordered">One</li>
+            <li data-list="ordered">Two</li>
+            <li data-list="bullet">Foo</li>
+            <li data-list="bullet">Bar</li>
+          </ol>
+        `,
+      );
+      expect(editor.getHTML(2, 12)).toEqualHTML(`
+        <ol>
+          <li>e</li>
+          <li>Two</li>
+        </ol>
+        <ul>
+          <li>Foo</li>
+          <li>Ba</li>
+        </ul>
+      `);
+    });
+
     it('nested list', function() {
       const editor = this.initialize(
         Editor,


### PR DESCRIPTION
At the moment, it's possible to construct a "mixed" list of ordered and
bulleted items, eg:

```markdown
  1. One
  2. Two
  - Foo
  - Bar
```

If you create this list in Quill, then cut it and paste it back again,
the bullet items are transformed into ordered items, which is
surprising.

This change updates the list HTML conversion logic to check that the
list is still a continuation of the previous type. If not, it starts a
new list of the correct type.