### PR TITLE
Fix Microsoft Edge

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -418,7 +418,8 @@ function matchIndent(node, delta, scroll) {
     if (op.attributes && op.attributes.list) {
       return composed.push(op);
     }
-    return composed.insert(op.insert, { indent, ...(op.attributes || {}) });
+    const attributes = Object.assign({ indent }, op.attributes);
+    return composed.insert(op.insert, attributes);
   }, new Delta());
 }
 


### PR DESCRIPTION
Spread in object literals is not supported in Microsoft Edge:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Browser_compatibility

Current HEAD of develop branch results in the following error in Edge when loading Quill:

```
SCRIPT1028: Expected identifier, string or number
```

I'm not sure what sort of automatic testing we could add to prevent this in future. I was looking for a ESLint rule that would prevent it, but only found one that does the opposite (disallows `Object.assign`). A more heavy-weight solution perhaps would be to use Sauce to load the entire code base in each browser to see if no errors are thrown. What do you think?