### PR TITLE
Move drag blocking to `Scroll`

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -15,6 +15,7 @@ class Scroll extends ScrollBlot {
     this.batch = false;
     this.optimize();
     this.enable();
+    this.domNode.addEventListener('dragstart', e => this.handleDragStart(e));
   }
 
   batchStart() {
@@ -61,6 +62,10 @@ class Scroll extends ScrollBlot {
   formatAt(index, length, format, value) {
     super.formatAt(index, length, format, value);
     this.optimize();
+  }
+
+  handleDragStart(event) {
+    event.preventDefault();
   }
 
   insertAt(index, value, def) {

--- a/core/quill.js
+++ b/core/quill.js
@@ -75,9 +75,6 @@ class Quill {
     this.container.innerHTML = '';
     instances.set(this.container, this);
     this.root = this.addContainer('ql-editor');
-    this.root.addEventListener('dragstart', e => {
-      e.preventDefault();
-    });
     this.root.classList.add('ql-blank');
     this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;

--- a/test/unit/blots/scroll.js
+++ b/test/unit/blots/scroll.js
@@ -39,6 +39,14 @@ describe('Scroll', function() {
     }, 1);
   });
 
+  it('prevent dragstart', function() {
+    const scroll = this.initialize(Scroll, '<p>Hello World!</p>');
+    const dragstart = new Event('dragstart');
+    spyOn(dragstart, 'preventDefault');
+    scroll.domNode.dispatchEvent(dragstart);
+    expect(dragstart.preventDefault).toHaveBeenCalled();
+  });
+
   describe('leaf()', function() {
     it('text', function() {
       const scroll = this.initialize(Scroll, '<p>Tests</p>');


### PR DESCRIPTION
At the moment, consumers cannot enable drag events within the editor,
because they're all disabled by the `Quill` constructor registering an
anonymous `dragstart` handler.

This change allows consumers to override this behaviour by moving this
listener to the `Scroll` blot, where the `dragstart` is prevented in a
named method, which can be overridden by extending the class.