### PR TITLE
Ignore `compositionend` && `compositionstart` if `IS_ANDROID` presented

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -24,7 +24,11 @@ class Selection {
     // savedRange is last non-null range
     this.savedRange = new Range(0, 0);
     this.lastRange = this.savedRange;
-    this.handleComposition();
+
+    if (typeof IS_ANDROID === 'undefined' || !IS_ANDROID) {
+      this.handleComposition();
+    }
+    
     this.handleDragging();
     this.emitter.listenDOM('selectionchange', document, () => {
       if (!this.mouseDown) {

--- a/formats/image.js
+++ b/formats/image.js
@@ -35,7 +35,7 @@ class Image extends EmbedBlot {
   }
 
   static sanitize(url) {
-    return sanitize(url, ['http', 'https', 'data']) ? url : '//:0';
+    return sanitize(url, ['http', 'https', 'data', 'cid']) ? url : '//:0';
   }
 
   static value(domNode) {


### PR DESCRIPTION
Quill does not work correctly if you put this Quill library inside android WebView. Android sends `compositionend` and `compositionstart` if the native button is clicked(button not inside HTML of webview). In my case, I created a native toolbar and the same code for button click inside HTML and button click inside android UI behaves differently.

These events lead to`"addRange(): The given range isn't in document."` inside quill and broke UI(i.e. hides native keyboard).

