### PR TITLE
Fix tab nabbing vulnerability in formatted links

### DIFF
--- a/formats/link.js
+++ b/formats/link.js
@@ -4,6 +4,7 @@ class Link extends Inline {
   static create(value) {
     const node = super.create(value);
     node.setAttribute('href', this.sanitize(value));
+    node.setAttribute('rel', 'noopener noreferrer');
     node.setAttribute('target', '_blank');
     return node;
   }

--- a/test/unit/formats/link.js
+++ b/test/unit/formats/link.js
@@ -13,7 +13,7 @@ describe('Link', function() {
         .insert('3\n'),
     );
     expect(editor.scroll.domNode).toEqualHTML(
-      '<p>0<a href="https://quilljs.com" target="_blank">12</a>3</p>',
+      '<p>0<a href="https://quilljs.com" target="_blank" rel="noopener noreferrer">12</a>3</p>',
     );
   });
 
@@ -38,14 +38,14 @@ describe('Link', function() {
         .insert('3\n'),
     );
     expect(editor.scroll.domNode).toEqualHTML(
-      '<p>0<a href="about:blank" target="_blank">12</a>3</p>',
+      '<p>0<a href="about:blank" target="_blank" rel="noopener noreferrer">12</a>3</p>',
     );
   });
 
   it('change', function() {
     const editor = this.initialize(
       Editor,
-      '<p>0<a href="https://github.com" target="_blank">12</a>3</p>',
+      '<p>0<a href="https://github.com" target="_blank" rel="noopener noreferrer">12</a>3</p>',
     );
     editor.formatText(1, 2, { link: 'https://quilljs.com' });
     expect(editor.getDelta()).toEqual(
@@ -55,14 +55,14 @@ describe('Link', function() {
         .insert('3\n'),
     );
     expect(editor.scroll.domNode).toEqualHTML(
-      '<p>0<a href="https://quilljs.com" target="_blank">12</a>3</p>',
+      '<p>0<a href="https://quilljs.com" target="_blank" rel="noopener noreferrer">12</a>3</p>',
     );
   });
 
   it('remove', function() {
     const editor = this.initialize(
       Editor,
-      '<p>0<a class="ql-size-large" href="https://quilljs.com" target="_blank">12</a>3</p>',
+      '<p>0<a class="ql-size-large" href="https://quilljs.com" target="_blank" rel="noopener noreferrer">12</a>3</p>',
     );
     editor.formatText(1, 2, { link: false });
     const delta = new Delta()


### PR DESCRIPTION
* Add attribute rel="noopener noreferrer" to <a> tags created by formats/link.js
* Make unit tests for links expect rel attribute

The vulnerability described in #2438 was not fully fixed with PR #2439 .
Using quill in readonly mode to display content still results in vulnerable anchor tags, because
the create function in formats/link.js sets target="_blank" but not rel="noopener noreferrer".

This pull request in combination with #2439 mitigates the tab nabbing vulnerability.
