### PR TITLE
Make `Selection` into a module

### DIFF
--- a/blots/cursor.ts
+++ b/blots/cursor.ts
@@ -1,6 +1,6 @@
 import { EmbedBlot, Scope, ScrollBlot } from 'parchment';
 import { Parent } from 'parchment/dist/typings/blot/abstract/blot';
-import Selection from '../core/selection';
+import Selection from '../modules/selection';
 import TextBlot from './text';
 
 class Cursor extends EmbedBlot {

--- a/core.ts
+++ b/core.ts
@@ -9,6 +9,7 @@ import Inline from './blots/inline';
 import Scroll from './blots/scroll';
 import TextBlot from './blots/text';
 
+import Selection from './modules/selection';
 import Clipboard from './modules/clipboard';
 import History from './modules/history';
 import Keyboard from './modules/keyboard';
@@ -28,6 +29,7 @@ Quill.register({
   'blots/scroll': Scroll,
   'blots/text': TextBlot,
 
+  'modules/selection': Selection,
   'modules/clipboard': Clipboard,
   'modules/history': History,
   'modules/keyboard': Keyboard,

--- a/core/editor.ts
+++ b/core/editor.ts
@@ -8,7 +8,7 @@ import Break from '../blots/break';
 import CursorBlot from '../blots/cursor';
 import Scroll from '../blots/scroll';
 import TextBlot, { escapeText } from '../blots/text';
-import { Range } from './selection';
+import { Range } from '../modules/selection';
 
 const ASCII = /^[ -~]*$/;
 

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -17,7 +17,7 @@ import Emitter, { EmitterSource } from './emitter';
 import instances from './instances';
 import logger from './logger';
 import Module from './module';
-import Selection, { Range } from './selection';
+import Selection, { Range } from '../modules/selection';
 import Theme, { ThemeConstructor } from './theme';
 
 const debug = logger('quill');
@@ -175,8 +175,8 @@ class Quill {
       emitter: this.emitter,
     });
     this.editor = new Editor(this.scroll);
-    this.selection = new Selection(this.scroll, this.emitter);
     this.theme = new this.options.theme(this, this.options); // eslint-disable-line new-cap
+    this.selection = this.theme.addModule('selection');
     this.keyboard = this.theme.addModule('keyboard');
     this.clipboard = this.theme.addModule('clipboard');
     this.history = this.theme.addModule('history');
@@ -696,6 +696,7 @@ function expandConfig(
         clipboard: true,
         keyboard: true,
         history: true,
+        selection: true,
         uploader: true,
       },
     },

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -3,6 +3,7 @@ import Clipboard from '../modules/clipboard';
 import History from '../modules/history';
 import Keyboard from '../modules/keyboard';
 import Uploader from '../modules/uploader';
+import Selection from '../modules/selection';
 
 interface ThemeOptions {
   modules: Record<string, unknown>;
@@ -33,6 +34,7 @@ class Theme {
   addModule(name: 'keyboard'): Keyboard;
   addModule(name: 'uploader'): Uploader;
   addModule(name: 'history'): History;
+  addModule(name: 'selection'): Selection;
   addModule(name: string): unknown;
   addModule(name: string) {
     // @ts-expect-error

--- a/modules/clipboard.ts
+++ b/modules/clipboard.ts
@@ -13,7 +13,7 @@ import { EmitterSource } from '../core/emitter';
 import logger from '../core/logger';
 import Module from '../core/module';
 import Quill from '../core/quill';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 import { AlignAttribute, AlignStyle } from '../formats/align';
 import { BackgroundStyle } from '../formats/background';
 import CodeBlock from '../formats/code';

--- a/modules/keyboard.ts
+++ b/modules/keyboard.ts
@@ -6,7 +6,7 @@ import Quill from '../core/quill';
 import logger from '../core/logger';
 import Module from '../core/module';
 import { BlockEmbed } from '../blots/block';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 
 const debug = logger('quill:keyboard');
 

--- a/modules/selection.ts
+++ b/modules/selection.ts
@@ -1,10 +1,11 @@
 import { LeafBlot, Scope } from 'parchment';
 import cloneDeep from 'lodash.clonedeep';
 import isEqual from 'lodash.isequal';
-import Emitter, { EmitterSource } from './emitter';
-import logger from './logger';
+import Emitter, { EmitterSource } from '../core/emitter';
+import logger from '../core/logger';
 import Cursor from '../blots/cursor';
 import Scroll from '../blots/scroll';
+import Module from '../core/module';
 
 const debug = logger('quill:selection');
 
@@ -23,7 +24,7 @@ class Range {
   constructor(public index: number, public length = 0) {}
 }
 
-class Selection {
+class Selection extends Module {
   scroll: Scroll;
   emitter: Emitter;
   composing: boolean;
@@ -35,9 +36,10 @@ class Selection {
   lastRange: Range | null;
   lastNative: NormalizedRange | null;
 
-  constructor(scroll: Scroll, emitter: Emitter) {
-    this.emitter = emitter;
-    this.scroll = scroll;
+  constructor(quill, options) {
+    super(quill, options);
+    this.emitter = quill.emitter;
+    this.scroll = quill.scroll;
     this.composing = false;
     this.mouseDown = false;
     this.root = this.scroll.domNode;

--- a/modules/uploader.ts
+++ b/modules/uploader.ts
@@ -2,7 +2,7 @@ import Delta from 'quill-delta';
 import Quill from '../core/quill';
 import Emitter from '../core/emitter';
 import Module from '../core/module';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 
 interface UploaderOptions {
   mimetypes: string[];

--- a/test/helpers/unit.js
+++ b/test/helpers/unit.js
@@ -1,7 +1,7 @@
 import isEqual from 'lodash.isequal';
 import Editor from '../../core/editor';
 import Emitter from '../../core/emitter';
-import Selection from '../../core/selection';
+import Selection from '../../modules/selection';
 import Scroll from '../../blots/scroll';
 import Quill, { globalRegistry } from '../../core/quill';
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -11,7 +11,6 @@ import './unit/blots/block-embed';
 import './unit/blots/inline';
 
 import './unit/core/editor';
-import './unit/core/selection';
 import './unit/core/quill';
 
 import './unit/formats/color';
@@ -28,6 +27,7 @@ import './unit/formats/table';
 import './unit/modules/clipboard';
 import './unit/modules/history';
 import './unit/modules/keyboard';
+import './unit/modules/selection';
 import './unit/modules/syntax';
 import './unit/modules/table';
 import './unit/modules/tableEmbed';

--- a/test/unit/blots/scroll.js
+++ b/test/unit/blots/scroll.js
@@ -1,5 +1,5 @@
 import Emitter from '../../../core/emitter';
-import Selection, { Range } from '../../../core/selection';
+import Selection, { Range } from '../../../modules/selection';
 import Cursor from '../../../blots/cursor';
 import Scroll from '../../../blots/scroll';
 

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -1,6 +1,6 @@
 import Delta from 'quill-delta';
 import Editor from '../../../core/editor';
-import Selection, { Range } from '../../../core/selection';
+import Selection, { Range } from '../../../modules/selection';
 
 describe('Editor', function () {
   describe('insert', function () {

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -4,7 +4,7 @@ import Theme from '../../../core/theme';
 import Emitter from '../../../core/emitter';
 import Toolbar from '../../../modules/toolbar';
 import Snow from '../../../themes/snow';
-import { Range } from '../../../core/selection';
+import { Range } from '../../../modules/selection';
 
 describe('Quill', function () {
   it('imports', function () {

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -1,5 +1,5 @@
 import Delta from 'quill-delta';
-import { Range } from '../../../core/selection';
+import { Range } from '../../../modules/selection';
 import Quill from '../../../core';
 
 describe('Clipboard', function () {

--- a/test/unit/modules/selection.js
+++ b/test/unit/modules/selection.js
@@ -1,4 +1,4 @@
-import Selection, { Range } from '../../../core/selection';
+import Selection, { Range } from '../../../modules/selection';
 import Cursor from '../../../blots/cursor';
 import Emitter from '../../../core/emitter';
 

--- a/themes/base.ts
+++ b/themes/base.ts
@@ -6,7 +6,7 @@ import ColorPicker from '../ui/color-picker';
 import IconPicker from '../ui/icon-picker';
 import Picker from '../ui/picker';
 import Tooltip from '../ui/tooltip';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 
 const ALIGNS = [false, 'center', 'right', 'justify'];
 

--- a/themes/bubble.ts
+++ b/themes/bubble.ts
@@ -1,7 +1,7 @@
 import merge from 'lodash.merge';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 import icons from '../ui/icons';
 
 const TOOLBAR_CONFIG = [

--- a/themes/snow.ts
+++ b/themes/snow.ts
@@ -2,7 +2,7 @@ import merge from 'lodash.merge';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
 import LinkBlot from '../formats/link';
-import { Range } from '../core/selection';
+import { Range } from '../modules/selection';
 import icons from '../ui/icons';
 
 const TOOLBAR_CONFIG = [


### PR DESCRIPTION
Sometimes consumers of Quill want to modify the behaviour of the
`Selection` class. However, unlike all the other default behaviour of
Quill, such as `Keyboard`, `Clipboard` and `History`, `Selection` is not
a `Module`, and so its behaviour cannot be modified without forking or
monkey-patching.

This change moves the `Selection` class into the `modules` directory
alongside the other core Quill modules, so that its behaviour can be
overridden like any other module.