### PR TITLE
Ensure compatibility with Terser `pure_getters` optimization

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -408,12 +408,11 @@ class Selection {
 
 function contains(parent, descendant) {
   try {
-    // Firefox inserts inaccessible nodes around video elements
-    descendant.parentNode; // eslint-disable-line no-unused-expressions
+    return parent.contains(descendant);
   } catch (e) {
+    // Firefox inserts inaccessible nodes around video elements
     return false;
   }
-  return parent.contains(descendant);
 }
 
 export { Range, Selection as default };


### PR DESCRIPTION
Hello!

This change makes Quill source compatible with [Terser](https://github.com/terser/terser) `pure_getters` optimization.

This change is needed for Angular projects, because:

1. Angular CLI (the most popular tool for building Angular projects) internally uses Webpack with [terser-webpack-plugin](https://webpack.js.org/plugins/terser-webpack-plugin/) and unconditionally applies `pure_getters` optimization. You can see all of it in Angular CLI sources: [webpack-configs/common.ts](https://github.com/angular/angular-cli/blob/v8.2.0/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts).

    At some point Angular CLI team disabled `pure_getters` optimization (see https://github.com/angular/angular-cli/issues/11439, https://github.com/angular/angular-cli/pull/14187), but then they returned it back for their reasons (https://github.com/angular/angular-cli/pull/14287).

2. Angular CLI not only compiles project code, but also recompiles the code of external libraries located in `node_modules`, including `quill.min.js` if it happens to be there

Here is the problematic code from Quill:

```
function contains(parent, descendant) {
  try {
    // Firefox inserts inaccessible nodes around video elements
    descendant.parentNode; // eslint-disable-line no-unused-expressions
  } catch (e) {
    return false;
  }
  return parent.contains(descendant);
}
```

With `pure_getters` optimization, Terser duly assumes that `descendant.parentNode` statement is not doing anything and prunes the whole `try..catch` block. You can easily reproduce the problem locally:

```
$ terser -c pure_getters <<EOF
export function contains(parent, descendant) {
  try {
    // Firefox inserts inaccessible nodes around video elements
    descendant.parentNode; // eslint-disable-line no-unused-expressions
  } catch (e) {
    return false;
  }
  return parent.contains(descendant);
}
EOF
export function contains(parent,descendant){return parent.contains(descendant)}
```

Of course, the resulting code will throw the Error described in https://github.com/quilljs/quill/issues/644 because the guards aren't there.