### PR TITLE
Add SMS to link protocol whitelist

### DIFF
--- a/formats/link.ts
+++ b/formats/link.ts
@@ -4,7 +4,7 @@ class Link extends Inline {
   static blotName = 'link';
   static tagName = 'A';
   static SANITIZED_URL = 'about:blank';
-  static PROTOCOL_WHITELIST = ['http', 'https', 'mailto', 'tel'];
+  static PROTOCOL_WHITELIST = ['http', 'https', 'mailto', 'tel', 'sms'];
 
   static create(value) {
     const node = super.create(value) as Element;


### PR DESCRIPTION
SMS protocol was missing added to `PROTOCOL_WHITELIST`
SMS links are widely supported - https://developer.apple.com/library/archive/featuredarticles/iPhoneURLScheme_Reference/SMSLinks/SMSLinks.html  