### PR TITLE
Add check on index in getFormat to ensure index is not null or undefined

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -266,10 +266,12 @@ class Quill {
   }
 
   getFormat(index = this.getSelection(true), length = 0) {
-    if (typeof index === 'number') {
-      return this.editor.getFormat(index, length);
-    }
-    return this.editor.getFormat(index.index, index.length);
+   if(index === null || typeof index === 'undefined' ){
+     throw Error('Invalid index type null or undefined');
+   }
+    return typeof index === 'number' ?
+        this.editor.getFormat(index, length) :
+        this.editor.getFormat(index.index, index.length);
   }
 
   getIndex(blot) {


### PR DESCRIPTION
If the value of index passed into getFormat is not of type "number" then it is treated as an object and call index.index and index.length. However, if for some reason an error occurs and null is passed through, then you get  "cannot get property index of null or undefined" uncaught error. 

I have just added a small check to throw a custom error (Open to suggestions on the error message) so we can send the error up and present it to logging tools (e.g. bugsnag) which will then autoNotify. 




