### PR TITLE
Fix toolbar button state not updated in some cases

### DIFF
--- a/packages/quill/src/modules/toolbar.ts
+++ b/packages/quill/src/modules/toolbar.ts
@@ -61,12 +61,7 @@ class Toolbar extends Module<ToolbarProps> {
         this.attach(input);
       },
     );
-    this.quill.on(Quill.events.EDITOR_CHANGE, (type, range) => {
-      if (type === Quill.events.SELECTION_CHANGE) {
-        this.update(range as Range);
-      }
-    });
-    this.quill.on(Quill.events.SCROLL_OPTIMIZE, () => {
+    this.quill.on(Quill.events.EDITOR_CHANGE, () => {
       const [range] = this.quill.selection.getRange(); // quill.getSelection triggers update
       this.update(range);
     });

--- a/packages/quill/test/unit/modules/toolbar.spec.ts
+++ b/packages/quill/test/unit/modules/toolbar.spec.ts
@@ -236,5 +236,14 @@ describe('Toolbar', () => {
       expect(centerButton.getAttribute('aria-pressed')).toBe('false');
       expect(leftButton.getAttribute('aria-pressed')).toBe('false');
     });
+
+    test('update on format', function () {
+      const { container, quill } = setup();
+      const boldButton = container?.parentNode?.querySelector('button.ql-bold');
+      quill.setSelection(1, 2);
+      expect(boldButton?.classList.contains('ql-active')).toBe(false);
+      quill.format('bold', true, 'user');
+      expect(boldButton?.classList.contains('ql-active')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
This change fixes the following bug:

  1. Start with plain text "foo bar" in the editor
  2. Highlight "bar" (NB: it's important to select text that's not at
     the start)
  3. Hit Ctrl+B to apply bold formatting
  4. Notice that the bold button in the toolbar doesn't receive the
     `ql-active` class, when it should

![Jan-02-2020 11-23-52](https://user-images.githubusercontent.com/12036746/71664847-7ca55680-2d52-11ea-8205-dff11244656b.gif)

This appears to happen because the listener on `SCROLL_OPTIMIZE` gets an
incorrect range.

Instead of listening on optimize, we listen for all `EDITOR_CHANGE`
events, which _do_ get the correct range.