### PR TITLE
[fix] leaf.position error

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -271,6 +271,7 @@ class Selection {
     indexes.forEach((index, i) => {
       index = Math.min(scrollLength - 1, index);
       const [leaf, leafOffset] = this.scroll.leaf(index);
+      if (!leaf || !leaf.position) return;
       const [node, offset] = leaf.position(leafOffset, i !== 0);
       args.push(node, offset);
     });


### PR DESCRIPTION
When inputting Japanese, the following error was displayed.

> Uncaught TypeError: leaf.position is not a function

This pull request fixed this bug.

related: #740