### PR TITLE
[Issue-2005] Don't prevent left arrow events on Break leafs

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -601,7 +601,12 @@ function makeEmbedArrowHandler(key, shiftKey) {
         index += range.length + 1;
       }
       const [leaf] = this.quill.getLeaf(index);
-      if (!(leaf instanceof EmbedBlot)) return true;
+
+      // NOTE: a line break is not an EmbedBlot that needs special handling
+      if (!(leaf instanceof EmbedBlot) || leaf.statics.tagName === 'BR') {
+        return true;
+      }
+
       if (key === 'ArrowLeft') {
         if (shiftKey) {
           this.quill.setSelection(


### PR DESCRIPTION
# Links
- Initial issue report: #2005 
- Relevant commit that added `makeEmbedArrowHandler`: [link](https://github.com/quilljs/quill/commit/33929871fb64c3b75b00cd256b6856b0881e8895)
- Issue that that commit was addressing: #1635
- Codesandbox that illustrates the issues with ArrowLeft key bindings: [link](https://codesandbox.io/s/quill-issue-example-6wm4f?fontsize=14&hidenavigation=1&theme=dark)

# Why
I'm currently trying to add a custom key binding for the left arrow. It works except for on empty lines (`<p><br /></p>`)

# Description of the problem
- `Keyboard` has a default keybinding `'embed left'` that is called before my custom key binding
- Currently `'embed left'` is returning `false` when the cursor is in an instance of an `EmbedBlot` [(code)](https://github.com/quilljs/quill/blob/develop/modules/keyboard.js#L627)
- My custom key binding is prevented based on the `matches.some(...)` logic [(code)](https://github.com/quilljs/quill/blob/develop/modules/keyboard.js#L177)

# What
- I updated the `'embed left'` handler to ignore `Break` like it does for all other non `EmbedBlot`s

# Alternative Solutions
- Make the custom key bindings fire before the default ones
  - It seems as though custom key bindings are meant to fire before the default key bindings, if you pass them in as part of the config. However that doesn't seem to be the case anymore (see [Codesandbox](https://codesandbox.io/s/quill-issue-example-6wm4f?fontsize=14&hidenavigation=1&theme=dark) for how binding is added). So maybe the fix should be fore that instead?
- Alter the `Break` class to not inherit from `EmbedBlot`
  - I looked into this briefly and it seems like a much more complex change

# Caveats
- I don't have a test for this, but I can add them once we can agree on a solution we want
  - i tested manually that my use case works as well as the use case that the original commit I referenced was trying to fix (using arrows to navigate past embeds like formulas)
