### PR TITLE
Unblocks Grammarly 

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -78,7 +78,6 @@ class Quill {
       e.preventDefault();
     });
     this.root.classList.add('ql-blank');
-    this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;
     this.emitter = new Emitter();
     const ScrollBlot = this.options.registry.query(


### PR DESCRIPTION
Hi all! 
Since Grammarly now works well on Quill in all browsers, we no longer need to block it. 
This PR unblocks Grammarly from integrating on Quill.