### PR TITLE
Add line-height picker to menu

### DIFF
--- a/assets/base.styl
+++ b/assets/base.styl
@@ -150,6 +150,19 @@ colorItemsPerRow = 7
       overflow: visible
     img
       max-width: 100%
+    .ql-line-height-1
+      line-height: 1
+    .ql-line-height-1_15
+      line-height: 1.15
+    .ql-line-height-1_5
+      line-height: 1.5
+    .ql-line-height-2
+      line-height: 2
+    .ql-line-height-2_5
+      line-height: 2.5
+    .ql-line-height-3
+      line-height: 3
+
 
   .ql-picker
     color: inactiveColor
@@ -197,7 +210,7 @@ colorItemsPerRow = 7
       top: 100%
       z-index: 1
 
-  .ql-color-picker, .ql-icon-picker
+  .ql-color-picker, .ql-icon-picker, .ql-line-height
     width: controlHeight + 4
     .ql-picker-label
       padding: 2px 4px
@@ -222,7 +235,7 @@ colorItemsPerRow = 7
       padding: 0px
       width: colorItemSize
 
-  .ql-picker:not(.ql-color-picker):not(.ql-icon-picker)
+  .ql-picker:not(.ql-color-picker):not(.ql-icon-picker):not(.ql-line-height)
     svg
       position: absolute
       margin-top: -9px
@@ -294,6 +307,20 @@ colorItemsPerRow = 7
       font-size: 18px
     .ql-picker-item[data-value=huge]::before
       font-size: 32px
+
+  .ql-picker.ql-line-height
+    .ql-picker-item[data-value='1']::after
+      content: '1'
+    .ql-picker-item[data-value='1.15']::after
+      content: '1.15'
+    .ql-picker-item[data-value='1.5']::after
+      content: '1.5'
+    .ql-picker-item[data-value='2']::after
+      content: '2'
+    .ql-picker-item[data-value='2.5']::after
+      content: '2.5'
+    .ql-picker-item[data-value='3']::after
+      content: '3'
 
   .ql-color-picker.ql-background
     .ql-picker-item

--- a/assets/icons/line-height.svg
+++ b/assets/icons/line-height.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 18 18">
+   <path d="M9 15h9v-2H9v2zM9 3v2h9V3H9zM7.5 5L4 1.5.5 5H3v8H.5L4 16.5 7.5 13H5V5h2.5zM9 10h9V8H9v2z"/>
+</svg>

--- a/formats/lineheight.js
+++ b/formats/lineheight.js
@@ -1,0 +1,20 @@
+import { ClassAttributor, Scope } from 'parchment';
+
+const config = {
+  scope: Scope.BLOCK,
+  whitelist: ['1', '1.15', '1.5', '2', '2.5', '3'],
+};
+
+class LineHeightClass extends ClassAttributor {
+  add(node, value) {
+    if (!this.canAdd(node, value)) return false;
+    this.remove(node);
+    const underscoredValue = value.replace('.', '_');
+    node.classList.add(`${this.keyName}-${underscoredValue}`);
+    return true;
+  }
+}
+
+const LineHeight = new LineHeightClass('line-height', 'ql-line-height', config);
+
+export default LineHeight;

--- a/quill.js
+++ b/quill.js
@@ -16,6 +16,7 @@ import { BackgroundClass, BackgroundStyle } from './formats/background';
 import { ColorClass, ColorStyle } from './formats/color';
 import { FontClass, FontStyle } from './formats/font';
 import { SizeClass, SizeStyle } from './formats/size';
+import LineHeight from './formats/lineheight';
 
 import Bold from './formats/bold';
 import Italic from './formats/italic';
@@ -37,6 +38,7 @@ import Toolbar from './modules/toolbar';
 import Icons from './ui/icons';
 import Picker from './ui/picker';
 import ColorPicker from './ui/color-picker';
+import LineHeightPicker from './ui/line-height-picker';
 import IconPicker from './ui/icon-picker';
 import Tooltip from './ui/tooltip';
 
@@ -52,6 +54,7 @@ Quill.register(
     'attributors/class/color': ColorClass,
     'attributors/class/direction': DirectionClass,
     'attributors/class/font': FontClass,
+    'attributors/class/line-height': LineHeight,
     'attributors/class/size': SizeClass,
 
     'attributors/style/align': AlignStyle,
@@ -73,6 +76,7 @@ Quill.register(
     'formats/background': BackgroundStyle,
     'formats/color': ColorStyle,
     'formats/font': FontClass,
+    'formats/line-height': LineHeight,
     'formats/size': SizeClass,
 
     'formats/blockquote': Blockquote,
@@ -103,6 +107,7 @@ Quill.register(
     'ui/picker': Picker,
     'ui/icon-picker': IconPicker,
     'ui/color-picker': ColorPicker,
+    'ui/line-height-picker': LineHeightPicker,
     'ui/tooltip': Tooltip,
   },
   true,

--- a/themes/base.js
+++ b/themes/base.js
@@ -2,6 +2,7 @@ import extend from 'extend';
 import Emitter from '../core/emitter';
 import Theme from '../core/theme';
 import ColorPicker from '../ui/color-picker';
+import LineHeightPicker from '../ui/line-height-picker';
 import IconPicker from '../ui/icon-picker';
 import Picker from '../ui/picker';
 import Tooltip from '../ui/tooltip';
@@ -51,6 +52,8 @@ const FONTS = [false, 'serif', 'monospace'];
 const HEADERS = ['1', '2', '3', false];
 
 const SIZES = ['small', false, 'large', 'huge'];
+
+const LINE_HEIGHTS = ['1', '1.15', '1.5', '2', '2.5', '3'];
 
 class BaseTheme extends Theme {
   constructor(quill, options) {
@@ -131,6 +134,12 @@ class BaseTheme extends Theme {
           );
         }
         return new ColorPicker(select, icons[format]);
+      }
+      if (select.classList.contains('ql-line-height')) {
+        if (select.querySelector('option') == null) {
+          fillSelect(select, LINE_HEIGHTS);
+        }
+        return new LineHeightPicker(select, icons.lineHeight);
       }
       if (select.querySelector('option') == null) {
         if (select.classList.contains('ql-font')) {

--- a/ui/icons.js
+++ b/ui/icons.js
@@ -17,6 +17,7 @@ import italicIcon from '../assets/icons/italic.svg';
 import imageIcon from '../assets/icons/image.svg';
 import indentIcon from '../assets/icons/indent.svg';
 import outdentIcon from '../assets/icons/outdent.svg';
+import lineHeightIcon from '../assets/icons/line-height.svg';
 import linkIcon from '../assets/icons/link.svg';
 import listBulletIcon from '../assets/icons/list-bullet.svg';
 import listCheckIcon from '../assets/icons/list-check.svg';
@@ -57,6 +58,7 @@ export default {
     '+1': indentIcon,
     '-1': outdentIcon,
   },
+  lineHeight: lineHeightIcon,
   link: linkIcon,
   list: {
     bullet: listBulletIcon,

--- a/ui/line-height-picker.js
+++ b/ui/line-height-picker.js
@@ -1,0 +1,10 @@
+import Picker from './picker';
+
+class LineHeightPicker extends Picker {
+  constructor(select, label) {
+    super(select);
+    this.label.innerHTML = label;
+  }
+}
+
+export default LineHeightPicker;


### PR DESCRIPTION
Add new picker to menu that allows user to modify line-height style.

The defaults line-height values were based on defaults seen in other text editors, like MS word.

The svg is from material ui: https://www.materialui.co/icon/format-line-spacing

![quill-line-height](https://user-images.githubusercontent.com/26531374/78510410-c3d42680-7749-11ea-87a4-88c74441bd90.gif)
