### PR TITLE
Unblocks Grammarly

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -76,7 +76,6 @@ class Quill {
     instances.set(this.container, this);
     this.root = this.addContainer('ql-editor');
     this.root.classList.add('ql-blank');
-    this.root.setAttribute('data-gramm', false);
     this.scrollingContainer = this.options.scrollingContainer || this.root;
     this.emitter = new Emitter();
     const ScrollBlot = this.options.registry.query(


### PR DESCRIPTION
Hi all!
Since Grammarly now works well on Quill in all browsers, we no longer need to block it.
This PR unblocks Grammarly from integrating on Quill.