### PR TITLE
Backspace at the header beginning should keep the format

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -199,15 +199,19 @@ class Keyboard extends Module {
       // Always deleting newline here, length always 1
       const [prev] = this.quill.getLine(range.index - 1);
       if (prev) {
-        const curFormats = line.formats();
-        const prevFormats = this.quill.getFormat(range.index - 1, 1);
-        formats = AttributeMap.diff(curFormats, prevFormats) || {};
-        if (Object.keys(formats).length > 0) {
-          // line.length() - 1 targets \n in line, another -1 for newline being deleted
-          const formatDelta = new Delta()
-            .retain(range.index + line.length() - 2)
-            .retain(1, formats);
-          delta = delta.compose(formatDelta);
+        const isPrevLineEmpty =
+          prev.statics.blotName === 'block' && prev.length() <= 1;
+        if (!isPrevLineEmpty) {
+          const curFormats = line.formats();
+          const prevFormats = this.quill.getFormat(range.index - 1, 1);
+          formats = AttributeMap.diff(curFormats, prevFormats) || {};
+          if (Object.keys(formats).length > 0) {
+            // line.length() - 1 targets \n in line, another -1 for newline being deleted
+            const formatDelta = new Delta()
+              .retain(range.index + line.length() - 2)
+              .retain(1, formats);
+            delta = delta.compose(formatDelta);
+          }
         }
       }
     }


### PR DESCRIPTION
Currently, press backspace at the beginning of a header clears the header format even if the previous line is empty.

### To reproduce
1. In an empty editor, press the enter key to create a new line.
2. Enter some text and set the line as a header.
3. Place the cursor at the beginning of the line.
4. Press backspace.

### Actual
The header format is lost.

### Expected
The header format should be kept. In contrast, if the previous line is not empty (either it has content or it is set a block format like `{ header: 2 }`).

---

## Test plan
Follow the reproduce steps, make sure the result is what mentioned in the expected section above.