### PR TITLE
Update _config.yml bump to version 1.3.7

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -9,7 +9,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-redirect-from
   - jekyll-feed
-version: 1.3.6
+version: 1.3.7
 cdn: //cdn.quilljs.com/
 github: https://github.com/quilljs/quill/tree/develop/docs
 quill: quill.min.js


### PR DESCRIPTION
I've noticed the last release on the GitHub repo is 1.3.6. If I'm not mistaken, there's a correlation between the release number and the site version, so I figured this edit was needed.