### PR TITLE
Pass focus options to underlying DOM element

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -99,9 +99,9 @@ class Selection {
     });
   }
 
-  focus() {
+  focus(options = {}) {
     if (this.hasFocus()) return;
-    this.root.focus();
+    this.root.focus(options);
     this.setRange(this.savedRange);
   }
 


### PR DESCRIPTION
## Motivation

DOM API provides optional `options` parameter for controlling scroll to element behaviour of `HTMLElement.focus` method.

See https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus

## Solution 