### PR TITLE
Fix length mismatch when copying code

### DIFF
--- a/formats/code.js
+++ b/formats/code.js
@@ -13,12 +13,18 @@ class CodeBlockContainer extends Container {
     return domNode;
   }
 
-  html(index, length) {
+  code(index, length) {
     const text = this.children
-      .map(child => child.domNode.innerText)
+      .map(child => (child.length() <= 1 ? '' : child.domNode.innerText))
       .join('\n')
       .slice(index, index + length);
-    return `<pre>${escapeText(text)}</pre>`;
+    return escapeText(text);
+  }
+
+  html(index, length) {
+    // `\n`s are needed in order to support empty lines at the beginning and the end.
+    // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
+    return `<pre>\n${this.code(index, length)}\n</pre>`;
   }
 }
 

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -135,6 +135,18 @@ class SyntaxCodeBlockContainer extends CodeBlockContainer {
     }
   }
 
+  html(index, length) {
+    const [codeBlock] = this.children.find(index);
+    const language = codeBlock
+      ? SyntaxCodeBlock.formats(codeBlock.domNode)
+      : 'plain';
+
+    return `<pre data-language="${language}">\n${this.code(
+      index,
+      length,
+    )}\n</pre>`;
+  }
+
   optimize(context) {
     super.optimize(context);
     if (

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -727,9 +727,19 @@ describe('Editor', function() {
     });
 
     it('multiline code', function() {
-      const editor = this.initialize(Editor, '<p>0123</p><p>4567</p>');
-      editor.formatLine(0, 9, { 'code-block': 'javascript' });
-      expect(editor.getHTML(0, 9)).toEqual('<pre>0123\n4567</pre>');
+      const editor = this.initialize(
+        Editor,
+        '<p><br></p><p>0123</p><p><br></p><p><br></p><p>4567</p><p><br></p>',
+      );
+      const length = editor.scroll.length();
+      editor.formatLine(0, length, { 'code-block': 'javascript' });
+
+      expect(editor.getHTML(0, length)).toEqual(
+        '<pre>\n\n0123\n\n\n4567\n\n</pre>',
+      );
+      expect(editor.getHTML(1, 7)).toEqual('<pre>\n0123\n\n\n\n</pre>');
+      expect(editor.getHTML(2, 7)).toEqual('<pre>\n123\n\n\n4\n</pre>');
+      expect(editor.getHTML(5, 7)).toEqual('<pre>\n\n\n\n4567\n</pre>');
     });
   });
 });

--- a/test/unit/modules/syntax.js
+++ b/test/unit/modules/syntax.js
@@ -294,4 +294,12 @@ describe('Syntax', function() {
       });
     });
   });
+
+  describe('html', function() {
+    it('code language', function() {
+      expect(this.quill.getSemanticHTML()).toContain(
+        'data-language="javascript"',
+      );
+    });
+  });
 });


### PR DESCRIPTION
`CodeBlockContainer#html()` generates duplicated `\n` when deals with empty lines. See the test plan for reproduction steps.

This PR added a fix for that, also fixed a related issue that copying & pasting code block doesn't keep the highlighting language.

### Test Plan

1. Run `npm start`
2. Visit `http://localhost:9000/standalone/full/`
3. Copy the following code block to the editor:

```javascript

start





end

```

4. Add some plain text after the code block. See the screenshot below.
<img width="757" alt="CleanShot 2020-04-28 at 22 31 21@2x" src="https://user-images.githubusercontent.com/635902/80499812-059a6a80-89a0-11ea-970f-7ece74e1a67f.png">

5. Copy the code block in the editor and paste after the plain text.
6. Make sure the pasted code block has the same content as the original one.
7. Set a highlighting language after step 3 and try again. Make sure the pasted code block keeps the language setting.