### PR TITLE
Fix pasting in checklist does not preserve indentation

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -414,7 +414,7 @@ function matchIndent(node, delta, scroll) {
   }
   if (indent <= 0) return delta;
   return delta.reduce((composed, op) => {
-    if (op.attributes && op.attributes.list) {
+    if (op.attributes && typeof op.attributes.indent === 'number') {
       return composed.push(op);
     }
     return composed.insert(op.insert, { indent, ...(op.attributes || {}) });

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -203,6 +203,20 @@ describe('Clipboard', function() {
       );
     });
 
+    it('html nested checklist', function() {
+      const delta = this.clipboard.convert({
+        html:
+          '<ul><li data-list="checked">One<ul><li data-list="checked">Alpha</li><li data-list="checked">Beta' +
+          '<ul><li data-list="checked">I</li></ul></li></ul></li></ul>',
+      });
+      expect(delta).toEqual(
+        new Delta()
+          .insert('One\n', { list: 'checked' })
+          .insert('Alpha\nBeta\n', { list: 'checked', indent: 1 })
+          .insert('I\n', { list: 'checked', indent: 2 }),
+      );
+    });
+
     it('html partial list', function() {
       const delta = this.clipboard.convert({
         html:


### PR DESCRIPTION
**To reproduce:**
1. Run `npm start` and open http://localhost:9000/standalone/full/
2. Add `<button class="ql-list" value="unchecked"></button>` to full.html so we can have a button to set list style to unchecked.
3. Use the button to create a checklist with some nested items.
4. Copy & paste the whole list.

**Expected:**
The indentation should be preserved.

**Actual:**
The indentation is lost.

-----
**Test Plan**

Follow the reproducible steps above, make sure it works as expected.