### PR TITLE
added const, checks to handle and set dataSize limits

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -171,9 +171,17 @@ BaseTheme.DEFAULTS = merge({}, Theme.DEFAULTS, {
             );
             fileInput.classList.add('ql-image');
             fileInput.addEventListener('change', () => {
-              const range = this.quill.getSelection(true);
-              this.quill.uploader.upload(range, fileInput.files);
-              fileInput.value = '';
+              const maxFilesize = this.quill.options.image.maxFilesize || 0;
+              const fileSize = fileInput.files[0].size; 
+              
+              if (maxFilesize === 0 || fileSize > maxFilesize) {
+                const range = this.quill.getSelection(true);
+                this.quill.uploader.upload(range, fileInput.files);
+                fileInput.value = '';
+              } else {
+                this.quill.options.image.errorHandler(fileSize);
+                fileInput.parentNode.removeChild(fileInput);
+              }
             });
             this.container.appendChild(fileInput);
           }


### PR DESCRIPTION
quill right now doesn't limit the size of uploaded files, slowing down the parent app.  

with this implementation the user can set a maximum size for the file, and assign a custom error handler if the uploaded file is  too large. 

the maxFileSize and error handler can be defined as follows: 


![](https://user-images.githubusercontent.com/55330111/84163470-d3395e00-aa71-11ea-8dce-9d0371fcc65a.png)

where the filesize is defined in bytes