### PR TITLE
Keep list numbers continuous when separated by certain elements

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -39,7 +39,7 @@ resets(arr)
 
 .ql-editor
   box-sizing: border-box
-  counter-reset: list-0
+  counter-reset: resets(0..MAX_INDENT)
   line-height: 1.42
   height: 100%
   outline: none
@@ -90,7 +90,10 @@ resets(arr)
     content: '\2610'
 
   li[data-list=ordered]
-    counter-reset: resets(1..MAX_INDENT)
+    @supports (counter-set: none)
+      counter-set: resets(1..MAX_INDENT)
+    @supports not (counter-set: none)
+      counter-reset: resets(1..MAX_INDENT)
     counter-increment: list-0
     > .ql-ui:before
       content: unquote('counter(list-0, ' + LIST_STYLE[0] + ')') '. '
@@ -101,7 +104,10 @@ resets(arr)
         content: unquote('counter(list-' + num + ', ' + LIST_STYLE[num%3] + ')') '. '
     if (num < MAX_INDENT)
       li[data-list=ordered].ql-indent-{num}
-        counter-reset: resets((num+1)..MAX_INDENT)
+        @supports (counter-set: none)
+          counter-set: resets((num+1)..MAX_INDENT)
+        @supports not (counter-set: none)
+          counter-reset: resets((num+1)..MAX_INDENT)
 
   for num in (1..MAX_INDENT)
     .ql-indent-{num}:not(.ql-direction-rtl)


### PR DESCRIPTION
Currently, blocks (except p and headings) reset inner lists' numbers, which is caused by `counter-reset`. The intention was to use `counter-reset` to reset number values to 0 but there's a side effect that can create a new counter.

This change uses `counter-set` instead to avoid the side effect.

Test plan:
In supported browsers, make sure the list number shows correctly as the following screenshot:
![CleanShot 2020-07-03 at 00 20 14@2x](https://user-images.githubusercontent.com/635902/86385541-06fb5280-bcc3-11ea-95d2-fa0eb374b9d6.png)

In other browsers, the numbers should not change.
