### PR TITLE
Handle native undo/redo

### DIFF
--- a/modules/history.js
+++ b/modules/history.js
@@ -33,6 +33,16 @@ class History extends Module {
         this.redo.bind(this),
       );
     }
+
+    this.quill.root.addEventListener('beforeinput', event => {
+      if (event.inputType === 'historyUndo') {
+        this.undo();
+        event.preventDefault();
+      } else if (event.inputType === 'historyRedo') {
+        this.redo();
+        event.preventDefault();
+      }
+    });
   }
 
   change(source, dest) {


### PR DESCRIPTION
Currently, our editor listens on the common hotkeys (cmd+z / cmd+shift+z) for undo/redo but the user could always undo using native browser UI like right-click, the edit topbar menu, and on mobile iOS there is a toolbar, and the native undo usually does not do the right thing.

Most modern browsers support using `beforeinput` to interrupt native undo/redo inputs so we'll use this to handle them natively. Firefox supports this event since v74 but hasn't enabled it by default.

To test:

* Insert some text, make some chars bold.
* Click Undo in the context menu, make sure the chars are unbold. Click undo again should remove the text.
* For Firefox, it should behave the same as before.

