### PR TITLE
Multiple namespaces support for registries and imports

### DIFF
--- a/core.js
+++ b/core.js
@@ -14,7 +14,7 @@ import History from './modules/history';
 import Keyboard from './modules/keyboard';
 import Uploader from './modules/uploader';
 
-Quill.register({
+Object.assign(Quill.defaultDefinitions, {
   'blots/block': Block,
   'blots/block/embed': BlockEmbed,
   'blots/break': Break,

--- a/core/quill.js
+++ b/core/quill.js
@@ -91,7 +91,7 @@ class Quill {
         registry.register(target);
       }
       if (typeof target.register === 'function') {
-        target.register(namespace);
+        target.register(options);
       }
     }
   }

--- a/core/theme.js
+++ b/core/theme.js
@@ -14,7 +14,9 @@ class Theme {
   }
 
   addModule(name) {
-    const ModuleClass = this.quill.constructor.import(`modules/${name}`);
+    const ModuleClass = this.quill.constructor.import(`modules/${name}`, {
+      namespace: this.options.namespace,
+    });
     this.modules[name] = new ModuleClass(
       this.quill,
       this.options.modules[name] || {},

--- a/docs/guides/how-to-customize-quill.md
+++ b/docs/guides/how-to-customize-quill.md
@@ -147,6 +147,4 @@ var quill = new Quill('#editor', {
 });
 ```
 
-You can view a list of Blots and Attributors available by calling `console.log(Quill.imports);`. Direct modification of this object is not supported. Use [`Quill.register`](/docs/api/#register) instead.
-
 A complete reference on Parchment, Blots and Attributors can be found on Parchment's own [README](https://github.com/quilljs/parchment/). For an in-depth walkthrough, take a look at [Cloning Medium with Parchment](/guides/cloning-medium-with-parchment/), which starts with Quill understanding just plain text, to adding all of the formats [Medium](https://medium.com/) supports. Most of the time, you will not have to build formats from scratch since most are already implemented in Quill, but it is still useful to understanding how Quill works at this deeper level.

--- a/formats/code.js
+++ b/formats/code.js
@@ -29,8 +29,8 @@ class CodeBlockContainer extends Container {
 }
 
 class CodeBlock extends Block {
-  static register() {
-    Quill.register(CodeBlockContainer);
+  static register(namespace) {
+    Quill.register(CodeBlockContainer, { namespace });
   }
 }
 

--- a/formats/code.js
+++ b/formats/code.js
@@ -29,8 +29,8 @@ class CodeBlockContainer extends Container {
 }
 
 class CodeBlock extends Block {
-  static register(namespace) {
-    Quill.register(CodeBlockContainer, { namespace });
+  static register(options) {
+    Quill.register(CodeBlockContainer, options);
   }
 }
 

--- a/formats/list.js
+++ b/formats/list.js
@@ -17,8 +17,8 @@ class ListItem extends Block {
     return domNode.getAttribute('data-list') || undefined;
   }
 
-  static register() {
-    Quill.register(ListContainer);
+  static register(namespace) {
+    Quill.register(ListContainer, { namespace });
   }
 
   constructor(scroll, domNode) {

--- a/formats/list.js
+++ b/formats/list.js
@@ -17,8 +17,8 @@ class ListItem extends Block {
     return domNode.getAttribute('data-list') || undefined;
   }
 
-  static register(namespace) {
-    Quill.register(ListContainer, { namespace });
+  static register(options) {
+    Quill.register(ListContainer, options);
   }
 
   constructor(scroll, domNode) {

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -166,10 +166,10 @@ SyntaxCodeBlock.requiredContainer = SyntaxCodeBlockContainer;
 SyntaxCodeBlock.allowedChildren = [CodeToken, CursorBlot, TextBlot, BreakBlot];
 
 class Syntax extends Module {
-  static register() {
-    Quill.register(CodeToken, true);
-    Quill.register(SyntaxCodeBlock, true);
-    Quill.register(SyntaxCodeBlockContainer, true);
+  static register(namespace) {
+    Quill.register(CodeToken, { namespace, overwrite: true });
+    Quill.register(SyntaxCodeBlock, { namespace, overwrite: true });
+    Quill.register(SyntaxCodeBlockContainer, { namespace, overwrite: true });
   }
 
   constructor(quill, options) {

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -166,10 +166,10 @@ SyntaxCodeBlock.requiredContainer = SyntaxCodeBlockContainer;
 SyntaxCodeBlock.allowedChildren = [CodeToken, CursorBlot, TextBlot, BreakBlot];
 
 class Syntax extends Module {
-  static register(namespace) {
-    Quill.register(CodeToken, { namespace, overwrite: true });
-    Quill.register(SyntaxCodeBlock, { namespace, overwrite: true });
-    Quill.register(SyntaxCodeBlockContainer, { namespace, overwrite: true });
+  static register(options) {
+    Quill.register(CodeToken, { ...options, overwrite: true });
+    Quill.register(SyntaxCodeBlock, { ...options, overwrite: true });
+    Quill.register(SyntaxCodeBlockContainer, { ...options, overwrite: true });
   }
 
   constructor(quill, options) {

--- a/modules/table.js
+++ b/modules/table.js
@@ -10,11 +10,11 @@ import {
 } from '../formats/table';
 
 class Table extends Module {
-  static register() {
-    Quill.register(TableCell);
-    Quill.register(TableRow);
-    Quill.register(TableBody);
-    Quill.register(TableContainer);
+  static register(namespace) {
+    Quill.register(TableCell, { namespace });
+    Quill.register(TableRow, { namespace });
+    Quill.register(TableBody, { namespace });
+    Quill.register(TableContainer, { namespace });
   }
 
   constructor(...args) {

--- a/modules/table.js
+++ b/modules/table.js
@@ -10,11 +10,11 @@ import {
 } from '../formats/table';
 
 class Table extends Module {
-  static register(namespace) {
-    Quill.register(TableCell, { namespace });
-    Quill.register(TableRow, { namespace });
-    Quill.register(TableBody, { namespace });
-    Quill.register(TableContainer, { namespace });
+  static register(options) {
+    Quill.register(TableCell, options);
+    Quill.register(TableRow, options);
+    Quill.register(TableBody, options);
+    Quill.register(TableContainer, options);
   }
 
   constructor(...args) {

--- a/test/helpers/unit.js
+++ b/test/helpers/unit.js
@@ -3,7 +3,7 @@ import Editor from '../../core/editor';
 import Emitter from '../../core/emitter';
 import Selection from '../../core/selection';
 import Scroll from '../../blots/scroll';
-import Quill, { globalRegistry } from '../../core/quill';
+import Quill from '../../core/quill';
 
 const div = document.createElement('div');
 div.id = 'test-container';
@@ -124,7 +124,9 @@ function initialize(klass, html, container = this.container, options = {}) {
   if (klass === HTMLElement) return container;
   if (klass === Quill) return new Quill(container, options);
   const emitter = new Emitter();
-  const scroll = new Scroll(globalRegistry, container, { emitter });
+  const scroll = new Scroll(Quill.getNamespace().registry, container, {
+    emitter,
+  });
   if (klass === Scroll) return scroll;
   if (klass === Editor) return new Editor(scroll);
   if (klass === Selection) return new Selection(scroll, emitter);

--- a/test/unit.js
+++ b/test/unit.js
@@ -13,6 +13,7 @@ import './unit/blots/inline';
 import './unit/core/editor';
 import './unit/core/selection';
 import './unit/core/quill';
+import './unit/core/theme';
 
 import './unit/formats/color';
 import './unit/formats/link';

--- a/test/unit.js
+++ b/test/unit.js
@@ -37,7 +37,6 @@ import './unit/ui/picker';
 import './unit/theme/base/tooltip';
 
 // Syntax version will otherwise be registered
-Quill.register(CodeBlockContainer, true);
 Quill.register(CodeBlock, true);
 
 export default Quill;

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -5,14 +5,9 @@ import Emitter from '../../../core/emitter';
 import Toolbar from '../../../modules/toolbar';
 import Snow from '../../../themes/snow';
 import { Range } from '../../../core/selection';
+import Bold from '../../../formats/bold';
 
 describe('Quill', function() {
-  it('imports', function() {
-    Object.keys(Quill.imports).forEach(function(path) {
-      expect(Quill.import(path)).toBeTruthy();
-    });
-  });
-
   describe('construction', function() {
     it('empty', function() {
       const quill = this.initialize(Quill, '');
@@ -41,6 +36,42 @@ describe('Quill', function() {
         new Delta().insert('Test').insert('\n', { align: 'center' }),
       );
       expect(quill.root).toEqualHTML('<p class="ql-align-center">Test</p>');
+    });
+  });
+
+  describe('namespaces', function() {
+    it('has a default namespace', function() {
+      const { imports } = Quill.getNamespace();
+      Object.keys(imports).forEach(function(path) {
+        expect(Quill.import(path)).toBeTruthy();
+      });
+
+      Object.keys(Quill.defaultDefinitions).forEach(function(path) {
+        expect(Quill.import(path)).toBeTruthy();
+      });
+    });
+
+    it('accepts other namespaces', function() {
+      const namespace = 'myspace';
+
+      const { defaultDefinitions } = Quill;
+      Quill.defaultDefinitions = {};
+      const { imports } = Quill.getNamespace(namespace);
+      Quill.defaultDefinitions = defaultDefinitions;
+
+      expect(Object.keys(imports).length).toEqual(0);
+      Quill.register(Bold, { namespace });
+      expect(Object.keys(imports).length).toEqual(1);
+
+      class CustomBlot extends Bold {}
+      CustomBlot.blotName = 'customBlot';
+      Quill.register(CustomBlot, { namespace });
+      expect(Quill.import(`formats/${CustomBlot.blotName}`)).toBeFalsy();
+      expect(
+        Quill.import(`formats/${CustomBlot.blotName}`, {
+          namespace,
+        }),
+      ).toBeTruthy();
     });
   });
 

--- a/test/unit/core/theme.js
+++ b/test/unit/core/theme.js
@@ -1,0 +1,17 @@
+import Theme from '../../../core/theme';
+import Quill from '../../../core';
+import Module from '../../../core/module';
+
+describe('Theme', function() {
+  it('imports modules from correct namespace', function() {
+    const namespace = 'theme';
+    const quill = this.initialize(Quill, '');
+    const theme = new Theme(quill, { namespace, modules: {} });
+    class CustomModule extends Module {}
+
+    const moduleName = 'theme-test-module';
+    Quill.register(`modules/${moduleName}`, CustomModule, { namespace });
+
+    expect(theme.addModule(moduleName)).toBeInstanceOf(CustomModule);
+  });
+});

--- a/test/unit/modules/history.js
+++ b/test/unit/modules/history.js
@@ -1,13 +1,14 @@
 import Delta from 'quill-delta';
 import Quill from '../../../core';
-import { globalRegistry } from '../../../core/quill';
 import { getLastChangeIndex } from '../../../modules/history';
+
+const { registry } = Quill.getNamespace();
 
 describe('History', function() {
   describe('getLastChangeIndex', function() {
     it('delete', function() {
       const delta = new Delta().retain(4).delete(2);
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(4);
+      expect(getLastChangeIndex(registry, delta)).toEqual(4);
     });
 
     it('delete with inserts', function() {
@@ -15,17 +16,17 @@ describe('History', function() {
         .retain(4)
         .insert('test')
         .delete(2);
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(8);
+      expect(getLastChangeIndex(registry, delta)).toEqual(8);
     });
 
     it('insert text', function() {
       const delta = new Delta().retain(4).insert('testing');
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(11);
+      expect(getLastChangeIndex(registry, delta)).toEqual(11);
     });
 
     it('insert embed', function() {
       const delta = new Delta().retain(4).insert({ image: true });
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(5);
+      expect(getLastChangeIndex(registry, delta)).toEqual(5);
     });
 
     it('insert with deletes', function() {
@@ -33,34 +34,34 @@ describe('History', function() {
         .retain(4)
         .delete(3)
         .insert('!');
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(5);
+      expect(getLastChangeIndex(registry, delta)).toEqual(5);
     });
 
     it('format', function() {
       const delta = new Delta().retain(4).retain(3, { bold: true });
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(7);
+      expect(getLastChangeIndex(registry, delta)).toEqual(7);
     });
 
     it('format newline', function() {
       const delta = new Delta().retain(4).retain(1, { align: 'left' });
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(4);
+      expect(getLastChangeIndex(registry, delta)).toEqual(4);
     });
 
     it('format mixed', function() {
       const delta = new Delta()
         .retain(4)
         .retain(1, { align: 'left', bold: true });
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(4);
+      expect(getLastChangeIndex(registry, delta)).toEqual(4);
     });
 
     it('insert newline', function() {
       const delta = new Delta().retain(4).insert('a\n');
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(5);
+      expect(getLastChangeIndex(registry, delta)).toEqual(5);
     });
 
     it('mutliple newline inserts', function() {
       const delta = new Delta().retain(4).insert('ab\n\n');
-      expect(getLastChangeIndex(globalRegistry, delta)).toEqual(7);
+      expect(getLastChangeIndex(registry, delta)).toEqual(7);
     });
   });
 


### PR DESCRIPTION
## Background
There're potential use cases that require displaying multiple Quill instances on the same page (either literally in the same view or SPAs). The instances may understand different format-set. A typical example is a wiki system that will have a Quill instance as the main editor with support of advanced formats whereas another instance as the comment editor which only supports links.

## Solution
This PR introduces namespace to create different feature scopes. Namely, for existing usages:

1. Registering formats/modules will be `Quill.register(LinkBlot, { namespace: 'comment' })` instead of `Quill.register(LinkBlot)`. The `overwrite` parameter should be passed via the option: `Quill.register(LinkBlot, { namespace: 'comment', overwrite: true })`. We still support boolean value as override for backward compatibility.

2. Importing formats/modules will be `Quill.import('formats/link', { namespace: 'comment' })` instead of `Quill.import('formats/link')`.

3. Creating a Quill instance can pass the `namespace` option (ex `new Quill({ namespace: 'comment' })`) to specify which format-set should be used. **All the three usages above can omit `namespace` and it will default to an internal default namespace. It worth noticing that the default namespace doesn't have hierarchical relations with custom ones so if users are going to create a new namespace, they are expected to register formats from nothing.

4. `Quill.defaultDefinitions` defines all "must-have" formats/modules like `Text` and `Uploader`. Every time a new namespace is created, it will be registered with all formats/modules in this list. What's more, given most users will likely just want to use Quill with default feature-set, to avoid boilerplate, we register some advanced formats (ex align, color, indent, list) to the default namespace so `new Quill()` will have all formats as our official demo.

3. The signature of `Blot.register(registry: Registry)` will change to `Blot.registry(options: { namespace: string, overwrite: boolean })` so blots/modules can use the options to register in the same namespace.

4. **Breaking change**. `Quill.imports` and `Quill#options.registry` will be removed in favor of `Quill.getNamespace('comment').imports` and `Quill.getNamespace('comment').registry` to add namespace support. Again, `'comment'` can be omitted to use the default namespace.

5. `Quill.find()` doesn't seem to necessarily need a namespace as it's unlikely a dom node belongs to multiple Quill instances, and we're simply delegating the calls to a static method `Registry#find()`.

## Test plan

1. http://localhost:9000/standalone/full/ should work as expected.
