### PR TITLE
Improve parsing of text-decoration styles

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -454,10 +454,10 @@ function matchStyles(node, delta) {
   if (style.fontStyle === 'italic') {
     formats.italic = true;
   }
-  if (style.textDecoration === 'underline') {
+  if (style.textDecoration.indexOf('underline') !== -1) {
     formats.underline = true;
   }
-  if (style.textDecoration === 'line-through') {
+  if (style.textDecoration.indexOf('line-through') !== -1) {
     formats.strike = true;
   }
   if (

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -329,6 +329,23 @@ describe('Clipboard', function() {
       expect(delta).toEqual(new Delta().insert('Test', { color: 'blue' }));
     });
 
+    it('text decoration', function() {
+      const delta = this.clipboard.convert({
+        html: `
+        <span style="text-decoration: underline;">underline</span>
+        <span style="text-decoration: line-through;">strike</span>
+        <span style="text-decoration: underline line-through;">mixed</span>
+        `,
+      });
+
+      expect(delta).toEqual(
+        new Delta()
+          .insert('underline', { underline: true })
+          .insert('strike', { strike: true })
+          .insert('mixed', { strike: true, underline: true }),
+      );
+    });
+
     it('custom matcher', function() {
       this.clipboard.addMatcher(Node.TEXT_NODE, function(node, delta) {
         let index = 0;


### PR DESCRIPTION
>The text-decoration property is specified as one **or more space-separated values** representing the various longhand text-decoration properties.

[MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)

The current implementation of the [clipboard](https://github.com/quilljs/quill/blob/develop/modules/clipboard.js#L457) module does not take into account the fact that more than one decorator can be used, for example:

```html
<span style="text-decoration: underline line-through;">mixed</span
```

It fixes #2585 