### PR TITLE
style: make quill button styles applied to .ql-formats only

### DIFF
--- a/assets/base.styl
+++ b/assets/base.styl
@@ -15,38 +15,40 @@ colorItemsPerRow = 7
     content: ''
     display: table
 
-  button
-    background: none
-    border: none
-    cursor: pointer
-    display: inline-block
-    float: left
-    height: controlHeight
-    padding: inputPaddingHeight inputPaddingWidth
-    width: controlHeight + (inputPaddingWidth - inputPaddingHeight)*2
-
-    svg
+  .ql-formats
+    button
+      background: none
+      border: none
+      cursor: pointer
+      display: inline-block
       float: left
-      height: 100%
+      height: controlHeight
+      padding: inputPaddingHeight inputPaddingWidth
+      width: controlHeight + (inputPaddingWidth - inputPaddingHeight)*2
 
-    &:active:hover
-      outline: none
+      svg
+        float: left
+        height: 100%
+
+      &:active:hover
+        outline: none
 
   input.ql-image[type=file]
     display: none
 
-  button:hover, button:focus, button.ql-active,
-  .ql-picker-label:hover, .ql-picker-label.ql-active,
-  .ql-picker-item:hover, .ql-picker-item.ql-selected
-    color: activeColor
-    .ql-fill, .ql-stroke.ql-fill
-      fill: activeColor
-    .ql-stroke, .ql-stroke-miter
-      stroke: activeColor
+  .ql-formats
+    button:hover, button:focus, button.ql-active,
+    .ql-picker-label:hover, .ql-picker-label.ql-active,
+    .ql-picker-item:hover, .ql-picker-item.ql-selected
+      color: activeColor
+      .ql-fill, .ql-stroke.ql-fill
+        fill: activeColor
+      .ql-stroke, .ql-stroke-miter
+        stroke: activeColor
 
 // Fix for iOS not losing hover on touch
 @media (pointer: coarse)
-  .ql-{themeName}.ql-toolbar, .ql-{themeName} .ql-toolbar
+  .ql-{themeName}.ql-toolbar .ql-formats, .ql-{themeName} .ql-toolbar .ql-formats
     button:hover:not(.ql-active)
       color: inactiveColor
       .ql-fill, .ql-stroke.ql-fill


### PR DESCRIPTION
The styles that are defined in the quill theme style use `button` selector. In fact these selectors are for format buttons. If you design your custom toolbar but still want to use quill styles in it there may be a problem if you have some other buttons that have a bit different role than format buttons on the toolbar. I suggest to use a stricter selector for the style by default to only apply the button formatting for the buttons with `ql-formats` class. I don't expect any other types of buttons to be there with default quill. And I think that if there are some toolbar customization that adds other button types inside the toolbar DOM it's better to leave the developer to add the styles rather than add the styles and force the developer to "cancel" the styles from Quill where they are not needed.