### PR TITLE
Fix missing Quill.find bubble parameter

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -20,8 +20,8 @@ class Quill {
     logger.level(limit);
   }
 
-  static find(node) {
-    return node.__quill || Parchment.find(node);
+  static find(node, bubble) {
+    return node.__quill || Parchment.find(node, bubble);
   }
 
   static import(name) {


### PR DESCRIPTION
Fix `Quill.find` signature to match documentation:
https://quilljs.com/docs/api/#find-experimental