### PR TITLE
Use latest quill-delta 4.2.2 with quill@1.3.7

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -1,5 +1,5 @@
 import Delta from 'quill-delta';
-import DeltaOp from 'quill-delta/lib/op';
+import AttributeMap from 'quill-delta/dist/AttributeMap';
 import Parchment from 'parchment';
 import CodeBlock from '../formats/code';
 import CursorBlot from '../blots/cursor';
@@ -45,7 +45,7 @@ class Editor {
             let [leaf, ] = line.descendant(Parchment.Leaf, offset);
             formats = extend(formats, bubbleFormats(leaf));
           }
-          attributes = DeltaOp.attributes.diff(formats, attributes) || {};
+          attributes = AttributeMap.diff(formats, attributes) || {};
         } else if (typeof op.insert === 'object') {
           let key = Object.keys(op.insert)[0];  // There should only be one key
           if (key == null) return index;

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -2,7 +2,7 @@ import clone from 'clone';
 import equal from 'deep-equal';
 import extend from 'extend';
 import Delta from 'quill-delta';
-import DeltaOp from 'quill-delta/lib/op';
+import AttributeMap from 'quill-delta/dist/AttributeMap';
 import Parchment from 'parchment';
 import Quill from '../core/quill';
 import logger from '../core/logger';
@@ -344,7 +344,7 @@ function handleBackspace(range, context) {
     if (prev != null && prev.length() > 1) {
       let curFormats = line.formats();
       let prevFormats = this.quill.getFormat(range.index-1, 1);
-      formats = DeltaOp.attributes.diff(curFormats, prevFormats) || {};
+      formats = AttributeMap.diff(curFormats, prevFormats) || {};
     }
   }
   // Check for astral symbols
@@ -367,7 +367,7 @@ function handleDelete(range, context) {
     if (next) {
       let curFormats = line.formats();
       let nextFormats = this.quill.getFormat(range.index, 1);
-      formats = DeltaOp.attributes.diff(curFormats, nextFormats) || {};
+      formats = AttributeMap.diff(curFormats, nextFormats) || {};
       nextLength = next.length();
     }
   }
@@ -383,7 +383,7 @@ function handleDeleteRange(range) {
   if (lines.length > 1) {
     let firstFormats = lines[0].formats();
     let lastFormats = lines[lines.length - 1].formats();
-    formats = DeltaOp.attributes.diff(lastFormats, firstFormats) || {};
+    formats = AttributeMap.diff(lastFormats, firstFormats) || {};
   }
   this.quill.deleteText(range, Quill.sources.USER);
   if (Object.keys(formats).length > 0) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eventemitter3": "^2.0.3",
     "extend": "^3.0.2",
     "parchment": "^1.1.4",
-    "quill-delta": "^3.6.2"
+    "quill-delta": "^4.2.2"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
**quill-delta** package since 3.6.3 version has a number of useful improvements like `invert` method and the latest 'fast-diff' library. See [CHANGELOG](https://github.com/quilljs/delta/blob/master/CHANGELOG.md). But **quill@1.3.7**, which is currently the latest "stable" version, still depends on **3.6.3**. 

With this pull-request, I would like to make **quill@1.3.7** use the latest quill-delta version.