### PR TITLE
bugfix: properly update font size label when selecting default sized …

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -115,7 +115,8 @@ class Toolbar extends Module {
         if (range == null) {
           option = null;
         } else if (formats[format] == null) {
-          option = input.querySelector('option[selected]');
+          option = Array.from(input.querySelectorAll('option')).filter((option) => option.getAttribute("value") === '');
+          option = option.length > 0 ? option[0] : input.querySelector('option[selected]');
         } else if (!Array.isArray(formats[format])) {
           let value = formats[format];
           if (typeof value === 'string') {


### PR DESCRIPTION
…text

## steps to reproduce bug:
1. write some text in default font size
2. write another text in different font size (for example "big")
3. select first text (the one with the default font size)
## expected:
- font size label should display "default" 
## actual:
- font size label displays the font size of the previously selected text (in the example "big")

This PR fixes this bug.