### PR TITLE
Ignore mutations happens in nested Quill instance

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -164,6 +164,10 @@ class Scroll extends ScrollBlot {
     if (!Array.isArray(mutations)) {
       mutations = this.observer.takeRecords();
     }
+    mutations = mutations.filter(({ target }) => {
+      const blot = this.find(target, true);
+      return blot && blot.scroll === this;
+    });
     if (mutations.length > 0) {
       this.emitter.emit(Emitter.events.SCROLL_BEFORE_UPDATE, source, mutations);
     }


### PR DESCRIPTION
Closes #1847

Previously, mutations generated inside nested Quill instances will be also handled by the parent, which is not expected.

This PR checks whether the scrolls of the blots are the current one and will ignore them if that isn't the case.