### PR TITLE
Do not update toolbar when selection was lost

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -34,7 +34,7 @@ class Toolbar extends Module {
       },
     );
     this.quill.on(Quill.events.EDITOR_CHANGE, (type, range) => {
-      if (type === Quill.events.SELECTION_CHANGE) {
+      if (range != null && type === Quill.events.SELECTION_CHANGE) {
         this.update(range);
       }
     });


### PR DESCRIPTION
This fixes an issue in Chromium and Chrome: When the toolbar size selection is opened, the selection of the text is lost and the size selection does not show the currently selected size.

In Icecat (Firefox 78) the text selection is not lost upon opening the size selection, therefore the issue does not appear.