### PR TITLE
Make side-bar container in API docs 'position: sticky'

### DIFF
--- a/docs/1.0/docs/api/contents.md
+++ b/docs/1.0/docs/api/contents.md
@@ -7,7 +7,7 @@ Deletes text from the editor, returning a [Delta](/guides/working-with-deltas/) 
 **Methods**
 
 ```javascript
-deleteText(index: Number, length: Number, source: String = 'api'): Delta
+deleteText(index: number, length: number, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -23,7 +23,7 @@ Retrieves contents of the editor, with formatting data, represented by a [Delta]
 **Methods**
 
 ```javascript
-getContents(index: Number = 0, length: Number = remaining): Delta
+getContents(index: number = 0, length: number = remaining): Delta
 ```
 
 **Examples**
@@ -39,7 +39,7 @@ Retrieves the length of the editor contents. Note even when Quill is empty, ther
 **Methods**
 
 ```javascript
-getLength(): Number
+getLength(): number
 ```
 
 **Examples**
@@ -57,7 +57,7 @@ The `length` parameter defaults to the length of the remaining document.
 **Methods**
 
 ```javascript
-getText(index: Number = 0, length: Number = remaining): String
+getText(index: number = 0, length: number = remaining): string
 ```
 
 **Examples**
@@ -73,7 +73,7 @@ Insert embedded content into the editor, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-insertEmbed(index: Number, type: String, value: any, source: String = 'api'): Delta
+insertEmbed(index: number, type: string, value: any, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -89,11 +89,11 @@ Inserts text into the editor, optionally with a specified format or multiple [fo
 **Methods**
 
 ```javascript
-insertText(index: Number, text: String, source: String = 'api'): Delta
-insertText(index: Number, text: String, format: String, value: any,
-           source: String = 'api'): Delta
-insertText(index: Number, text: String, formats: { [String]: any },
-           source: String = 'api'): Delta
+insertText(index: number, text: string, source: string = 'api'): Delta
+insertText(index: number, text: string, format: string, value: any,
+           source: string = 'api'): Delta
+insertText(index: number, text: string, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -114,7 +114,7 @@ Overwrites editor with given contents. Contents should end with a [newline](/1.0
 **Methods**
 
 ```javascript
-setContents(delta: Delta, source: String = 'api'): Delta
+setContents(delta: Delta, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -134,7 +134,7 @@ Sets contents of editor with given text, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-setText(text: String, source: String = 'api'): Delta
+setText(text: string, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -150,7 +150,7 @@ Applies Delta to editor contents, returning a [Delta](/guides/working-with-delta
 **Methods**
 
 ```javascript
-updateContents(delta: Delta, source: String = 'api'): Delta
+updateContents(delta: Delta, source: string = 'api'): Delta
 ```
 
 **Examples**

--- a/docs/1.0/docs/api/editor.md
+++ b/docs/1.0/docs/api/editor.md
@@ -76,7 +76,7 @@ Synchronously check editor for user updates and fires events, if changes have oc
 **Methods**
 
 ```javascript
-update(source: String = 'user')
+update(source: string = 'user')
 ```
 
 **Examples**

--- a/docs/1.0/docs/api/events.md
+++ b/docs/1.0/docs/api/events.md
@@ -18,7 +18,7 @@ Changes to text may cause changes to the selection (ex. typing advances the curs
 **Callback Signature**
 
 ```javascript
-handler(delta: Delta, oldContents: Delta, source: String)
+handler(delta: Delta, oldContents: Delta, source: string)
 ```
 
 **Examples**
@@ -44,7 +44,7 @@ APIs causing the selection to change may also be called with a `"silent"` source
 ```javascript
 handler(range: { index: Number, length: Number },
         oldRange: { index: Number, length: Number },
-        source: String)
+        source: string)
 ```
 
 **Examples**
@@ -71,7 +71,7 @@ Emitted when either `text-change` or `selection-change` would be emitted, even w
 **Callback Signature**
 
 ```javascript
-handler(name: String, ...args)
+handler(name: string, ...args)
 ```
 
 **Examples**
@@ -93,7 +93,7 @@ Adds event handler. See [text-change](#text-change) or [selection-change](#selec
 **Methods**
 
 ```javascript
-on(name: String, handler: Function): Quill
+on(name: string, handler: Function): Quill
 ```
 
 **Examples**
@@ -112,7 +112,7 @@ Adds handler for one emission of an event. See [text-change](#text-change) or [s
 **Methods**
 
 ```javascript
-once(name: String, handler: Function): Quill
+once(name: string, handler: Function): Quill
 ```
 
 **Examples**
@@ -130,7 +130,7 @@ Removes event handler.
 **Methods**
 
 ```javascript
-off(name: String, handler: Function): Quill
+off(name: string, handler: Function): Quill
 ```
 
 **Examples**

--- a/docs/1.0/docs/api/extension.md
+++ b/docs/1.0/docs/api/extension.md
@@ -7,7 +7,7 @@ Static method enabling logging messages at a given level: `'error'`, `'warn'`, `
 **Methods**
 
 ```javascript
-Quill.debug(level: String | Boolean)
+Quill.debug(level: string | Boolean)
 ```
 
 **Examples**
@@ -45,8 +45,8 @@ Registers a module, theme, or format(s), making them available to be added to an
 
 ```javascript
 Quill.register(format: Attributor | BlotDefinintion, supressWarning: Boolean = false)
-Quill.register(path: String, def: any, supressWarning: Boolean = false)
-Quill.register(defs: { [String]: any }, supressWarning: Boolean = false)
+Quill.register(path: string, def: any, supressWarning: Boolean = false)
+Quill.register(defs: { [key: string]: any }, supressWarning: Boolean = false)
 ```
 
 **Examples**
@@ -77,7 +77,7 @@ Adds and returns a container element inside the Quill container, sibling to the 
 **Methods**
 
 ```javascript
-addContainer(className: String, refNode?: Node): Element
+addContainer(className: string, refNode?: Node): Element
 addContainer(domNode: Node, refNode?: Node): Element
 ```
 
@@ -95,7 +95,7 @@ Retrieves a module that has been added to the editor.
 **Methods**
 
 ```javascript
-getModule(name: String): any
+getModule(name: string): any
 ```
 
 **Examples**

--- a/docs/1.0/docs/api/formatting.md
+++ b/docs/1.0/docs/api/formatting.md
@@ -7,7 +7,7 @@ Format text at user's current selection, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-format(name: String, value: any, source: String = 'api'): Delta
+format(name: string, value: any, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -24,11 +24,11 @@ Formats all lines in given range, returning a [Delta](/guides/working-with-delta
 **Methods**
 
 ```javascript
-formatLine(index: Number, length: Number, source: String = 'api'): Delta
-formatLine(index: Number, length: Number, format: String, value: any,
-           source: String = 'api'): Delta
-formatLine(index: Number, length: Number, formats: { [String]: any },
-           source: String = 'api'): Delta
+formatLine(index: Number, length: Number, source: string = 'api'): Delta
+formatLine(index: Number, length: Number, format: string, value: any,
+           source: string = 'api'): Delta
+formatLine(index: Number, length: Number, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -47,11 +47,11 @@ Formats text in the editor, returning a [Delta](/guides/working-with-deltas/) re
 **Methods**
 
 ```javascript
-formatText(index: Number, length: Number, source: String = 'api'): Delta
-formatText(index: Number, length: Number, format: String, value: any,
-           source: String = 'api'): Delta
-formatText(index: Number, length: Number, formats: { [String]: any },
-           source: String = 'api'): Delta
+formatText(index: Number, length: Number, source: string = 'api'): Delta
+formatText(index: Number, length: Number, format: string, value: any,
+           source: string = 'api'): Delta
+formatText(index: Number, length: Number, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -76,8 +76,8 @@ Retrieves common formatting of the text in the given range. For a format to be r
 **Methods**
 
 ```javascript
-getFormat(range: Range = current): { [String]: any }
-getFormat(index: Number, length: Number = 0): { [String]: any }
+getFormat(range: Range = current): { [key: string]: any }
+getFormat(index: Number, length: Number = 0): { [key: string]: any }
 ```
 
 **Examples**
@@ -111,7 +111,7 @@ Removes all formatting and embeds within given range, returning a [Delta](/guide
 **Methods**
 
 ```javascript
-removeFormat(index: Number, length: Number, source: String = 'api'): Delta
+removeFormat(index: Number, length: Number, source: string = 'api'): Delta
 ```
 
 **Examples**

--- a/docs/1.0/docs/api/selection.md
+++ b/docs/1.0/docs/api/selection.md
@@ -51,9 +51,9 @@ Sets user selection to given range, which will also focus the editor. Providing 
 **Methods**
 
 ```javascript
-setSelection(index: Number, length: Number, source: String = 'api')
+setSelection(index: Number, length: Number, source: string = 'api')
 setSelection(range: { index: Number, length: Number },
-             souce: String = 'api')
+             souce: string = 'api')
 ```
 
 **Examples**

--- a/docs/1.0/docs/modules/clipboard.md
+++ b/docs/1.0/docs/modules/clipboard.md
@@ -20,7 +20,7 @@ Adds a custom matcher to the Clipboard. Matchers using `nodeType` are called fir
 **Methods**
 
 ```javascript
-addMatcher(selector: String, (node: Node, delta: Delta) => Delta)
+addMatcher(selector: string, (node: Node, delta: Delta) => Delta)
 addMatcher(nodeType: Number, (node: Node, delta: Delta) => Delta)
 ```
 
@@ -46,8 +46,8 @@ Improper handling of HTML can lead to [cross site scripting (XSS)](https://www.o
 **Methods**
 
 ```javascript
-dangerouslyPasteHTML(html: String, source: String = 'api')
-dangerouslyPasteHTML(index: Number, html: String, source: String = 'api')
+dangerouslyPasteHTML(html: string, source: string = 'api')
+dangerouslyPasteHTML(index: Number, html: string, source: string = 'api')
 ```
 
 **Examples**

--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -1139,6 +1139,10 @@ body:not(.home) .navbar-link:before {
   font-size: 1.2rem;
   margin-top: 11em;
   text-transform: uppercase;
+  position: sticky;
+  top: 1rem;
+  max-height: 100vh;
+  overscroll-behavior: auto;
 }
 #sidebar-container .search-item {
   display: none;

--- a/docs/docs/api/contents.md
+++ b/docs/docs/api/contents.md
@@ -7,7 +7,7 @@ Deletes text from the editor, returning a [Delta](/guides/working-with-deltas/) 
 **Methods**
 
 ```javascript
-deleteText(index: Number, length: Number, source: String = 'api'): Delta
+deleteText(index: number, length: number, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -23,7 +23,7 @@ Retrieves contents of the editor, with formatting data, represented by a [Delta]
 **Methods**
 
 ```javascript
-getContents(index: Number = 0, length: Number = remaining): Delta
+getContents(index: number = 0, length: number = remaining): Delta
 ```
 
 **Examples**
@@ -39,7 +39,7 @@ Retrieves the length of the editor contents. Note even when Quill is empty, ther
 **Methods**
 
 ```javascript
-getLength(): Number
+getLength(): number
 ```
 
 **Examples**
@@ -57,7 +57,7 @@ The `length` parameter defaults to the length of the remaining document.
 **Methods**
 
 ```javascript
-getText(index: Number = 0, length: Number = remaining): String
+getText(index: number = 0, length: number = remaining): string
 ```
 
 **Examples**
@@ -73,7 +73,7 @@ Insert embedded content into the editor, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-insertEmbed(index: Number, type: String, value: any, source: String = 'api'): Delta
+insertEmbed(index: number, type: string, value: any, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -89,11 +89,11 @@ Inserts text into the editor, optionally with a specified format or multiple [fo
 **Methods**
 
 ```javascript
-insertText(index: Number, text: String, source: String = 'api'): Delta
-insertText(index: Number, text: String, format: String, value: any,
-           source: String = 'api'): Delta
-insertText(index: Number, text: String, formats: { [String]: any },
-           source: String = 'api'): Delta
+insertText(index: number, text: string, source: string = 'api'): Delta
+insertText(index: number, text: string, format: string, value: any,
+           source: string = 'api'): Delta
+insertText(index: number, text: string, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -114,7 +114,7 @@ Overwrites editor with given contents. Contents should end with a [newline](/doc
 **Methods**
 
 ```javascript
-setContents(delta: Delta, source: String = 'api'): Delta
+setContents(delta: Delta, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -134,7 +134,7 @@ Sets contents of editor with given text, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-setText(text: String, source: String = 'api'): Delta
+setText(text: string, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -150,7 +150,7 @@ Applies Delta to editor contents, returning a [Delta](/guides/working-with-delta
 **Methods**
 
 ```javascript
-updateContents(delta: Delta, source: String = 'api'): Delta
+updateContents(delta: Delta, source: string = 'api'): Delta
 ```
 
 **Examples**

--- a/docs/docs/api/editor.md
+++ b/docs/docs/api/editor.md
@@ -76,7 +76,7 @@ Synchronously check editor for user updates and fires events, if changes have oc
 **Methods**
 
 ```javascript
-update(source: String = 'user')
+update(source: string = 'user')
 ```
 
 **Examples**

--- a/docs/docs/api/events.md
+++ b/docs/docs/api/events.md
@@ -18,7 +18,7 @@ Changes to text may cause changes to the selection (ex. typing advances the curs
 **Callback Signature**
 
 ```javascript
-handler(delta: Delta, oldContents: Delta, source: String)
+handler(delta: Delta, oldContents: Delta, source: string)
 ```
 
 **Examples**
@@ -44,7 +44,7 @@ APIs causing the selection to change may also be called with a `"silent"` source
 ```javascript
 handler(range: { index: Number, length: Number },
         oldRange: { index: Number, length: Number },
-        source: String)
+        source: string)
 ```
 
 **Examples**
@@ -71,7 +71,7 @@ Emitted when either `text-change` or `selection-change` would be emitted, even w
 **Callback Signature**
 
 ```javascript
-handler(name: String, ...args)
+handler(name: string, ...args)
 ```
 
 **Examples**
@@ -93,7 +93,7 @@ Adds event handler. See [text-change](#text-change) or [selection-change](#selec
 **Methods**
 
 ```javascript
-on(name: String, handler: Function): Quill
+on(name: string, handler: Function): Quill
 ```
 
 **Examples**
@@ -112,7 +112,7 @@ Adds handler for one emission of an event. See [text-change](#text-change) or [s
 **Methods**
 
 ```javascript
-once(name: String, handler: Function): Quill
+once(name: string, handler: Function): Quill
 ```
 
 **Examples**
@@ -130,7 +130,7 @@ Removes event handler.
 **Methods**
 
 ```javascript
-off(name: String, handler: Function): Quill
+off(name: string, handler: Function): Quill
 ```
 
 **Examples**

--- a/docs/docs/api/extension.md
+++ b/docs/docs/api/extension.md
@@ -7,7 +7,7 @@ Static method enabling logging messages at a given level: `'error'`, `'warn'`, `
 **Methods**
 
 ```javascript
-Quill.debug(level: String | Boolean)
+Quill.debug(level: string | Boolean)
 ```
 
 **Examples**
@@ -45,8 +45,8 @@ Registers a module, theme, or format(s), making them available to be added to an
 
 ```javascript
 Quill.register(format: Attributor | BlotDefinintion, supressWarning: Boolean = false)
-Quill.register(path: String, def: any, supressWarning: Boolean = false)
-Quill.register(defs: { [String]: any }, supressWarning: Boolean = false)
+Quill.register(path: string, def: any, supressWarning: Boolean = false)
+Quill.register(defs: { [key: string]: any }, supressWarning: Boolean = false)
 ```
 
 **Examples**
@@ -77,7 +77,7 @@ Adds and returns a container element inside the Quill container, sibling to the 
 **Methods**
 
 ```javascript
-addContainer(className: String, refNode?: Node): Element
+addContainer(className: string, refNode?: Node): Element
 addContainer(domNode: Node, refNode?: Node): Element
 ```
 
@@ -95,7 +95,7 @@ Retrieves a module that has been added to the editor.
 **Methods**
 
 ```javascript
-getModule(name: String): any
+getModule(name: string): any
 ```
 
 **Examples**

--- a/docs/docs/api/formatting.md
+++ b/docs/docs/api/formatting.md
@@ -7,7 +7,7 @@ Format text at user's current selection, returning a [Delta](/guides/working-wit
 **Methods**
 
 ```javascript
-format(name: String, value: any, source: String = 'api'): Delta
+format(name: string, value: any, source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -24,11 +24,11 @@ Formats all lines in given range, returning a [Delta](/guides/working-with-delta
 **Methods**
 
 ```javascript
-formatLine(index: Number, length: Number, source: String = 'api'): Delta
-formatLine(index: Number, length: Number, format: String, value: any,
-           source: String = 'api'): Delta
-formatLine(index: Number, length: Number, formats: { [String]: any },
-           source: String = 'api'): Delta
+formatLine(index: Number, length: Number, source: string = 'api'): Delta
+formatLine(index: Number, length: Number, format: string, value: any,
+           source: string = 'api'): Delta
+formatLine(index: Number, length: Number, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -47,11 +47,11 @@ Formats text in the editor, returning a [Delta](/guides/working-with-deltas/) re
 **Methods**
 
 ```javascript
-formatText(index: Number, length: Number, source: String = 'api'): Delta
-formatText(index: Number, length: Number, format: String, value: any,
-           source: String = 'api'): Delta
-formatText(index: Number, length: Number, formats: { [String]: any },
-           source: String = 'api'): Delta
+formatText(index: Number, length: Number, source: string = 'api'): Delta
+formatText(index: Number, length: Number, format: string, value: any,
+           source: string = 'api'): Delta
+formatText(index: Number, length: Number, formats: { [key: string]: any },
+           source: string = 'api'): Delta
 ```
 
 **Examples**
@@ -76,8 +76,8 @@ Retrieves common formatting of the text in the given range. For a format to be r
 **Methods**
 
 ```javascript
-getFormat(range: Range = current): { [String]: any }
-getFormat(index: Number, length: Number = 0): { [String]: any }
+getFormat(range: Range = current): { [key: string]: any }
+getFormat(index: Number, length: Number = 0): { [key: string]: any }
 ```
 
 **Examples**
@@ -111,7 +111,7 @@ Removes all formatting and embeds within given range, returning a [Delta](/guide
 **Methods**
 
 ```javascript
-removeFormat(index: Number, length: Number, source: String = 'api'): Delta
+removeFormat(index: Number, length: Number, source: string = 'api'): Delta
 ```
 
 **Examples**

--- a/docs/docs/api/selection.md
+++ b/docs/docs/api/selection.md
@@ -51,9 +51,9 @@ Sets user selection to given range, which will also focus the editor. Providing 
 **Methods**
 
 ```javascript
-setSelection(index: Number, length: Number = 0, source: String = 'api')
+setSelection(index: Number, length: Number = 0, source: string = 'api')
 setSelection(range: { index: Number, length: Number },
-             source: String = 'api')
+             source: string = 'api')
 ```
 
 **Examples**

--- a/docs/docs/modules/clipboard.md
+++ b/docs/docs/modules/clipboard.md
@@ -20,7 +20,7 @@ Adds a custom matcher to the Clipboard. Matchers using `nodeType` are called fir
 **Methods**
 
 ```javascript
-addMatcher(selector: String, (node: Node, delta: Delta) => Delta)
+addMatcher(selector: string, (node: Node, delta: Delta) => Delta)
 addMatcher(nodeType: Number, (node: Node, delta: Delta) => Delta)
 ```
 
@@ -46,8 +46,8 @@ Improper handling of HTML can lead to [cross site scripting (XSS)](https://www.o
 **Methods**
 
 ```javascript
-dangerouslyPasteHTML(html: String, source: String = 'api')
-dangerouslyPasteHTML(index: Number, html: String, source: String = 'api')
+dangerouslyPasteHTML(html: string, source: string = 'api')
+dangerouslyPasteHTML(index: Number, html: string, source: string = 'api')
 ```
 
 **Examples**


### PR DESCRIPTION
Make side-bar container in API docs 'position: sticky' so users don't have to scroll to very top to navigate through the docs.