### PR TITLE
Header/paragraph doesn't reset list numbering in Firefox

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -57,7 +57,10 @@ resets(arr)
     margin: 0
     padding: 0
   p, h1, h2, h3, h4, h5, h6
-    counter-reset: resets(0..MAX_INDENT)
+    @supports (counter-set: none)
+      counter-set: resets(0..MAX_INDENT)
+    @supports not (counter-set: none)
+      counter-reset: resets(0..MAX_INDENT)
   table
     border-collapse: collapse
   td


### PR DESCRIPTION
Reproducible steps:
1. Add some list items and a paragraph like the attached screenshot.
<img width="219" alt="CleanShot 2021-01-13 at 22 42 13@2x" src="https://user-images.githubusercontent.com/635902/104466821-98dc0480-55f0-11eb-8e77-911bddc152d6.png">
2. The second list should start with 1 but in Firefox it starts with 3.

The reason is Firefox changes its counter behavior recently: https://bugzilla.mozilla.org/show_bug.cgi?id=1679712. We are using `counter-reset` to set the numbering to 0. However, in Firefox, it actually creates a new counter instead of reset the existing one.

To fix, the PR uses `counter-set`, and if it's not supported fallback to `counter-reset`.

Browser behaviors for reference:

|               | Chrome              | Firefox             | Safari              |
|---------------|---------------------|---------------------|---------------------|
| counter-reset | CSS level 2 | CSS level 3 | CSS level 2 |
| counter-set   | ✅                  |                   ✅ | ❌                   |

Test plan:
Make sure the numbering of the example above looks correct in all browsers.