### PR TITLE
Cut across lines shouldn't affect the formatting of the line above

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -19,6 +19,7 @@ import { ColorStyle } from '../formats/color';
 import { DirectionAttribute, DirectionStyle } from '../formats/direction';
 import { FontStyle } from '../formats/font';
 import { SizeStyle } from '../formats/size';
+import { deleteRange } from './keyboard';
 
 const debug = logger('quill:clipboard');
 
@@ -135,7 +136,7 @@ class Clipboard extends Module {
     e.clipboardData.setData('text/plain', text);
     e.clipboardData.setData('text/html', html);
     if (isCut) {
-      this.quill.deleteText(range, Quill.sources.USER);
+      deleteRange({ range, quill: this.quill });
     }
   }
 

--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -244,18 +244,7 @@ class Keyboard extends Module {
   }
 
   handleDeleteRange(range) {
-    const lines = this.quill.getLines(range);
-    let formats = {};
-    if (lines.length > 1) {
-      const firstFormats = lines[0].formats();
-      const lastFormats = lines[lines.length - 1].formats();
-      formats = AttributeMap.diff(lastFormats, firstFormats) || {};
-    }
-    this.quill.deleteText(range, Quill.sources.USER);
-    if (Object.keys(formats).length > 0) {
-      this.quill.formatLine(range.index, 1, formats, Quill.sources.USER);
-    }
-    this.quill.setSelection(range.index, Quill.sources.SILENT);
+    deleteRange({ range, quill: this.quill });
     this.quill.focus();
   }
 
@@ -709,6 +698,21 @@ function normalize(binding) {
   return binding;
 }
 
+function deleteRange({ quill, range }) {
+  const lines = quill.getLines(range);
+  let formats = {};
+  if (lines.length > 1) {
+    const firstFormats = lines[0].formats();
+    const lastFormats = lines[lines.length - 1].formats();
+    formats = AttributeMap.diff(lastFormats, firstFormats) || {};
+  }
+  quill.deleteText(range, Quill.sources.USER);
+  if (Object.keys(formats).length > 0) {
+    quill.formatLine(range.index, 1, formats, Quill.sources.USER);
+  }
+  quill.setSelection(range.index, Quill.sources.SILENT);
+}
+
 function tableSide(table, row, cell, offset) {
   if (row.prev == null && row.next == null) {
     if (cell.prev == null && cell.next == null) {
@@ -725,4 +729,4 @@ function tableSide(table, row, cell, offset) {
   return null;
 }
 
-export { Keyboard as default, SHORTKEY, normalize };
+export { Keyboard as default, SHORTKEY, normalize, deleteRange };

--- a/test/unit/modules/clipboard.js
+++ b/test/unit/modules/clipboard.js
@@ -58,6 +58,33 @@ describe('Clipboard', function() {
       });
     });
 
+    describe('cut', () => {
+      beforeEach(function() {
+        this.clipboardData = {};
+        this.clipboardEvent = {
+          clipboardData: {
+            setData: (type, data) => {
+              this.clipboardData[type] = data;
+            },
+          },
+          preventDefault: () => {},
+        };
+      });
+
+      it('keeps formats of first line', function(done) {
+        this.quill.clipboard.onCaptureCopy(this.clipboardEvent, true);
+        setTimeout(() => {
+          expect(this.quill.root).toEqualHTML('<h1>01<em>7</em>8</h1>');
+          expect(this.quill.getSelection()).toEqual(new Range(2));
+          expect(this.clipboardData['text/plain']).toEqual('23\n56');
+          expect(this.clipboardData['text/html']).toEqual(
+            '<h1>23</h1><p>5<em>6</em></p>',
+          );
+          done();
+        }, 2);
+      });
+    });
+
     it('dangerouslyPasteHTML(html)', function() {
       this.quill.clipboard.dangerouslyPasteHTML('<i>ab</i><b>cd</b>');
       expect(this.quill.root).toEqualHTML(


### PR DESCRIPTION
To test:

1. Open http://localhost:9000/standalone/full/
2. Create two lines:

    ```
    Hea|der
    Normal |paragraph
    ```

3. Cut text between two |.

Expected:

The first line is a header.

Actually:

The first line is a normal paragraph.