### PR TITLE
Fix checkbox not checkable on Firefox

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -72,9 +72,7 @@ resets(arr)
     list-style-type: none
     padding-left: LIST_STYLE_OUTER_WIDTH
     position: relative
-    @supports (display: contents)
-      > .ql-ui
-        display: contents
+
     > .ql-ui:before
       display: inline-block
       margin-left: -1*LIST_STYLE_OUTER_WIDTH
@@ -82,6 +80,12 @@ resets(arr)
       text-align: right
       white-space: nowrap
       width: LIST_STYLE_WIDTH
+
+  @supports (display: contents)
+    li[data-list=bullet],
+    li[data-list=ordered]
+      > .ql-ui
+        display: contents
 
   li[data-list=checked],
   li[data-list=unchecked]


### PR DESCRIPTION
The cause is items with `display: contents` [don't have correct frames](https://bugzilla.mozilla.org/show_bug.cgi?id=1131128) on Firefox, so the event listener attached to the checkbox won't work.

This PR only applies the `display: contents` to ordered and bullet list. It worth noticing that `display: contents` was introduced to fix the following issues:

1. On Firefox, command + left arrow key can't move the caret to the beginning of the list item.
2. Left arrow can't move the caret that is at the beginning of a list item to the previous line.

After this change, regressions of the above issues are expected but only for the checkboxes.

Also, after some tests, `display: contents` introduces a side effect on Safari that pressing command + left arrow on the first line of a list item will move the caret to the beginning of the editor. Not sure the reason though.

### Test plan:

1. Make sure checkboxes are checkable on Firefox.
2. Make sure Command + Left arrow key & Left arrow key work on Firefox for bullet and ordered lists.