### PR TITLE
Issue/3336 repeated style

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -316,7 +316,7 @@ function combineFormats(formats, combined) {
       if (combined[name].indexOf(formats[name]) < 0) {
         merged[name] = combined[name].concat([formats[name]]);
       } else {
-        // If style already exists, don't add to list, but don't lose other styles
+        // If style already exists, don't add to an array, but don't lose other styles
         merged[name] = combined[name];
       }
     } else {

--- a/core/editor.js
+++ b/core/editor.js
@@ -315,6 +315,8 @@ function combineFormats(formats, combined) {
     } else if (Array.isArray(combined[name])) {
       if (combined[name].indexOf(formats[name]) < 0) {
         merged[name] = combined[name].concat([formats[name]]);
+      } else {
+        merged[name] = combined[name];
       }
     } else {
       merged[name] = [combined[name], formats[name]];

--- a/core/editor.js
+++ b/core/editor.js
@@ -316,7 +316,7 @@ function combineFormats(formats, combined) {
       if (combined[name].indexOf(formats[name]) < 0) {
         merged[name] = combined[name].concat([formats[name]]);
       } else {
-        //If style already exists, don't add to list, but don't lose other styles
+        // If style already exists, don't add to list, but don't lose other styles
         merged[name] = combined[name];
       }
     } else {

--- a/core/editor.js
+++ b/core/editor.js
@@ -316,6 +316,7 @@ function combineFormats(formats, combined) {
       if (combined[name].indexOf(formats[name]) < 0) {
         merged[name] = combined[name].concat([formats[name]]);
       } else {
+        //If style already exists, don't add to list, but don't lose other styles
         merged[name] = combined[name];
       }
     } else {

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -565,6 +565,41 @@ describe('Editor', function() {
       });
     });
 
+    it('across leaves repeated', function() {
+      const editor = this.initialize(
+        Editor,
+        `
+        <h1>
+          <strong class="ql-size-small"><em>01</em></strong>
+          <em class="ql-size-large"><u>23</u></em>
+          <em class="ql-size-huge"><u>45</u></em>
+          <em class="ql-size-small"><u>45</u></em>
+        </h1>
+      `,
+      );
+      expect(editor.getFormat(1, 4)).toEqual({
+        italic: true,
+        header: 1,
+        size: ['small', 'large', 'huge'],
+      });
+    });
+
+    it('across lines repeated', function() {
+      const editor = this.initialize(
+        Editor,
+        `
+        <h1 class="ql-align-right"><em>01</em></h1>
+        <h1 class="ql-align-center"><em>34</em></h1>
+        <h1 class="ql-align-right"><em>36</em></h1>
+        <h1 class="ql-align-center"><em>33</em></h1>
+      `,
+      );
+      expect(editor.getFormat(1, 3)).toEqual({
+        italic: true,
+        header: 1,
+        align: ['right', 'center'],
+      });
+    });
     it('across lines', function() {
       const editor = this.initialize(
         Editor,


### PR DESCRIPTION
## Fix issue #3336 with repeated styles

This pull request fixes issue #3336.

When calling getFormat() and finding multiple style value, there were two options to solve this issue: 
- Adding already existing style to style array which means it is in an array twice
- Skipping and continue looping

I decided to go with second option because it fits more with the existing code.

## Code

In combineFormats function, I changed this code block:

```javascript
if (combined[name].indexOf(formats[name]) < 0) {
  merged[name] = combined[name].concat([formats[name]]);
} else {
  // Here is the change
  merged[name] = combined[name];
}
```

The whole function:

```javascript
function combineFormats(formats, combined) {
  return Object.keys(combined).reduce((merged, name) => {
    if (formats[name] == null) return merged;
    if (combined[name] === formats[name]) {
      merged[name] = combined[name];
    } else if (Array.isArray(combined[name])) {
      if (combined[name].indexOf(formats[name]) < 0) {
        merged[name] = combined[name].concat([formats[name]]);
      } else {
        // If style already exists continue looping but do not lose other styles
        merged[name] = combined[name];
      }
    } else {
      merged[name] = [combined[name], formats[name]];
    }
    return merged;
  }, {});
}
```
If you have any questions, I am opened to discussion. I hope you get to merge this pull request. Let me know if it is good. Thanks!

