### PR TITLE
bugfix: Picker does not remove the data-value attribute from picker label in toolbar

### DIFF
--- a/test/unit/ui/picker.js
+++ b/test/unit/ui/picker.js
@@ -3,7 +3,7 @@ import Picker from '../../../ui/picker';
 describe('Picker', function() {
   beforeEach(function() {
     this.container.innerHTML =
-      '<select><option selected>0</option><option value="1">1</option></select>';
+      '<select><option selected value="0">0</option><option value="1">1</option></select>';
     this.pickerSelectorInstance = new Picker(this.container.firstChild);
     this.pickerSelector = this.container.querySelector('.ql-picker');
   });
@@ -14,7 +14,7 @@ describe('Picker', function() {
     expect(
       this.container.querySelector('.ql-picker-item.ql-selected').outerHTML,
     ).toEqualHTML(
-      '<span tabindex="0" role="button" class="ql-picker-item ql-selected" data-label="0"></span>',
+      '<span tabindex="0" role="button" class="ql-picker-item ql-selected" data-value="0" data-label="0"></span>',
     );
     expect(
       this.container.querySelector('.ql-picker-item:not(.ql-selected)')
@@ -22,6 +22,16 @@ describe('Picker', function() {
     ).toEqualHTML(
       '<span tabindex="0" role="button" class="ql-picker-item" data-value="1" data-label="1"></span>',
     );
+  });
+
+  it('removes data-value attribute from picker-label when reseting a selected item', function() {
+    expect(
+      this.pickerSelectorInstance.label.getAttribute('data-value'),
+    ).toEqual('0');
+    this.pickerSelectorInstance.selectItem(null);
+    expect(
+      this.pickerSelectorInstance.label.hasAttribute('data-value'),
+    ).toBeFalsy();
   });
 
   it('escape charcters', function() {

--- a/ui/picker.js
+++ b/ui/picker.js
@@ -138,7 +138,10 @@ class Picker {
     if (selected != null) {
       selected.classList.remove('ql-selected');
     }
-    if (item == null) return;
+    if (item == null) {
+      this.label.removeAttribute('data-value');
+      return;
+    }
     item.classList.add('ql-selected');
     this.select.selectedIndex = Array.from(item.parentNode.children).indexOf(
       item,


### PR DESCRIPTION
The `ColorPicker` which is inherited from `Picker` does not remove the `data-value` attribute from `ql-picker-label` element when the toolbar is defined using an array.

This PR fixes the issue.

**Steps for Reproduction**

1. Visit https://codepen.io/jastkand/pen/bGqgwyJ
2. Put a focus on the first line. The `.ql-toolbar .ql-color-picker > .ql-picker-label` element will have `data-value="purple"` attribute assigned - which is correct.
3. Put a focus on the third line. The `.ql-toolbar .ql-color-picker > .ql-picker-label` element still have the `data-value="purple"` attribute assigned - which is not expected. 

**Expected behavior**:
The `data-value` attribute is removed when focus moved to the non-colored line.

**Actual behavior**:
The `data-value` attribute keeps its value.

**Version**:
1.3.7