### PR TITLE
Fix for https://github.com/quilljs/quill/issues/2670

### DIFF
--- a/_develop/webpack.config.js
+++ b/_develop/webpack.config.js
@@ -154,7 +154,7 @@ module.exports = env => {
       ...prodConfig,
       mode: 'production',
       entry: { 'quill.min.js': './quill.js' },
-      devtool: 'source-map',
+      devtool: 'cheap-module-source-map',
     };
   }
   if (env && env.coverage) {


### PR DESCRIPTION
The production build ( published on npmjs ) of quill version 2.0.0-dev.4 contains eval calls which hinders it from being used in projects which do not allow "unsafe-eval"  in their Content-Security-Policy. Switching to cheap-module-source-map removes the eval calls.