### PR TITLE
Add API to set a placeholder

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -660,8 +660,8 @@ class Quill {
     return this.setContents(delta, source);
   }
 
-  setPlaceholder(placeholder) {
-    if (placeholder && placeholder.length > 0) {
+  setPlaceholder(placeholder: string | null) {
+    if (placeholder) {
       this.root.setAttribute('data-placeholder', placeholder);
       this.root.setAttribute('aria-placeholder', placeholder);
     } else {

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -221,7 +221,7 @@ class Quill {
     }
     this.history.clear();
     if (this.options.placeholder) {
-      this.root.setAttribute('data-placeholder', this.options.placeholder);
+      this.setPlaceholder(this.options.placeholder);
     }
     if (this.options.readOnly) {
       this.disable();
@@ -658,6 +658,16 @@ class Quill {
   setText(text: string, source: EmitterSource = Emitter.sources.API) {
     const delta = new Delta().insert(text);
     return this.setContents(delta, source);
+  }
+  
+  setPlaceholder(placeholder) {
+    if (placeholder && placeholder.length > 0) {
+      this.root.setAttribute('data-placeholder', placeholder);
+      this.root.setAttribute('aria-placeholder', placeholder);
+    } else {
+      this.root.removeAttribute('data-placeholder');
+      this.root.removeAttribute('aria-placeholder');
+    }
   }
 
   update(source: EmitterSource = Emitter.sources.USER) {

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -659,7 +659,7 @@ class Quill {
     const delta = new Delta().insert(text);
     return this.setContents(delta, source);
   }
-  
+
   setPlaceholder(placeholder) {
     if (placeholder && placeholder.length > 0) {
       this.root.setAttribute('data-placeholder', placeholder);

--- a/test/unit/core/quill.js
+++ b/test/unit/core/quill.js
@@ -902,7 +902,26 @@ describe('Quill', function() {
       expect(this.quill.root.dataset.placeholder).toEqual(
         'a great day to be a placeholder',
       );
+      expect(this.quill.root.getAttribute('aria-placeholder')).toEqual(
+        'a great day to be a placeholder',
+      );
       expect(this.quill.root.classList).toContain('ql-blank');
+    });
+
+    it('update placeholder', function() {
+      this.quill.setPlaceholder('this is an updated placeholder');
+      expect(this.quill.root.dataset.placeholder).toEqual(
+        'this is an updated placeholder',
+      );
+      expect(this.quill.root.getAttribute('aria-placeholder')).toEqual(
+        'this is an updated placeholder',
+      );
+    });
+
+    it('remove placeholder', function() {
+      this.quill.setPlaceholder('');
+      expect(this.quill.root.dataset.placeholder).not.toBeDefined();
+      expect(this.quill.root.hasAttribute('aria-placeholder')).toBe(false);
     });
 
     it('with text', function() {


### PR DESCRIPTION
This adds a new public API to set a placeholder, useful when used in reactive libraries such as React for keeping placeholder state in sync.

Additionally, we want to set the `aria-placeholder` attribute to ensure it's accessible for screen readers.