### PR TITLE
fixed ISSUE-2286 by preventing Scroll.update while in read-only mode

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -151,6 +151,7 @@ class Scroll extends ScrollBlot {
   }
 
   update(mutations) {
+    if (!this.isEnabled()) return;
     if (this.batch) {
       if (Array.isArray(mutations)) {
         this.batch = this.batch.concat(mutations);

--- a/test/unit/blots/scroll.js
+++ b/test/unit/blots/scroll.js
@@ -39,6 +39,17 @@ describe('Scroll', function() {
     }, 1);
   });
 
+  it("don't emit if in read-only", function(done) {
+    const scroll = this.initialize(Scroll, '<p>Hello World!</p>');
+    scroll.enable(false);
+    spyOn(scroll.emitter, 'emit').and.callThrough();
+    scroll.domNode.firstChild.appendChild(document.createTextNode('!'));
+    setTimeout(function() {
+      expect(scroll.emitter.emit).not.toHaveBeenCalled();
+      done();
+    }, 1);
+  });
+
   it('prevent dragstart', function() {
     const scroll = this.initialize(Scroll, '<p>Hello World!</p>');
     const dragstart = new Event('dragstart');


### PR DESCRIPTION
This PR fixes Issue #2286 by preventing `Scroll.update` from being called while in read-only mode.

Currently Chrome's built-in translation feature doesn't work for read-only quill content, which is a huge accessibility barrier. This is due to the translator modifying the content of the text in the DOM which triggers `Scroll.update`, even though the editor is in read-only mode. Although `Quill.update` checks whether `isEnabled()` is `true/false`, `Scroll.update` doesn't. Therefore, it seems to me that the intended behaviour is that `update` is not triggered, whenever `isEnabled()` is `false`, which is why I would consider `Scroll.update` not doing so a bug. This PR fixes this inconsistency and thereby solves Issues #2286.