### PR TITLE
Discontinue inline formats on enter

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -268,13 +268,6 @@ class Keyboard extends Module {
     this.quill.updateContents(delta, Quill.sources.USER);
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
     this.quill.focus();
-
-    Object.keys(context.format).forEach(name => {
-      if (lineFormats[name] != null) return;
-      if (Array.isArray(context.format[name])) return;
-      if (name === 'code' || name === 'link') return;
-      this.quill.format(name, context.format[name], Quill.sources.USER);
-    });
   }
 }
 


### PR DESCRIPTION
It's more intuitive to not preserve inline formats on enter.