### PR TITLE
fix: should ignore "Enter" shortcut when composing in safari

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -110,7 +110,12 @@ class Keyboard extends Module {
 
   listen() {
     this.quill.root.addEventListener('keydown', evt => {
-      if (evt.defaultPrevented || evt.isComposing) return;
+      if (
+        evt.defaultPrevented ||
+        evt.isComposing ||
+        (evt.key === 'Enter' && evt.keyCode === 229) // handle safari composition end with Enter
+      )
+        return;
       const bindings = (this.bindings[evt.key] || []).concat(
         this.bindings[evt.which] || [],
       );


### PR DESCRIPTION
In version 1.x, keybinding uses keyCode, while in version 2.x it uses key, which leads to differences in keyboard events when using the input method.
In safar, chrome and firefox, pressing `Enter` in the input method state gives them different behaviour.

- Safari, the key is Enter, keyCode 229, isComposing is false.
- Firefox, key is Process, keyCode 229, isComposing is true.
- Chrome, key is Enter, keyCode 229, isComposing is true

This difference causes pressing enter when using the input method in Safari to result in the insertion of a blank line, which leads to incorrect data.