### PR TITLE
fix: Set float style to list bullets to avoid text wrapping after them

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -75,6 +75,7 @@ resets(arr)
 
     > .ql-ui:before
       display: inline-block
+      float: left;
       margin-left: -1*LIST_STYLE_OUTER_WIDTH
       margin-right: LIST_STYLE_MARGIN
       text-align: right


### PR DESCRIPTION
**Steps for Reproduction**
1. Visit quilljs.com and open Quill Playground
2. Create list in editor and enter a line without spaces: longlinewithoutwhitespaces
3. Change size of the browser window so that longlinewithoutwhitespaces is no longer has enough space

**Expected behavior:**
Quills list elements seem to be expected to do word wrap in case overflow (`overflow-wrap: break-word;`). 

It is expected to work the same way as native list does with applied `overflow-wrap: break-word;`. Namely to have line break in the longlinewithoutwhitespaces to accomodate with new width

**Actual behavior:**
There is a line break right after the bullet point in this line.

I guess this happens because Quill renders list bullet points using `:content` selector. It is considered by user-agent to be eligible to have line wrap after itself (soft wrap opportunity)

https://drafts.csswg.org/css-text/#line-break-details

<img width="630" alt="Screenshot 2021-09-14 at 12 46 37" src="https://user-images.githubusercontent.com/6560271/133217106-d208e44e-618f-4fe8-98c2-bae46a5a8a06.png">

**Platforms:**
Chrome 93.0.4577.63, MacOS 11.5.1, 

**Version:**
Quill 1.3.6

**Fix:**
The solution is to exclude bullet point from layout flow. Using `float: left` is one of the ways to accomplish this. 

In future it can be updated to use `inline-start` to support lists with rtl languages. It is not widely supported yet and I'm not sure Quill is even expected to have bullet points at the right side for rtl languages

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow

**Tests:**
It could be tested by screenshot tests, but I didn't find such tests in Quill. Am I missing it?