### PR TITLE
Use disc counter instead of unicode character

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -93,7 +93,7 @@ resets(arr)
       color: #777
 
   li[data-list=bullet] > .ql-ui:before
-    content: '\2022'
+    content: counter(list-0, disc)
   li[data-list=checked] > .ql-ui:before
     content: '\2611'
   li[data-list=unchecked] > .ql-ui:before


### PR DESCRIPTION
I might be totally off here, but I'm sometimes getting an invalid unicode character with my font (which is weird, can't figure out the root cause). I was looking at the other lists in Quill and they use the counter mechanism to get their character. 

It seems like using the list-0 disc is the safest way to specify the bullet, as it doesn't require unicode character.