### PR TITLE
Add support for Trusted Types

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -8,6 +8,7 @@ import Selection, { Range } from './selection';
 import extend from 'extend';
 import logger from './logger';
 import Theme from './theme';
+import Security from './security';
 
 let debug = logger('quill');
 
@@ -67,7 +68,7 @@ class Quill {
     }
     let html = this.container.innerHTML.trim();
     this.container.classList.add('ql-container');
-    this.container.innerHTML = '';
+    this.container.textContent = '';
     this.container.__quill = this;
     this.root = this.addContainer('ql-editor');
     this.root.classList.add('ql-blank');
@@ -97,7 +98,9 @@ class Quill {
         return this.editor.update(null, mutations, index);
       }, source);
     });
-    let contents = this.clipboard.convert(`<div class='ql-editor' style="white-space: normal;">${html}<p><br></p></div>`);
+    // Security: Blessed HTML is already part of the DOM.
+    let initialContents = Quill.import('core/security').blessHTML(`<div class='ql-editor' style="white-space: normal;">${html}<p><br></p></div>`);
+    let contents = this.clipboard.convert(initialContents);
     this.setContents(contents);
     this.history.clear();
     if (this.options.placeholder) {
@@ -361,10 +364,11 @@ Quill.sources = Emitter.sources;
 Quill.version = typeof(QUILL_VERSION) === 'undefined' ? 'dev' : QUILL_VERSION;
 
 Quill.imports = {
-  'delta'       : Delta,
-  'parchment'   : Parchment,
-  'core/module' : Module,
-  'core/theme'  : Theme
+  'delta'         : Delta,
+  'parchment'     : Parchment,
+  'core/module'   : Module,
+  'core/theme'    : Theme,
+  'core/security' : new Security(),
 };
 
 

--- a/core/security.js
+++ b/core/security.js
@@ -1,0 +1,39 @@
+class Security {
+  constructor(trustedTypes) {
+    this.trustedTypes = trustedTypes || window.trustedTypes;
+    this.supportsTrustedTypes =
+      !!(this.trustedTypes && this.trustedTypes.createPolicy);
+    let trustedTypesPolicy = {
+      createHTML: function (html) {
+        // Trust all strings passed to this function.
+        return html;
+      }
+    };
+
+    try {
+      if (this.supportsTrustedTypes) {
+        trustedTypesPolicy = this.trustedTypes.createPolicy('quill', trustedTypesPolicy);
+      }
+    } catch (e) {}
+
+    // Security: Only call this function with HTML from a trusted source.
+    this.blessHTML = trustedTypesPolicy.createHTML.bind(trustedTypesPolicy);
+  }
+
+  // Security: Only call this function with an object containing HTML from a trusted source.
+  deepBless(input) {
+    return JSON.parse(JSON.stringify(input), (key, value) => {
+      return typeof value === 'string' ? this.blessHTML(value) : value;
+    });
+  }
+
+  isTrustedHTML(value) {
+    return this.supportsTrustedTypes && this.trustedTypes.isHTML(value);
+  }
+
+  replace(value, target, replacement) {
+    return this.isTrustedHTML(value) ? this.blessHTML(value.toString().replace(target, replacement)) : value.replace(target, replacement);
+  }
+}
+
+export default Security;

--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -57,6 +57,7 @@ const STYLE_ATTRIBUTORS = [
 class Clipboard extends Module {
   constructor(quill, options) {
     super(quill, options);
+    this.security = Quill.import('core/security');
     this.quill.root.addEventListener('paste', this.onPaste.bind(this));
     this.container = this.quill.addContainer('ql-clipboard');
     this.container.setAttribute('contenteditable', true);
@@ -73,14 +74,14 @@ class Clipboard extends Module {
   }
 
   convert(html) {
-    if (typeof html === 'string') {
-      this.container.innerHTML = html.replace(/\>\r?\n +\</g, '><'); // Remove spaces between tags
+    if (typeof html === 'string' || this.security.isTrustedHTML(html)) {
+      this.container.innerHTML = this.security.replace(html, /\>\r?\n +\</g, '><'); // Remove spaces between tags
       return this.convert();
     }
     const formats = this.quill.getFormat(this.quill.selection.savedRange.index);
     if (formats[CodeBlock.blotName]) {
       const text = this.container.innerText;
-      this.container.innerHTML = '';
+      this.container.textContent = '';
       return new Delta().insert(text, { [CodeBlock.blotName]: formats[CodeBlock.blotName] });
     }
     let [elementMatchers, textMatchers] = this.prepareMatching();
@@ -90,7 +91,7 @@ class Clipboard extends Module {
       delta = delta.compose(new Delta().retain(delta.length() - 1).delete(1));
     }
     debug.log('convert', this.container.innerHTML, delta);
-    this.container.innerHTML = '';
+    this.container.textContent = '';
     return delta;
   }
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -11,6 +11,7 @@ import './unit/blots/block-embed.js';
 import './unit/blots/inline.js';
 
 import './unit/core/editor';
+import './unit/core/security';
 import './unit/core/selection';
 import './unit/core/quill';
 

--- a/test/unit/core/security.js
+++ b/test/unit/core/security.js
@@ -1,0 +1,145 @@
+import Security from '../../../core/security';
+
+let MOCK_TRUSTED_TYPES = {
+  createPolicy: (name, func) => {
+    return {
+      createHTML: (value) => {
+        return {
+          isHTML: true,
+          toString: () => func.createHTML(value)
+        }
+      }
+    }
+  },
+  isHTML: (value) => !!value.isHTML
+};
+
+describe('Security', function() {
+  describe('with Trusted Types support', function() {
+    beforeEach(function() {
+      this.security = new Security(MOCK_TRUSTED_TYPES);
+    });
+
+    describe('blessHTML()', function() {
+      it('creates TrustedTypes', function() {
+        let trustedType = this.security.blessHTML('<p>foo</p>');
+        let expected = '<p>foo</p>';
+        expect(trustedType.toString()).toBe(expected);
+        expect(this.security.isTrustedHTML(trustedType)).toBe(true);
+      });
+    });
+
+    describe('deepBless()', function() {
+      it('blesses all strings in an object', function() {
+        let input = {
+          foo: '<p>foo</p>',
+          bar: '<p>bar</p>'
+        }
+        let trustedType = this.security.deepBless(input);
+        expect(trustedType.foo.toString()).toBe(input.foo);
+        expect(this.security.isTrustedHTML(trustedType.foo)).toBe(true);
+        expect(trustedType.bar.toString()).toBe(input.bar);
+        expect(this.security.isTrustedHTML(trustedType.bar)).toBe(true);
+      });
+
+      it('ignores all non-strings', function() {
+        let input = {
+          foo: true,
+          bar: []
+        }
+        let trustedType = this.security.deepBless(input);
+        expect(this.security.isTrustedHTML(trustedType.foo)).toBe(false);
+        expect(this.security.isTrustedHTML(trustedType.bar)).toBe(false);
+      });
+    });
+
+    describe('isTrustedHTML()', function() {
+      it('detects TrustedTypes', function() {
+        let trustedType = this.security.blessHTML('<p>foo</p>');
+        expect(this.security.isTrustedHTML(trustedType)).toBe(true);
+      });
+
+      it('detects non-TrustedTypes', function() {
+        expect(this.security.isTrustedHTML('<p>foo</p>')).toBe(false);
+      });
+    });
+
+    describe('replace()', function() {
+      it('replaces values in TrustedTypes', function() {
+        let trustedType = this.security.blessHTML('<p>foo</p>');
+        let replacedTrustedType = this.security.replace(trustedType, 'foo', 'bar');
+        let expected = '<p>bar</p>';
+        expect(this.security.isTrustedHTML(replacedTrustedType)).toBe(true);
+        expect(replacedTrustedType.toString()).toBe(expected);
+      });
+
+      it('replaces values in strings', function() {
+        let input = '<p>foo</p>';
+        let replacedInput = this.security.replace(input, 'foo', 'bar');
+        let expected = '<p>bar</p>';
+        expect(this.security.isTrustedHTML(replacedInput)).toBe(false);
+        expect(replacedInput).toBe(expected);
+      });
+    });
+  });
+
+  describe('without Trusted Types support', function() {
+    beforeEach(function() {
+      this.security = new Security({});
+    });
+
+    describe('blessHTML()', function() {
+      it('returns plain strings', function() {
+        let trustedType = this.security.blessHTML('<p>foo</p>');
+        let expected = '<p>foo</p>';
+        expect(trustedType).toBe(expected);
+        expect(this.security.isTrustedHTML(trustedType)).toBe(false);
+      });
+    });
+
+    describe('deepBless()', function() {
+      it('returns an object with plain strings', function() {
+        let input = {
+          foo: '<p>foo</p>',
+          bar: '<p>bar</p>'
+        }
+        let trustedType = this.security.deepBless(input);
+        expect(trustedType.foo).toBe(input.foo);
+        expect(this.security.isTrustedHTML(trustedType.foo)).toBe(false);
+        expect(trustedType.bar).toBe(input.bar);
+        expect(this.security.isTrustedHTML(trustedType.bar)).toBe(false);
+      });
+
+      it('ignores all non-strings', function() {
+        let input = {
+          foo: true,
+          bar: []
+        }
+        let trustedType = this.security.deepBless(input);
+        expect(this.security.isTrustedHTML(trustedType.foo)).toBe(false);
+        expect(this.security.isTrustedHTML(trustedType.bar)).toBe(false);
+      });
+    });
+
+    describe('isTrustedHTML()', function() {
+      it('returns false for strings passed through blessHTML', function() {
+        let trustedType = this.security.blessHTML('<p>foo</p>');
+        expect(this.security.isTrustedHTML(trustedType)).toBe(false);
+      });
+
+      it('returns false for plain strings', function() {
+        expect(this.security.isTrustedHTML('<p>foo</p>')).toBe(false);
+      });
+    });
+
+    describe('replace()', function() {
+      it('replaces values in strings', function() {
+        let input = '<p>foo</p>';
+        let replacedInput = this.security.replace(input, 'foo', 'bar');
+        let expected = '<p>bar</p>';
+        expect(this.security.isTrustedHTML(replacedInput)).toBe(false);
+        expect(replacedInput).toBe(expected);
+      });
+    });
+  });
+});

--- a/themes/base.js
+++ b/themes/base.js
@@ -1,3 +1,4 @@
+import Quill from '../core/quill';
 import extend from 'extend';
 import Delta from 'quill-delta';
 import Emitter from '../core/emitter';
@@ -64,8 +65,9 @@ class BaseTheme extends Theme {
         name = name.slice('ql-'.length);
         if (icons[name] == null) return;
         if (name === 'direction') {
-          button.innerHTML = icons[name][''] + icons[name]['rtl'];
-        } else if (typeof icons[name] === 'string') {
+          button.innerHTML = icons[name][''];
+          button.insertAdjacentHTML('beforeend', icons[name]['rtl']);
+        } else if (typeof icons[name] === 'string' || Quill.import('core/security').isTrustedHTML(icons[name])) {
           button.innerHTML = icons[name];
         } else {
           let value = button.value || '';

--- a/themes/bubble.js
+++ b/themes/bubble.js
@@ -1,3 +1,4 @@
+import Quill from '../core/quill';
 import extend from 'extend';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
@@ -17,13 +18,15 @@ class BubbleTheme extends BaseTheme {
     }
     super(quill, options);
     this.quill.container.classList.add('ql-bubble');
+    // Security: Blessed HTML is imported from a trusted file.
+    this.blessedIcons = Quill.import('core/security').deepBless(icons);
   }
 
   extendToolbar(toolbar) {
     this.tooltip = new BubbleTooltip(this.quill, this.options.bounds);
     this.tooltip.root.appendChild(toolbar.container);
-    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button')), icons);
-    this.buildPickers([].slice.call(toolbar.container.querySelectorAll('select')), icons);
+    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button')), this.blessedIcons);
+    this.buildPickers([].slice.call(toolbar.container.querySelectorAll('select')), this.blessedIcons);
   }
 }
 BubbleTheme.DEFAULTS = extend(true, {}, BaseTheme.DEFAULTS, {
@@ -99,13 +102,14 @@ class BubbleTooltip extends BaseTooltip {
     arrow.style.marginLeft = (-1*shift - arrow.offsetWidth/2) + 'px';
   }
 }
-BubbleTooltip.TEMPLATE = [
+// Security: Blessed HTML is provided hardcoded here.
+BubbleTooltip.TEMPLATE = Quill.import('core/security').blessHTML([
   '<span class="ql-tooltip-arrow"></span>',
   '<div class="ql-tooltip-editor">',
     '<input type="text" data-formula="e=mc^2" data-link="https://quilljs.com" data-video="Embed URL">',
     '<a class="ql-close"></a>',
   '</div>'
-].join('');
+].join(''));
 
 
 export { BubbleTooltip, BubbleTheme as default };

--- a/themes/snow.js
+++ b/themes/snow.js
@@ -1,3 +1,4 @@
+import Quill from '../core/quill';
 import extend from 'extend';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
@@ -20,12 +21,14 @@ class SnowTheme extends BaseTheme {
     }
     super(quill, options);
     this.quill.container.classList.add('ql-snow');
+    // Security: Blessed HTML is imported from a trusted file.
+    this.blessedIcons = Quill.import('core/security').deepBless(icons);
   }
 
   extendToolbar(toolbar) {
     toolbar.container.classList.add('ql-snow');
-    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button')), icons);
-    this.buildPickers([].slice.call(toolbar.container.querySelectorAll('select')), icons);
+    this.buildButtons([].slice.call(toolbar.container.querySelectorAll('button')), this.blessedIcons);
+    this.buildPickers([].slice.call(toolbar.container.querySelectorAll('select')), this.blessedIcons);
     this.tooltip = new SnowTooltip(this.quill, this.options.bounds);
     if (toolbar.container.querySelector('.ql-link')) {
       this.quill.keyboard.addBinding({ key: 'K', shortKey: true }, function(range, context) {
@@ -109,12 +112,13 @@ class SnowTooltip extends BaseTooltip {
     this.root.removeAttribute('data-mode');
   }
 }
-SnowTooltip.TEMPLATE = [
+// Security: Blessed HTML is provided hardcoded here.
+SnowTooltip.TEMPLATE = Quill.import('core/security').blessHTML([
   '<a class="ql-preview" rel="noopener noreferrer" target="_blank" href="about:blank"></a>',
   '<input type="text" data-formula="e=mc^2" data-link="https://quilljs.com" data-video="Embed URL">',
   '<a class="ql-action"></a>',
   '<a class="ql-remove"></a>'
-].join('');
+].join(''));
 
 
 export default SnowTheme;

--- a/ui/icon-picker.js
+++ b/ui/icon-picker.js
@@ -1,3 +1,4 @@
+import Quill from '../core/quill';
 import Picker from './picker';
 
 
@@ -15,7 +16,8 @@ class IconPicker extends Picker {
   selectItem(item, trigger) {
     super.selectItem(item, trigger);
     item = item || this.defaultItem;
-    this.label.innerHTML = item.innerHTML;
+    // Security: Blessed HTML is already part of the DOM.
+    this.label.innerHTML = Quill.import('core/security').blessHTML(item.innerHTML);
   }
 }
 

--- a/ui/picker.js
+++ b/ui/picker.js
@@ -1,3 +1,4 @@
+import Quill from '../core/quill';
 import Keyboard from '../modules/keyboard';
 import DropdownIcon from '../assets/icons/dropdown.svg';
 
@@ -81,7 +82,8 @@ class Picker {
   buildLabel() {
     let label = document.createElement('span');
     label.classList.add('ql-picker-label');
-    label.innerHTML = DropdownIcon;
+    // Security: Blessed HTML is imported from a trusted file.
+    label.innerHTML = Quill.import('core/security').blessHTML(DropdownIcon);
     label.tabIndex = '0';
     label.setAttribute('role', 'button');
     label.setAttribute('aria-expanded', 'false');

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -3,6 +3,7 @@ class Tooltip {
     this.quill = quill;
     this.boundsContainer = boundsContainer || document.body;
     this.root = quill.addContainer('ql-tooltip');
+    // Security: Expecting theme to provide blessed HTML.
     this.root.innerHTML = this.constructor.TEMPLATE;
     if (this.quill.root === this.quill.scrollingContainer) {
       this.quill.root.addEventListener('scroll', () => {


### PR DESCRIPTION
This PR adds support for [Trusted Types](https://web.dev/trusted-types/). When enabled in a web app, Trusted Types help prevent DOM-based cross-site scripting vulnerabilities.

This change is backwards compatible with web apps that have not yet enabled Trusted Types. Trusted Types can be enabled via an [HTTP header](https://web.dev/trusted-types/#switch-to-enforcing-content-security-policy).

This change introduces a `Security` module, which is used to "bless" plain text, i.e. convert it to a `TrustedHTML` object. When Trusted Types are enabled, only `TrustedHTML` can be passed to risky sinks such as `.innerHTML`.

The `Security` functions that bless the HTML should be called with care, and the best practice is to add a comment explaining why the HTML text passed in cannot be user-manipulated.