### PR TITLE
Fix lint error no-else-return in clipboard

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -155,7 +155,9 @@ class Clipboard extends Module {
     if (!html && files.length > 0) {
       this.quill.uploader.upload(range, files);
       return;
-    } else if (html && files.length > 0) {
+    }
+
+    if (html && files.length > 0) {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       if (
         doc.body.childElementCount === 1 &&


### PR DESCRIPTION
Fix this lint error:
```
$ npm run build

quill/modules/clipboard.js
  158:12  error  Unnecessary 'else' after 'return'  no-else-return

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```