### PR TITLE
Fix linting error

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -155,7 +155,8 @@ class Clipboard extends Module {
     if (!html && files.length > 0) {
       this.quill.uploader.upload(range, files);
       return;
-    } else if (html && files.length > 0) {
+    }
+    if (html && files.length > 0) {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       if (
         doc.body.childElementCount === 1 &&


### PR DESCRIPTION
This change fixes the following linting error:

```
~/quill/modules/clipboard.js
  158:12  error  Unnecessary 'else' after 'return'  no-else-return
```