### PR TITLE
getLeaf() should ignore non-leaf blots

### DIFF
--- a/blots/scroll.js
+++ b/blots/scroll.js
@@ -1,4 +1,4 @@
-import { Scope, ScrollBlot, ContainerBlot } from 'parchment';
+import { Scope, ScrollBlot, ContainerBlot, LeafBlot } from 'parchment';
 import Emitter from '../core/emitter';
 import Block, { BlockEmbed } from './block';
 import Break from './break';
@@ -103,7 +103,11 @@ class Scroll extends ScrollBlot {
   }
 
   leaf(index) {
-    return this.path(index).pop() || [null, -1];
+    const last = this.path(index).pop();
+    if (!last || !(last[0] instanceof LeafBlot)) {
+      return [null, -1];
+    }
+    return last;
   }
 
   line(index) {

--- a/core/quill.js
+++ b/core/quill.js
@@ -249,6 +249,7 @@ class Quill {
     } else {
       bounds = this.selection.getBounds(index.index, index.length);
     }
+    if (!bounds) return null;
     const containerBounds = this.container.getBoundingClientRect();
     return {
       bottom: bounds.bottom - containerBounds.top,

--- a/test/unit/core/selection.js
+++ b/test/unit/core/selection.js
@@ -630,5 +630,14 @@ describe('Selection', function() {
         this.bounds = selection.getBounds(0, 10);
       }).not.toThrow();
     });
+
+    it('empty container', function() {
+      const selection = this.initialize(
+        Selection,
+        '<table><tr><td data-row="a">a</td></tr></table>',
+      );
+      this.quill.updateContents([{ retain: 1 }, { insert: '\n' }]);
+      expect(selection.getBounds(2, 0)).toEqual(null);
+    });
   });
 });


### PR DESCRIPTION
Previously, `Quill#getLeaf()` can return non-leaf blots, which is unexpected. For example, it breaks `Selection#getBounds()` as it calls `leaf.position(offset, true)`, which is only provided by leaf blots.

The reason `Quill#getLeaf()` may return a non-leaf blot is, in `ParentBlot#path()`, if `this.children.find(index, inclusive)` return `[null, 0]` (aka the parent blot is empty), the last element of the path would be the parent blot itself, causing `Scroll#leaf()` gets the parent blot.

The reason that a parent blot can be empty is in `Container#optimize()`, [we don't call](https://github.com/quilljs/parchment/blob/4257051dfc0a9c3e240c4906f8e36a697f95b1f8/src/blot/abstract/container.ts#L40) container's children's `optimize()` function, so the children who are parent blots don't have a chance to create a default child. I haven't reproduced this in practice so not 100% sure, but programmatically a reproducible example can be found in the added test case in this PR.

----

This PR ensures `Scroll#leaf()` always returns a leaf or `null`. In fact, this won't happen if we get `Container#optimize()` fixed, so it may be debatable whether we should do the check. However, IMO people may override `Container#optmize()` and forget optimizing children even we fix it on our side, so to make `Scroll#leaf()` complete, a check would be helpful.