### PR TITLE
Fix getBounds of empty text nodes

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -152,6 +152,14 @@ class Selection {
     let side = 'left';
     let rect;
     if (node instanceof Text) {
+      // Return null if the text node is empty because it is
+      // not able to get a useful client rect:
+      // https://github.com/w3c/csswg-drafts/issues/2514.
+      // Empty text nodes are most likely caused by TextBlot#optimize()
+      // not getting called when editor content changes.
+      if (!node.data.length) {
+        return null;
+      }
       if (offset < node.data.length) {
         range.setStart(node, offset);
         range.setEnd(node, offset + 1);


### PR DESCRIPTION
This PR fixes the exception of `Error: Failed to execute 'setStart' on 'Range': The offset 4294967295 is larger than the node's length`.

It happens when the `Text` node is empty, which is possibly caused by the `Container#optimize()` issue mentioned in https://github.com/quilljs/quill/pull/3489.