### PR TITLE
fix getHTML when the range is not root

### DIFF
--- a/core/editor.js
+++ b/core/editor.js
@@ -143,7 +143,7 @@ class Editor {
   getHTML(index, length) {
     const [line, lineOffset] = this.scroll.line(index);
     if (line.length() >= lineOffset + length) {
-      return convertHTML(line, lineOffset, length, true);
+      return convertHTML(line, lineOffset, length, false);
     }
     return convertHTML(this.scroll, index, length, true);
   }


### PR DESCRIPTION
This PR fixes the Error: the formats does not copied when the selection is in the blot. which is also mentioned in #2853