### PR TITLE
Run clipboard matchers against plain text pastes

### DIFF
--- a/modules/clipboard.ts
+++ b/modules/clipboard.ts
@@ -100,7 +100,10 @@ class Clipboard extends Module<ClipboardOptions> {
       });
     }
     if (!html) {
-      return new Delta().insert(text || '');
+      html = (text || '')
+        .split('\n')
+        .map(line => `<p>${line}</p>`)
+        .join('');
     }
     const delta = this.convertHTML(html);
     // Remove trailing newline


### PR DESCRIPTION
At the moment, if the clipboard pastes `text/plain` content and no
`text/html` content, the `Clipboard.convert()` function will completely
skip the matching logic.

This is surprising when registering text node clipboard matchers.

This change updates the `convert()` function to change the plain text
into basic HTML, which is passed through the matchers.

The conversion interprets newlines as paragraph `<p>` elements,
consistent with Quill's existing behaviour.