### PR TITLE
Move code escaping to `html()`

### DIFF
--- a/formats/code.js
+++ b/formats/code.js
@@ -14,17 +14,16 @@ class CodeBlockContainer extends Container {
   }
 
   code(index, length) {
-    const text = this.children
+    return this.children
       .map(child => (child.length() <= 1 ? '' : child.domNode.innerText))
       .join('\n')
       .slice(index, index + length);
-    return escapeText(text);
   }
 
   html(index, length) {
     // `\n`s are needed in order to support empty lines at the beginning and the end.
     // https://html.spec.whatwg.org/multipage/syntax.html#element-restrictions
-    return `<pre>\n${this.code(index, length)}\n</pre>`;
+    return `<pre>\n${escapeText(this.code(index, length))}\n</pre>`;
   }
 }
 

--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -141,9 +141,8 @@ class SyntaxCodeBlockContainer extends CodeBlockContainer {
       ? SyntaxCodeBlock.formats(codeBlock.domNode)
       : 'plain';
 
-    return `<pre data-language="${language}">\n${this.code(
-      index,
-      length,
+    return `<pre data-language="${language}">\n${escapeText(
+      this.code(index, length),
     )}\n</pre>`;
   }
 


### PR DESCRIPTION
The `code()` method should be rendering target agnostic so this PR moves the encode logic to `html()`. It breaks BC for `code()` but it was introduced in 2.0 and we don't have it documented or decided to make it as a public API yet so should be fine.