### PR TITLE
Keep cursor unlinked to avoid elements being pushed down inside

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -155,7 +155,8 @@ class Clipboard extends Module {
     if (!html && files.length > 0) {
       this.quill.uploader.upload(range, files);
       return;
-    } else if (html && files.length > 0) {
+    }
+    if (html && files.length > 0) {
       const doc = new DOMParser().parseFromString(html, 'text/html');
       if (
         doc.body.childElementCount === 1 &&

--- a/test/unit/core/selection.js
+++ b/test/unit/core/selection.js
@@ -441,6 +441,40 @@ describe('Selection', function() {
         <p>01<em><span class="ql-cursor">${Cursor.CONTENTS}</span></em>23</p>
       `);
     });
+
+    describe('unlink cursor', function() {
+      const cursorHTML = `<span class="ql-cursor">${Cursor.CONTENTS}</span>`;
+
+      it('one level', function() {
+        this.setup(
+          '<p><strong><a href="https://example.com">link</a></strong></p><p><br></p>',
+          4,
+        );
+        this.selection.format('bold', false);
+        expect(this.container).toEqualHTML(`
+          <p><strong><a href="https://example.com">link</a></strong>${cursorHTML}</p><p><br></p>
+        `);
+      });
+
+      it('nested formats', function() {
+        this.setup(
+          '<p><strong><em><a href="https://example.com">bold</a></em></strong></p><p><br></p>',
+          4,
+        );
+        this.selection.format('italic', false);
+        expect(this.container).toEqualHTML(`
+          <p><strong><em><a href="https://example.com">bold</a></em>${cursorHTML}</strong></p><p><br></p>
+        `);
+      });
+
+      it('ignore link format', function() {
+        this.setup('<p><strong>bold</strong></p><p><br></p>', 4);
+        this.selection.format('link', 'https://example.com');
+        expect(this.container).toEqualHTML(`
+          <p><strong>bold${cursorHTML}</strong></p><p><br></p>
+        `);
+      });
+    });
   });
 
   describe('getBounds()', function() {


### PR DESCRIPTION
When `.ql-cursor` is inside a link, and the user types a character, Safari will [push down the link](https://github.com/WebKit/WebKit/blob/04b6d7ece074eeb461d3e222d468ef0836256191/Source/WebCore/editing/CompositeEditCommand.cpp#L1706) inside `.ql-cursor` and move the cursor's `textNode` inside the link. This breaks our position calculation. So this PR makes sure the cursor is always unlinked to avoid this.

To test:

1. Type "abc", bold them and linkify them.
2. Move the caret after "c", press cmd+b to cancel the bold format.
3. Type any characters, and delete some characters, make sure everything works as expected.