### PR TITLE
Avoid fetching selections when possible

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -194,6 +194,12 @@ class Selection {
   }
 
   getRange() {
+    const root = this.scroll.domNode;
+    if ('isConnected' in root && !root.isConnected) {
+      // document.getSelection() forces layout on Blink, so we trend to
+      // not calling it.
+      return [null, null];
+    }
     const normalized = this.getNativeRange();
     if (normalized == null) return [null, null];
     const range = this.normalizedToRange(normalized);


### PR DESCRIPTION
On Blink, `document.getSelection()` [forces](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/dom_selection.cc;l=207) [layout](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/editing/frame_selection.cc;l=159-160;drc=dc3638e64423b1d2d5e3323b419028ab631f3923) which breaks the browser's optimization of batch DOM mutations. The impact on the performance is noticeable when you do a lot of DOM mutations and `getRange()` at the same time. It is worth noticing that editor mutation triggers `getRange()` (https://github.com/quilljs/quill/blob/d462f8000ffbaa3aab853809fb08f7809f828475/core/quill.js#L103) so the impact is non-trivial when you initialize many Quill instances at the same time.

This PR optimizes Quill initialization when the container has not been inserted into the DOM tree yet. This enables an optimization possibility that users can insert the Quill container **after** the content is initialized. So instead of:

```js
const container = document.body.appendChild(
  document.createElement('div')
);

const quill = new Quill(container);
```

Users can:

```js
const container = document.createElement('div');
const quill = new Quill(container);
document.body.appendChild(container);
```

As an example, when rendering 4000 Quill instances on a page, previously it took ~2min:


<img width="327" alt="CleanShot 2022-02-24 at 16 56 07@2x" src="https://user-images.githubusercontent.com/635902/155491533-728a3e1e-5b27-4bd5-a190-e629e842cc18.png">

And after this PR, it only takes 14s:

<img width="340" alt="CleanShot 2022-02-24 at 16 57 14@2x" src="https://user-images.githubusercontent.com/635902/155491698-3d2705b9-01c8-4b69-a8e0-c89958ec39b3.png">

