### PR TITLE
No need to setContents when container is empty

### DIFF
--- a/core/quill.js
+++ b/core/quill.js
@@ -109,11 +109,13 @@ class Quill {
         source,
       );
     });
-    const contents = this.clipboard.convert({
-      html: `${html}<p><br></p>`,
-      text: '\n',
-    });
-    this.setContents(contents);
+    if (html) {
+      const contents = this.clipboard.convert({
+        html: `${html}<p><br></p>`,
+        text: '\n',
+      });
+      this.setContents(contents);
+    }
     this.history.clear();
     if (this.options.placeholder) {
       this.root.setAttribute('data-placeholder', this.options.placeholder);


### PR DESCRIPTION
It's only necessary to call `setContents()` when `html` is not empty. Otherwise, we can avoid it for better performance.