### PR TITLE
Alternate way of handling text replacement.

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -269,6 +269,25 @@ class Keyboard extends Module {
     this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
     this.quill.focus();
   }
+  
+  onCaptureKeypress(event) {
+    if (event.defaultPrevented || !this.quill.isEnabled()) return;
+
+    const range = this.quill.getSelection(true);
+    if (range == null || range.length == 0) return;
+
+    event.preventDefault();
+    this.handleKeypress(range, event.key);
+  }
+
+
+  handleKeypress(range, key) {
+    const delta = new Delta().retain(range.index).delete(range.length).insert(key);
+    this.quill.updateContents(delta, Quill.sources.USER);
+
+    this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
+    this.quill.focus();
+  }
 }
 
 Keyboard.DEFAULTS = {


### PR DESCRIPTION
Remove the need of mutation observer in case of selected text getting replaced on keypress. Making the behaviour exactly same as first deleting a range of text & then inserting a char.

Why is this required? - Because we are entirely dependent on the browser dom to make the changes correctly and if there are any mistakes, then we need to reactively make the changes required after looking at mutation records from the browser. This is specially a nightmare when we are dealing with custom blots/attributors. The proposed changes will bypass the need of mutation observer altogether!