### PR TITLE
Fixing incorrect deletion in case of embed blot

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -222,11 +222,11 @@ class Selection {
       const [node, offset] = position;
       const blot = this.scroll.find(node, true);
       const index = blot.offset(this.scroll);
-      if (offset === 0) {
-        return index;
-      }
       if (blot instanceof LeafBlot) {
         return index + blot.index(node, offset);
+      }
+      if (offset === 0) {
+        return index;
       }
       return index + blot.length();
     });


### PR DESCRIPTION
Embedblots have a left guard and a right guard. On placing the cursor after an embedblot and pressing backspace, the character just before embed blot is deleted instead of the embed blot. This is because the getSelection api returns incorrect value (actual value -1). This was happening because in the normalizedToRange function, the node was correctly found to be the right guard dom node, with an offset of zero. The index was also correctly found to be the index of the embed blot. However, before the offset had a change to be corrected by calling the blot.index(node,offset) function (which would have returned 1 for right guard), the incorrect value was returned by the if statement above it. 

FIX: Move the check for LeafBlot above the offset===0 check.