### PR TITLE
🐛 Fix inserting newlines into formatted text

### DIFF
--- a/core/editor.ts
+++ b/core/editor.ts
@@ -27,7 +27,8 @@ class Editor {
     this.scroll.batchStart();
     const normalizedDelta = normalizeDelta(delta);
     const deleteDelta = new Delta();
-    normalizedDelta.reduce((index, op) => {
+    const normalizedOps = splitOpLines(normalizedDelta.ops.slice());
+    normalizedOps.reduce((index, op) => {
       const length = Op.length(op);
       let attributes = op.attributes || {};
       let isImplicitNewlinePrepended = false;
@@ -410,6 +411,23 @@ function shiftRange(
   amount: number,
 ) {
   return new Range(index + amount, length);
+}
+
+function splitOpLines(ops) {
+  const split = [];
+  ops.forEach(op => {
+    if (typeof op.insert === 'string') {
+      const lines = op.insert.split('\n');
+      lines.forEach((line, index) => {
+        if (index) split.push({ insert: '\n', attributes: op.attributes });
+        if (line) split.push({ insert: line, attributes: op.attributes });
+      });
+    } else {
+      split.push(op);
+    }
+  });
+
+  return split;
 }
 
 export default Editor;

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -755,6 +755,14 @@ describe('Editor', function () {
       editor.applyDelta(new Delta().delete(4).retain(1).delete(2));
       expect(editor.scroll.domNode.innerHTML).toEqual('<p>2</p>');
     });
+
+    it('prepending bold with a newline and unformatted text', function () {
+      const editor = this.initialize(Editor, '<p><strong>a</strong></p>');
+      editor.applyDelta(new Delta().insert('\n1'));
+      expect(this.container).toEqualHTML(
+        '<p><br></p><p>1<strong>a</strong></p>',
+      );
+    });
   });
 
   describe('getFormat()', function () {


### PR DESCRIPTION
Consider a document with a single piece of bold text. As a `Delta`, this
would be represented as:

```js
const doc = new Delta().insert('a', {bold: true})
```

Now consider the following `Delta` being applied:

```js
const delta = new Delta().insert('\n1')
```

The above `Delta` will:

  - prepend the document with a newline
  - follow that newline with an **unformatted** string

Indeed, using `doc.compose(delta)` yields:

```js
const result = new Delta()
  .insert('\n1')
  .insert('a', {bold: true})
```

However, the same result is not reached when using the Quill
`editor.applyDelta()`, which instead results in bold formatting being
incorrectly applied to our unformatted string:

```js
const badResult = new Delta()
  .insert('\n')
  .insert('1a', {bold: true})
```

This happens because Quill does an insert of the whole insertion, but
doesn't handle the line splitting.

This change fixes this issue by splitting ops on newlines, and handling
them separately, which applies the correct formatting.