### PR TITLE
Improve Tab handling in code block

### DIFF
--- a/modules/keyboard.js
+++ b/modules/keyboard.js
@@ -551,8 +551,17 @@ function makeCodeBlockHandler(indent) {
     key: 'Tab',
     shiftKey: !indent,
     format: { 'code-block': true },
-    handler(range) {
+    handler(range, { event }) {
       const CodeBlock = this.quill.scroll.query('code-block');
+      if (range.length === 0 && !event.shiftKey) {
+        this.quill.insertText(range.index, CodeBlock.TAB, Quill.sources.USER);
+        this.quill.setSelection(
+          range.index + CodeBlock.TAB.length,
+          Quill.sources.SILENT,
+        );
+        return;
+      }
+
       const lines =
         range.length === 0
           ? this.quill.getLines(range.index, 1)


### PR DESCRIPTION
Until this change, the Tab key always indented selected lines. However, it's more common for code editors to insert tab char with collapsed selection.

To test:
1. When the selection is collapsed, Tab should insert `CodeBlock.TAB`.
2. With the shift key pressed, Tab should always reduce indention.
3. Otherwise it should keep the current behavior.