### PR TITLE
Fill color picker label background as selected color for more accessibility

### DIFF
--- a/themes/base.js
+++ b/themes/base.js
@@ -130,7 +130,7 @@ class BaseTheme extends Theme {
             format === 'background' ? '#ffffff' : '#000000',
           );
         }
-        return new ColorPicker(select, icons[format]);
+        return new ColorPicker(select, icons[format], format);
       }
       if (select.querySelector('option') == null) {
         if (select.classList.contains('ql-font')) {

--- a/ui/color-picker.js
+++ b/ui/color-picker.js
@@ -1,8 +1,9 @@
 import Picker from './picker';
 
 class ColorPicker extends Picker {
-  constructor(select, label) {
+  constructor(select, label, format) {
     super(select);
+    this.format = format;
     this.label.innerHTML = label;
     this.container.classList.add('ql-color-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item'))
@@ -20,16 +21,55 @@ class ColorPicker extends Picker {
 
   selectItem(item, trigger) {
     super.selectItem(item, trigger);
-    const colorLabel = this.label.querySelector('.ql-color-label');
+
+    const selectors = {
+      color: '.ql-stroke',
+      background: '.ql-fill > rect',
+    };
+
+    const svgShapes = this.label.querySelectorAll(selectors[this.format]);
     const value = item ? item.getAttribute('data-value') || '' : '';
-    if (colorLabel) {
-      if (colorLabel.tagName === 'line') {
-        colorLabel.style.stroke = value;
-      } else {
-        colorLabel.style.fill = value;
+
+    if (this.format === 'color') {
+      this.label.querySelector('svg').style.backgroundColor = value;
+    }
+
+    if (!value) {
+      for (const svgShape of svgShapes) {
+        if (svgShape) {
+          svgShape.style = {};
+        }
+      }
+      return;
+    }
+
+    const calculateStrokeColor = {
+      color: () => {
+        const [r, g, b] = hexToRgb(value);
+        const isCloseToBrightColor = (r + g + b) / 3 > 127;
+
+        return isCloseToBrightColor ? '#000' : '#fff';
+      },
+      background: () => value,
+    };
+
+    for (const svgShape of svgShapes) {
+      if (svgShape) {
+        svgShape.style.stroke = calculateStrokeColor[this.format]();
       }
     }
   }
+}
+
+function hexToRgb(hex) {
+  return hex
+    .replace(
+      /^#?([a-f\d])([a-f\d])([a-f\d])$/i,
+      (m, r, g, b) => `#${r + r + g + g + b + b}`,
+    )
+    .substring(1)
+    .match(/.{2}/g)
+    .map(x => parseInt(x, 16));
 }
 
 export default ColorPicker;


### PR DESCRIPTION
It is hard to determine in eyes which color is currently selected based on the 'A' glyph-shaped label color.

So I would like to suggest inverting color picker background color between label colors for accessibility:

| AS-IS | suggestion |
| :--: | :--: |
| <img width="197" alt="Screen Shot 2022-07-24 at 7 53 54 PM" src="https://user-images.githubusercontent.com/5278201/180644111-5dfd3023-ec70-4c43-8f40-1431d29bfa15.png"> | <img width="194" alt="Screen Shot 2022-07-24 at 7 41 30 PM" src="https://user-images.githubusercontent.com/5278201/180644118-6b6a997b-1a97-4cca-a3af-0ecde0f50e39.png"> |


