### PR TITLE
Bug: selection is sometimes not left updated after modify

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -657,6 +657,8 @@ function modify(modifier, source, index, shift) {
       range = shiftRange(range, index, shift, source);
     }
     this.setSelection(range, Emitter.sources.SILENT);
+  } else {
+    this.selection.update(Emitter.sources.SILENT);
   }
   if (change.length() > 0) {
     const args = [Emitter.events.TEXT_CHANGE, change, oldDelta, source];


### PR DESCRIPTION
I noticed this commit: https://github.com/quilljs/quill/commit/efcd75c8523c437aafb53d5806224ec603fa3f5c

Which was made it seems under an assmption that `modify()` would always `SILENT`ly update the selection. This doesn't happen when you navigate with your cursor, which was causing bugs in the `quill-emoji` plugin. This PR ensures that the selection is always updated properly.