### PR TITLE
Add aria labels to toolbar

### DIFF
--- a/modules/toolbar.js
+++ b/modules/toolbar.js
@@ -57,6 +57,18 @@ class Toolbar extends Module {
     format = format.slice('ql-'.length);
     if (input.tagName === 'BUTTON') {
       input.setAttribute('type', 'button');
+      input.setAttribute('aria-label', format);
+      if (input.value) {
+        input.setAttribute('aria-label', `${format} ${input.value}`);
+      }
+      if (format === 'direction') {
+        input.setAttribute(
+          'aria-label',
+          `Text ${format} ${
+            input.value === 'rtl' ? 'right to left' : 'left to right'
+          }`,
+        );
+      }
     }
     if (
       this.handlers[format] == null &&
@@ -153,9 +165,11 @@ Toolbar.DEFAULTS = {};
 function addButton(container, format, value) {
   const input = document.createElement('button');
   input.setAttribute('type', 'button');
+  input.setAttribute('aria-label', format);
   input.classList.add(`ql-${format}`);
   if (value != null) {
     input.value = value;
+    input.setAttribute('aria-label', `${value} ${format}`);
   }
   container.appendChild(input);
 }

--- a/test/unit/modules/toolbar.js
+++ b/test/unit/modules/toolbar.js
@@ -7,8 +7,8 @@ describe('Toolbar', function() {
       addControls(this.container, ['bold', 'italic']);
       expect(this.container).toEqualHTML(`
         <span class="ql-formats">
-          <button type="button" class="ql-bold"></button>
-          <button type="button" class="ql-italic"></button>
+          <button type="button" aria-label="bold" class="ql-bold"></button>
+          <button type="button" aria-label="italic" class="ql-italic"></button>
         </span>
       `);
     });
@@ -20,12 +20,12 @@ describe('Toolbar', function() {
       ]);
       expect(this.container).toEqualHTML(`
         <span class="ql-formats">
-          <button type="button" class="ql-bold"></button>
-          <button type="button" class="ql-italic"></button>
+          <button type="button" aria-label="bold" class="ql-bold"></button>
+          <button type="button" aria-label="italic" class="ql-italic"></button>
         </span>
         <span class="ql-formats">
-          <button type="button" class="ql-underline"></button>
-          <button type="button" class="ql-strike"></button>
+          <button type="button" aria-label="underline" class="ql-underline"></button>
+          <button type="button" aria-label="strike" class="ql-strike"></button>
         </span>
       `);
     });
@@ -34,8 +34,8 @@ describe('Toolbar', function() {
       addControls(this.container, ['bold', { header: '2' }]);
       expect(this.container).toEqualHTML(`
         <span class="ql-formats">
-          <button type="button" class="ql-bold"></button>
-          <button type="button" class="ql-header" value="2"></button>
+          <button type="button" aria-label="bold" class="ql-bold"></button>
+          <button type="button" aria-label="2 header" class="ql-header" value="2"></button>
         </span>
       `);
     });
@@ -83,14 +83,14 @@ describe('Toolbar', function() {
           </select>
         </span>
         <span class="ql-formats">
-          <button type="button" class="ql-bold"></button>
-          <button type="button" class="ql-italic"></button>
-          <button type="button" class="ql-underline"></button>
-          <button type="button" class="ql-strike"></button>
+          <button type="button" aria-label="bold" class="ql-bold"></button>
+          <button type="button" aria-label="italic" class="ql-italic"></button>
+          <button type="button" aria-label="underline" class="ql-underline"></button>
+          <button type="button" aria-label="strike" class="ql-strike"></button>
         </span>
         <span class="ql-formats">
-          <button type="button" class="ql-list" value="ordered"></button>
-          <button type="button" class="ql-list" value="bullet"></button>
+          <button type="button" aria-label="ordered list" class="ql-list" value="ordered"></button>
+          <button type="button" aria-label="bullet list" class="ql-list" value="bullet"></button>
           <select class="ql-align">
             <option selected="selected"></option>
             <option value="center"></option>
@@ -99,8 +99,8 @@ describe('Toolbar', function() {
           </select>
         </span>
         <span class="ql-formats">
-          <button type="button" class="ql-link"></button>
-          <button type="button" class="ql-image"></button>
+          <button type="button" aria-label="link" class="ql-link"></button>
+          <button type="button" aria-label="image" class="ql-image"></button>
         </span>
       `);
     });

--- a/test/unit/ui/picker.js
+++ b/test/unit/ui/picker.js
@@ -20,7 +20,7 @@ describe('Picker', function() {
       this.container.querySelector('.ql-picker-item:not(.ql-selected)')
         .outerHTML,
     ).toEqualHTML(
-      '<span tabindex="0" role="button" class="ql-picker-item" data-value="1" data-label="1"></span>',
+      '<span tabindex="0" role="button" class="ql-picker-item" aria-label="1" data-value="1" data-label="1"></span>',
     );
   });
 

--- a/themes/base.js
+++ b/themes/base.js
@@ -111,6 +111,7 @@ class BaseTheme extends Theme {
   buildPickers(selects, icons) {
     this.pickers = Array.from(selects).map(select => {
       if (select.classList.contains('ql-align')) {
+        select.setAttribute('aria-label', 'Align text');
         if (select.querySelector('option') == null) {
           fillSelect(select, ALIGNS);
         }
@@ -120,6 +121,12 @@ class BaseTheme extends Theme {
         select.classList.contains('ql-background') ||
         select.classList.contains('ql-color')
       ) {
+        if (select.classList.contains('ql-background')) {
+          select.setAttribute('aria-label', 'Background color');
+        }
+        if (select.classList.contains('ql-color')) {
+          select.setAttribute('aria-label', 'Text color');
+        }
         const format = select.classList.contains('ql-background')
           ? 'background'
           : 'color';
@@ -134,10 +141,12 @@ class BaseTheme extends Theme {
       }
       if (select.querySelector('option') == null) {
         if (select.classList.contains('ql-font')) {
+          select.setAttribute('aria-label', 'Select a Font');
           fillSelect(select, FONTS);
         } else if (select.classList.contains('ql-header')) {
           fillSelect(select, HEADERS);
         } else if (select.classList.contains('ql-size')) {
+          select.setAttribute('aria-label', 'Select a font size');
           fillSelect(select, SIZES);
         }
       }

--- a/ui/icon-picker.js
+++ b/ui/icon-picker.js
@@ -6,6 +6,9 @@ class IconPicker extends Picker {
     this.container.classList.add('ql-icon-picker');
     Array.from(this.container.querySelectorAll('.ql-picker-item')).forEach(
       item => {
+        if (item.getAttribute('data-value') === null) {
+          item.setAttribute('aria-label', 'Left');
+        }
         item.innerHTML = icons[item.getAttribute('data-value') || ''];
       },
     );

--- a/ui/picker.js
+++ b/ui/picker.js
@@ -49,6 +49,10 @@ class Picker {
     item.classList.add('ql-picker-item');
     if (option.hasAttribute('value')) {
       item.setAttribute('data-value', option.getAttribute('value'));
+      item.setAttribute(
+        'aria-label',
+        this.getAriaLabel(option.getAttribute('value')),
+      );
     }
     if (option.textContent) {
       item.setAttribute('data-label', option.textContent);
@@ -71,6 +75,90 @@ class Picker {
     });
 
     return item;
+  }
+
+  getAriaLabel(value) {
+    if (value.startsWith('#')) {
+      return this.convertHexCodeToHumanReadableString(value);
+    }
+    return value;
+  }
+
+  convertHexCodeToHumanReadableString(value) {
+    switch (value) {
+      case '#e60000':
+        return 'Electric red';
+      case '#ff9900':
+        return 'Light orange';
+      case '#ffff00':
+        return 'Yellow';
+      case '#008a00':
+        return 'Green';
+      case '#0066cc':
+        return 'Navy blue';
+      case '#9933ff':
+        return 'Blue violet';
+      case '#ffffff':
+        return 'White';
+      case '#facccc':
+        return 'Light pink';
+      case '#ffebcc':
+        return 'Light yellow';
+      case '#ffffcc':
+        return 'Cream';
+      case '#cce8cc':
+        return 'Light sage';
+      case '#cce0f5':
+        return 'Light blue';
+      case '#ebd6ff':
+        return 'Light purple';
+      case '#bbbbbb':
+        return 'Silver';
+      case '#f06666':
+        return 'Salmon';
+      case '#ffc266':
+        return 'Light orange';
+      case '#ffff66':
+        return 'Lemon';
+      case '#66b966':
+        return 'Fern';
+      case '#66a3e0':
+        return 'Cornflower blue';
+      case '#c285ff':
+        return 'Purple';
+      case '#888888':
+        return 'Gray';
+      case '#a10000':
+        return 'Dark red';
+      case '#b26b00':
+        return 'Orange-brown';
+      case '#b2b200':
+        return 'Chartreuse';
+      case '#006100':
+        return 'Forest green';
+      case '#0047b2':
+        return 'Cobalt blue';
+      case '#6b24b2':
+        return 'Deep purple';
+      case '#444444':
+        return 'Dark gray';
+      case '#5c0000':
+        return 'Dark purple';
+      case '#663d00':
+        return 'Nutmeg brown';
+      case '#666600':
+        return 'Dark yellow-green';
+      case '#003700':
+        return 'Deep fir green';
+      case '#002966':
+        return 'Midnight blue';
+      case '#3d1466':
+        return 'Deepest purple';
+      case '#000000':
+        return 'Black';
+      default:
+        return '';
+    }
   }
 
   buildLabel() {


### PR DESCRIPTION
Adds aria-labels to improve the accessibility of toolbar elements and color picker dropdowns. Some existing unit tests had to be tweaked in order to add these aria-labels to the html markup but all tests pass.
<img width="1318" alt="Screen Shot 2022-08-25 at 7 44 48 AM" src="https://user-images.githubusercontent.com/79113236/186681572-c056d00e-88c7-4cd7-8b09-946dcb1ecef9.png">


addresses these issues:
[#3360](https://github.com/quilljs/quill/issues/3360)
[#3320](https://github.com/quilljs/quill/issues/3320)
[#2038](https://github.com/quilljs/quill/issues/2038)
 