### PR TITLE
TypeScript compatibility improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .*
 !.eslintrc.json
 !.eslintignore
+!.npmignore
 
 /dist
 /node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+*.ts
+!*.d.ts
+.*
+Gemfile
+Gemfile.lock
+_develop
+.github
+.vscode
+docs
+test
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -5,20 +5,6 @@
   "author": "Jason Chen <jhchen7@gmail.com>",
   "homepage": "http://quilljs.com",
   "main": "dist/quill.js",
-  "exports": {
-    ".": "./dist/quill.js",
-    "./core": "./dist/core.js",
-    "./blots/*": "./dist/blots/*.js",
-    "./formats/*": "./dist/formats/*.js",
-    "./modules/*": "./dist/modules/*.js",
-    "./themes/*": "./dist/themes/*.js",
-    "./ui/*": "./dist/ui/*.js",
-    "./assets/": "./assets/"
-  },
-  "files": [
-    "assets",
-    "dist"
-  ],
   "config": {
     "ports": {
       "proxy": "9000",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "outDir": "./dist",
     "allowSyntheticDefaultImports": true,
     "target": "es6",
     "sourceMap": true,


### PR DESCRIPTION
This PR reverts https://github.com/quilljs/quill/pull/3631/commits/1f484a20e1a61a6929ec2c2e9595c21e6e3a388a to improve the compatibility with TypeScript by moving from `exports`.

TypeScript 4.7 supported `exports` but it requires `moduleResolution` set to `Node16`. This leads to some side effects like relative imports have to include the extename (`import('../a.js')` instead of `import('../a')`), and most importantly `Node16` is not designed to be used together with bundlers in browser environments, as its name suggests and it brings some Node.js-specific requirements and behaviors.

TypeScript 4.9 may provide some `moduleResolution` modes that can support `exports` without introducing any Node.js-specific behaviors: https://github.com/microsoft/TypeScript/issues/50152. However, at best it will release at the end of this year so this is not something we can rely on now.

The con of this PR is the TS outputs can clutter the dev filetree but it can be resolved with an additional build step (set the output path to `/dist` and when publish run `npm publish ./dist`) or a script to delete all outputs (seems the only case we build the TS is before publishing). Either of the workaround can be addressed in a separate PR/ticket.
