### PR TITLE
Patch Security Issue CVE-2021-3163 #3364

### DIFF
--- a/modules/clipboard.js
+++ b/modules/clipboard.js
@@ -74,7 +74,7 @@ class Clipboard extends Module {
 
   convert(html) {
     if (typeof html === 'string') {
-      this.container.innerHTML = html.replace(/\>\r?\n +\</g, '><'); // Remove spaces between tags
+      this.container.replaceChildren(...(new DOMParser()).parseFromString(html, "text/html").body.children)
       return this.convert();
     }
     const formats = this.quill.getFormat(this.quill.selection.savedRange.index);


### PR DESCRIPTION
The purpose of setting the html string to container is to get the HTML elements. It is unsafe to do this via set innerHTML, which must render the HTML (including any inline javascript) to generate the HTML elements. In Quill 2, this problem is fixed by using DOMParser in a similar way as done here.