### PR TITLE
Fix errors when canceling IME compositions.

### DIFF
--- a/core/selection.js
+++ b/core/selection.js
@@ -62,8 +62,9 @@ class Selection {
     this.root.addEventListener('compositionstart', () => {
       this.composing = true;
     });
-    this.root.addEventListener('compositionend', () => {
+    this.root.addEventListener('compositionend', (e) => {
       this.composing = false;
+      if (e.data.length === 0) return;
       if (this.cursor.parent) {
         const range = this.cursor.restore();
         if (!range) return;


### PR DESCRIPTION
This resolves #1698
The code is fundamentally compatible with develop, and the issue still exists there.

Trying to restore the cursor in this case will remove the cursor (since the text is just the cursor content). In this case, we want to skip any further action.

The simplest repro I've found is:
- Using Microsoft Bopomofo on Windows
- Navigate to https://quilljs.com/standalone/snow/ (I used Chrome, latest)
- Click a format, like Bold (this adds the cursor node)
- Start a composition, then hit ESC.

Notice that focus is lost and "selection.js:294 addRange(): The given range isn't in document." is logged to console.