### PR TITLE
Add missing typing for Quill.find

### DIFF
--- a/core/instances.ts
+++ b/core/instances.ts
@@ -1,1 +1,3 @@
-export default new WeakMap();
+import type Quill from '../core';
+
+export default new WeakMap<Node, Quill>();


### PR DESCRIPTION
Previously `Quill.find()` returned `any`, whereas it should be `Quill | Blot`.