### PR TITLE
Refactor Selection#scrollIntoView()

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -650,7 +650,7 @@ class Quill {
       [index, length, , source] = overload(index, length, source);
       this.selection.setRange(new Range(Math.max(0, index), length), source);
       if (source !== Emitter.sources.SILENT) {
-        this.selection.scrollIntoView(this.scrollingContainer);
+        this.scrollIntoView();
       }
     }
   }

--- a/core/selection.ts
+++ b/core/selection.ts
@@ -331,13 +331,6 @@ class Selection {
     if (range == null) return;
     const bounds = this.getBounds(range.index, range.length);
     if (bounds == null) return;
-    const limit = this.scroll.length() - 1;
-    const [first] = this.scroll.line(Math.min(range.index, limit));
-    let last = first;
-    if (range.length > 0) {
-      [last] = this.scroll.line(Math.min(range.index + range.length, limit));
-    }
-    if (first == null || last == null) return;
     const scrollBounds = scrollingContainer.getBoundingClientRect();
     if (bounds.top < scrollBounds.top) {
       scrollingContainer.scrollTop -= scrollBounds.top - bounds.top;


### PR DESCRIPTION
<del>Breaking Change: This PR moves scrollIntoView from selection to quill to make it easier to be overridden. The only reason `scrollIntoView` was in selection seems to be the usage of `lastRange` but in quill we already use `this.selection.lastRange`.</del> On second thought I think semantically it makes sense to keep it in the selection module.

Also not sure why `if (first == null || last == null) return;` is needed so this PR removes it.