### PR TITLE
Use displayMode in formula

### DIFF
--- a/formats/formula.ts
+++ b/formats/formula.ts
@@ -16,6 +16,7 @@ class Formula extends Embed {
       window.katex.render(value, node, {
         throwOnError: false,
         errorColor: '#f00',
+        displayMode: true,
       });
       node.setAttribute('data-value', value);
     }


### PR DESCRIPTION
Render with Katex with the config `displayMode: true` will provide a nice block format of formula, instead of the current inline style.