### PR TITLE
🏷️ Fix Toolbar `Handler` type

### DIFF
--- a/modules/toolbar.ts
+++ b/modules/toolbar.ts
@@ -6,7 +6,7 @@ import Module from '../core/module';
 
 const debug = logger('quill:toolbar');
 
-type Handler = () => void;
+type Handler = (value: any) => void;
 
 interface ToolbarProps {
   container: HTMLElement;


### PR DESCRIPTION
Handlers are called with a format-dependent [`value`][1].

This change updates the `Handler` type to allow passing a value.

[1]: https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/modules/toolbar.ts#L106