### PR TITLE
🏷️ Fix `Quill.getFormat()` arguments

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -429,8 +429,8 @@ class Quill {
     return this.editor.getContents(index, length);
   }
 
-  getFormat(index: number, length?: number);
-  getFormat(range: { index: number; length: number });
+  getFormat(index?: number, length?: number);
+  getFormat(range?: { index: number; length: number });
   getFormat(
     index: { index: number; length: number } | number = this.getSelection(true),
     length = 0,


### PR DESCRIPTION
`Quill.getFormat()` is allowed to be called with no arguments, since it [defaults][1] to just getting the current selection.

However, the overload declarations require arguments, resulting in a compilation error when trying to call `getFormat()` with no arguments:

```
(method) Quill.getFormat(index: number, length?: number): any (+1 overload)
Expected 1-2 arguments, but got 0.ts(2554)
```

This change makes all the arguments in the overloads optional to match the implementation.

[1]: https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/core/quill.ts#L435