### PR TITLE
🏷️ Add overload for `Clipboard.dangerouslyPasteHTML()`

### DIFF
--- a/modules/clipboard.ts
+++ b/modules/clipboard.ts
@@ -130,8 +130,14 @@ class Clipboard extends Module<ClipboardOptions> {
     );
   }
 
+  dangerouslyPasteHTML(html: string, source?: EmitterSource): void;
   dangerouslyPasteHTML(
     index: number,
+    html: string,
+    source?: EmitterSource,
+  ): void;
+  dangerouslyPasteHTML(
+    index: number | string,
     html: string,
     source: EmitterSource = Quill.sources.API,
   ) {


### PR DESCRIPTION
`Clipboard.dangerouslyPasteHTML()` is allowed to be called without an index as its first argument.

At the moment, doing this results in a compilation error:

```
(method) Clipboard.dangerouslyPasteHTML(index: number, html: string, source?: EmitterSource): void
Expected 2-3 arguments, but got 1.ts(2554)
```

This change adds the overload to allow this.