### PR TITLE
🏷️ Fix `Block.moveChildren()` signature

### DIFF
--- a/blots/block.ts
+++ b/blots/block.ts
@@ -88,7 +88,7 @@ class Block extends BlockBlot {
     return this.cache.length;
   }
 
-  moveChildren(target, ref) {
+  moveChildren(target, ref?) {
     super.moveChildren(target, ref);
     this.cache = {};
   }


### PR DESCRIPTION
The `Block` blot inherits from `parchment`'s `ParentBlot`, where the `ref` argument [is optional][1].

This change updates the `Block` signature to match its parent.

[1]: https://github.com/quilljs/parchment/blob/634e50f4d73a3351952250146510332dbc0af961/src/blot/abstract/parent.ts#L238