### PR TITLE
🏷️ Add `@types/lodash.clonedeep` types

### DIFF
--- a/modules/keyboard.ts
+++ b/modules/keyboard.ts
@@ -762,14 +762,10 @@ function normalize(binding: Binding): BindingObject {
   } else {
     return null;
   }
-  // @ts-expect-error
   if (binding.shortKey) {
-    // @ts-expect-error
     binding[SHORTKEY] = binding.shortKey;
-    // @ts-expect-error
     delete binding.shortKey;
   }
-  // @ts-expect-error
   return binding;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@babel/preset-env": "^7.19.4",
         "@playwright/test": "^1.27.1",
         "@types/jasmine": "^4.3.0",
+        "@types/lodash.clonedeep": "^4.5.7",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
         "babel-loader": "^8.2.5",
@@ -4076,6 +4077,15 @@
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -27460,6 +27470,15 @@
       "version": "4.14.186",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/mdast": {
       "version": "3.0.10",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-env": "^7.19.4",
     "@playwright/test": "^1.27.1",
     "@types/jasmine": "^4.3.0",
+    "@types/lodash.clonedeep": "^4.5.7",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
     "babel-loader": "^8.2.5",


### PR DESCRIPTION
This lets us remove the `@ts-expect-error` comments from the `Keyboard` module.