### PR TITLE
🏷️ Fix `Quill.getText()` arguments

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -495,8 +495,8 @@ class Quill {
     return this.editor.getHTML(index, length);
   }
 
-  getText(range: { index: number; length: number }): string;
-  getText(index: number, length?: number): string;
+  getText(range?: { index: number; length: number }): string;
+  getText(index?: number, length?: number): string;
   getText(
     index: { index: number; length: number } | number = 0,
     length?: number,


### PR DESCRIPTION
`Quill.getText()` is allowed to be called with no arguments, since it [defaults][1] to returning the whole document.

However, the overload declarations require arguments, resulting in a compilation error when trying to call `getText()` with no arguments:

```
(method) Quill.getText(range: {
    index: number;
    length: number;
}): string (+1 overload)
Expected 1-2 arguments, but got 0.ts(2554)
```

This change makes all the arguments in the overloads optional to match the implementation.

[1]: https://github.com/quilljs/quill/blob/d2f689fb4744cdada96c632a8bccf6d476932d7b/core/quill.ts#L501-L502