### PR TITLE
Improve initial load performance

### DIFF
--- a/core/quill.ts
+++ b/core/quill.ts
@@ -626,11 +626,10 @@ class Quill {
         const length = this.getLength();
         // Quill will set empty editor to \n
         const delete1 = this.editor.deleteText(0, length);
-        // delta always applied before existing content
-        const applied = this.editor.applyDelta(delta);
+        const appended = this.editor.appendContents(delta);
         // Remove extra \n from empty editor initialization
-        const delete2 = this.editor.deleteText(this.getLength() - 1, 1);
-        return delete1.compose(applied).compose(delete2);
+        const delete2 = this.editor.deleteText(0, 1);
+        return delete1.compose(appended).compose(delete2);
       },
       source,
     );

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -2,9 +2,9 @@ import Delta from 'quill-delta';
 import Editor from '../../../core/editor';
 import Selection, { Range } from '../../../core/selection';
 
-describe('Editor', function() {
-  describe('insert', function() {
-    it('text', function() {
+describe('Editor', function () {
+  describe('insert', function () {
+    it('text', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(2, '!!');
       expect(editor.getDelta()).toEqual(
@@ -13,7 +13,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><strong>01!!23</strong></p>');
     });
 
-    it('embed', function() {
+    it('embed', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertEmbed(2, 'image', '/assets/favicon.png');
       expect(editor.getDelta()).toEqual(
@@ -28,28 +28,28 @@ describe('Editor', function() {
       );
     });
 
-    it('on empty line', function() {
+    it('on empty line', function () {
       const editor = this.initialize(Editor, '<p>0</p><p><br></p><p>3</p>');
       editor.insertText(2, '!');
       expect(editor.getDelta()).toEqual(new Delta().insert('0\n!\n3\n'));
       expect(this.container).toEqualHTML('<p>0</p><p>!</p><p>3</p>');
     });
 
-    it('end of document', function() {
+    it('end of document', function () {
       const editor = this.initialize(Editor, '<p>Hello</p>');
       editor.insertText(6, 'World!');
       expect(editor.getDelta()).toEqual(new Delta().insert('Hello\nWorld!\n'));
       expect(this.container).toEqualHTML('<p>Hello</p><p>World!</p>');
     });
 
-    it('end of document with newline', function() {
+    it('end of document with newline', function () {
       const editor = this.initialize(Editor, '<p>Hello</p>');
       editor.insertText(6, 'World!\n');
       expect(editor.getDelta()).toEqual(new Delta().insert('Hello\nWorld!\n'));
       expect(this.container).toEqualHTML('<p>Hello</p><p>World!</p>');
     });
 
-    it('embed at end of document with newline', function() {
+    it('embed at end of document with newline', function () {
       const editor = this.initialize(Editor, '<p>Hello</p>');
       editor.insertEmbed(6, 'image', '/assets/favicon.png');
       expect(editor.getDelta()).toEqual(
@@ -63,7 +63,7 @@ describe('Editor', function() {
       );
     });
 
-    it('newline splitting', function() {
+    it('newline splitting', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(2, '\n');
       expect(editor.getDelta()).toEqual(
@@ -78,21 +78,18 @@ describe('Editor', function() {
         <p><strong>23</strong></p>`);
     });
 
-    it('prepend newline', function() {
+    it('prepend newline', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(0, '\n');
       expect(editor.getDelta()).toEqual(
-        new Delta()
-          .insert('\n')
-          .insert('0123', { bold: true })
-          .insert('\n'),
+        new Delta().insert('\n').insert('0123', { bold: true }).insert('\n'),
       );
       expect(this.container).toEqualHTML(`
         <p><br></p>
         <p><strong>0123</strong></p>`);
     });
 
-    it('append newline', function() {
+    it('append newline', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(4, '\n');
       expect(editor.getDelta()).toEqual(
@@ -103,7 +100,7 @@ describe('Editor', function() {
         <p><br></p>`);
     });
 
-    it('multiline text', function() {
+    it('multiline text', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(2, '\n!!\n!!\n');
       expect(editor.getDelta()).toEqual(
@@ -124,7 +121,7 @@ describe('Editor', function() {
         <p><strong>23</strong></p>`);
     });
 
-    it('multiple newlines', function() {
+    it('multiple newlines', function () {
       const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
       editor.insertText(2, '\n\n');
       expect(editor.getDelta()).toEqual(
@@ -140,7 +137,7 @@ describe('Editor', function() {
         <p><strong>23</strong></p>`);
     });
 
-    it('text removing formatting', function() {
+    it('text removing formatting', function () {
       const editor = this.initialize(Editor, '<p><s>01</s></p>');
       editor.insertText(2, '23', { bold: false, strike: false });
       expect(editor.getDelta()).toEqual(
@@ -149,8 +146,8 @@ describe('Editor', function() {
     });
   });
 
-  describe('delete', function() {
-    it('inner node', function() {
+  describe('delete', function () {
+    it('inner node', function () {
       const editor = this.initialize(
         Editor,
         '<p><strong><em>0123</em></strong></p>',
@@ -162,7 +159,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><strong><em>03</em></strong></p>');
     });
 
-    it('parts of multiple lines', function() {
+    it('parts of multiple lines', function () {
       const editor = this.initialize(
         Editor,
         '<p><em>0123</em></p><p><em>5678</em></p>',
@@ -174,7 +171,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><em>0178</em></p>');
     });
 
-    it('entire line keeping newline', function() {
+    it('entire line keeping newline', function () {
       const editor = this.initialize(
         Editor,
         '<p><strong><em>0123</em></strong></p>',
@@ -184,7 +181,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><br></p>');
     });
 
-    it('newline', function() {
+    it('newline', function () {
       const editor = this.initialize(
         Editor,
         '<p><em>0123</em></p><p><em>5678</em></p>',
@@ -196,7 +193,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><em>01235678</em></p>');
     });
 
-    it('entire document', function() {
+    it('entire document', function () {
       const editor = this.initialize(
         Editor,
         '<p><strong><em>0123</em></strong></p>',
@@ -206,7 +203,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p><br></p>');
     });
 
-    it('multiple complete lines', function() {
+    it('multiple complete lines', function () {
       const editor = this.initialize(
         Editor,
         '<p><em>012</em></p><p><em>456</em></p><p><em>890</em></p>',
@@ -219,22 +216,22 @@ describe('Editor', function() {
     });
   });
 
-  describe('format', function() {
-    it('line', function() {
+  describe('format', function () {
+    it('line', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.formatLine(1, 1, { header: 1 });
       expect(editor.scroll.domNode).toEqualHTML('<h1>0123</h1>');
     });
   });
 
-  describe('removeFormat', function() {
-    it('unwrap', function() {
+  describe('removeFormat', function () {
+    it('unwrap', function () {
       const editor = this.initialize(Editor, '<p>0<em>12</em>3</p>');
       editor.removeFormat(1, 2);
       expect(this.container).toEqualHTML('<p>0123</p>');
     });
 
-    it('split inline', function() {
+    it('split inline', function () {
       const editor = this.initialize(
         Editor,
         '<p>0<strong><em>12</em></strong>3</p>',
@@ -245,7 +242,7 @@ describe('Editor', function() {
       );
     });
 
-    it('partial line', function() {
+    it('partial line', function () {
       const editor = this.initialize(
         Editor,
         '<h1>01</h1><ol><li data-list="ordered">34</li></ol>',
@@ -254,7 +251,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>01</p><p>34</p>');
     });
 
-    it('remove embed', function() {
+    it('remove embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0<img src="/assets/favicon.png">2</p>',
@@ -263,7 +260,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>02</p>');
     });
 
-    it('combined', function() {
+    it('combined', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -280,7 +277,7 @@ describe('Editor', function() {
       `);
     });
 
-    it('end of document', function() {
+    it('end of document', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -298,26 +295,53 @@ describe('Editor', function() {
     });
   });
 
-  describe('applyDelta', function() {
-    it('insert', function() {
+  describe('appendContents', function () {
+    it('block embed formats', function () {
+      const editor = this.initialize(Editor, '<p></p>');
+      editor.appendContents(new Delta().insert({ video: '#' }, { width: 300 }));
+      expect(this.container.innerHTML).toContain('width="300"');
+    });
+
+    it('produces same result with applyDelta when there are multiple block formats', function () {
+      const editor1 = this.initialize(Editor, '<p></p>');
+      editor1.appendContents(
+        new Delta().insert('abc').insert('\n', { header: 1, blockquote: true }),
+      );
+      const html1 = this.container.innerHTML;
+
+      const editor2 = this.initialize(Editor, '<p></p>');
+      editor2.applyDelta(
+        new Delta()
+          .retain(1)
+          .insert('abc')
+          .insert('\n', { header: 1, blockquote: true }),
+      );
+      const html2 = this.container.innerHTML;
+
+      expect(html1).toEqual(html2);
+    });
+  });
+
+  describe('applyDelta', function () {
+    it('insert', function () {
       const editor = this.initialize(Editor, '<p></p>');
       editor.applyDelta(new Delta().insert('01'));
       expect(this.container).toEqualHTML('<p>01</p>');
     });
 
-    it('attributed insert', function() {
+    it('attributed insert', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(2).insert('|', { bold: true }));
       expect(this.container).toEqualHTML('<p>01<strong>|</strong>23</p>');
     });
 
-    it('format', function() {
+    it('format', function () {
       const editor = this.initialize(Editor, '<p>01</p>');
       editor.applyDelta(new Delta().retain(2, { bold: true }));
       expect(this.container).toEqualHTML('<p><strong>01</strong></p>');
     });
 
-    it('discontinuous formats', function() {
+    it('discontinuous formats', function () {
       const editor = this.initialize(Editor, '');
       const delta = new Delta()
         .insert('ab', { bold: true })
@@ -329,25 +353,25 @@ describe('Editor', function() {
       );
     });
 
-    it('unformatted insert', function() {
+    it('unformatted insert', function () {
       const editor = this.initialize(Editor, '<p><em>01</em></p>');
       editor.applyDelta(new Delta().retain(1).insert('|'));
       expect(this.container).toEqualHTML('<p><em>0</em>|<em>1</em></p>');
     });
 
-    it('insert at format boundary', function() {
+    it('insert at format boundary', function () {
       const editor = this.initialize(Editor, '<p><em>0</em><u>1</u></p>');
       editor.applyDelta(new Delta().retain(1).insert('|', { strike: true }));
       expect(this.container).toEqualHTML('<p><em>0</em><s>|</s><u>1</u></p>');
     });
 
-    it('unformatted newline', function() {
+    it('unformatted newline', function () {
       const editor = this.initialize(Editor, '<h1>01</h1>');
       editor.applyDelta(new Delta().retain(2).insert('\n'));
       expect(this.container).toEqualHTML('<p>01</p><h1><br></h1>');
     });
 
-    it('formatted embed', function() {
+    it('formatted embed', function () {
       const editor = this.initialize(Editor, '');
       editor.applyDelta(
         new Delta().insert({ image: '/assets/favicon.png' }, { italic: true }),
@@ -357,7 +381,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert text before block embed', function() {
+    it('insert text before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -368,7 +392,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert attributed text before block embed', function() {
+    it('insert attributed text before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -379,7 +403,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert text with newline before block embed', function() {
+    it('insert text with newline before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -390,23 +414,20 @@ describe('Editor', function() {
       );
     });
 
-    it('insert attributed text with newline before block embed', function() {
+    it('insert attributed text with newline before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
       );
       editor.applyDelta(
-        new Delta()
-          .retain(5)
-          .insert('5678', { bold: true })
-          .insert('\n'),
+        new Delta().retain(5).insert('5678', { bold: true }).insert('\n'),
       );
       expect(this.container).toEqualHTML(
         '<p>0123</p><p><strong>5678</strong></p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
       );
     });
 
-    it('multiple inserts and deletes', function() {
+    it('multiple inserts and deletes', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(
         new Delta()
@@ -420,7 +441,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>0acdefg</p>');
     });
 
-    it('insert text with delete in existing block', function() {
+    it('insert text with delete in existing block', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -436,7 +457,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>0123abc</p>');
     });
 
-    it('insert text with delete before block embed', function() {
+    it('insert text with delete before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -451,7 +472,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>0123</p><p>abc</p>');
     });
 
-    it('insert inline embed with delete in existing block', function() {
+    it('insert inline embed with delete in existing block', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -469,7 +490,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert inline embed with delete before block embed', function() {
+    it('insert inline embed with delete before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -487,7 +508,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert inline embed with delete before block embed using delete op first', function() {
+    it('insert inline embed with delete before block embed using delete op first', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -505,7 +526,7 @@ describe('Editor', function() {
       );
     });
 
-    it('insert inline embed and text with delete before block embed', function() {
+    it('insert inline embed and text with delete before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
@@ -523,53 +544,40 @@ describe('Editor', function() {
       );
     });
 
-    it('insert block embed with delete before block embed', function() {
+    it('insert block embed with delete before block embed', function () {
       const editor = this.initialize(
         Editor,
         '<p>0123</p><iframe src="#" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
       );
       editor.applyDelta(
-        new Delta()
-          .retain(5)
-          .insert({ video: '#changed' })
-          .delete(1),
+        new Delta().retain(5).insert({ video: '#changed' }).delete(1),
       );
       expect(this.container).toEqualHTML(
         '<p>0123</p><iframe src="#changed" class="ql-video" frameborder="0" allowfullscreen="true"></iframe>',
       );
     });
 
-    it('deletes block embed and appends text', function() {
+    it('deletes block embed and appends text', function () {
       const editor = this.initialize(
         Editor,
         `<p><br></p><iframe class="ql-video" frameborder="0" allowfullscreen="true" src="#"></iframe><p>b</p>`,
       );
-      editor.applyDelta(
-        new Delta()
-          .retain(1)
-          .insert('a')
-          .delete(1),
-      );
+      editor.applyDelta(new Delta().retain(1).insert('a').delete(1));
       expect(this.container).toEqualHTML('<p><br></p><p>ab</p>');
     });
 
-    it('multiple delete block embed and append texts', function() {
+    it('multiple delete block embed and append texts', function () {
       const editor = this.initialize(
         Editor,
         `<p><br></p><iframe class="ql-video" frameborder="0" allowfullscreen="true" src="#"></iframe><iframe class="ql-video" frameborder="0" allowfullscreen="true" src="#"></iframe><p>b</p>`,
       );
       editor.applyDelta(
-        new Delta()
-          .retain(1)
-          .insert('a')
-          .delete(1)
-          .insert('!')
-          .delete(1),
+        new Delta().retain(1).insert('a').delete(1).insert('!').delete(1),
       );
       expect(this.container).toEqualHTML('<p><br></p><p>a!b</p>');
     });
 
-    it('multiple nonconsecutive delete block embed and append texts', function() {
+    it('multiple nonconsecutive delete block embed and append texts', function () {
       const editor = this.initialize(
         Editor,
         `<p><br></p>
@@ -603,7 +611,7 @@ describe('Editor', function() {
       );
     });
 
-    it('improper block embed insert', function() {
+    it('improper block embed insert', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(2).insert({ video: '#' }));
       expect(this.container).toEqualHTML(
@@ -611,7 +619,7 @@ describe('Editor', function() {
       );
     });
 
-    it('append formatted block embed', function() {
+    it('append formatted block embed', function () {
       const editor = this.initialize(Editor, '<p>0123</p><p><br></p>');
       editor.applyDelta(
         new Delta().retain(5).insert({ video: '#' }, { align: 'right' }),
@@ -621,36 +629,33 @@ describe('Editor', function() {
       );
     });
 
-    it('append', function() {
+    it('append', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(5).insert('5678'));
       expect(this.container).toEqualHTML('<p>0123</p><p>5678</p>');
     });
 
-    it('append newline', function() {
+    it('append newline', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(5).insert('\n', { header: 2 }));
       expect(this.container).toEqualHTML('<p>0123</p><h2><br></h2>');
     });
 
-    it('append text with newline', function() {
+    it('append text with newline', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(
-        new Delta()
-          .retain(5)
-          .insert('5678')
-          .insert('\n', { header: 2 }),
+        new Delta().retain(5).insert('5678').insert('\n', { header: 2 }),
       );
       expect(this.container).toEqualHTML('<p>0123</p><h2>5678</h2>');
     });
 
-    it('append non-isolated newline', function() {
+    it('append non-isolated newline', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(new Delta().retain(5).insert('5678\n', { header: 2 }));
       expect(this.container).toEqualHTML('<p>0123</p><h2>5678</h2>');
     });
 
-    it('eventual append', function() {
+    it('eventual append', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(
         new Delta()
@@ -662,7 +667,7 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<h1>01ab</h1><p>23</p><h2>cd</h2>');
     });
 
-    it('append text, embed and newline', function() {
+    it('append text, embed and newline', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(
         new Delta()
@@ -676,7 +681,7 @@ describe('Editor', function() {
       );
     });
 
-    it('append multiple lines', function() {
+    it('append multiple lines', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       editor.applyDelta(
         new Delta()
@@ -689,33 +694,27 @@ describe('Editor', function() {
       expect(this.container).toEqualHTML('<p>0123</p><h1>56</h1><h2>89</h2>');
     });
 
-    it('code block', function() {
+    it('code block', function () {
       const editor = this.initialize(Editor, {
-        html:
-          '<p>0</p><div class="ql-code-block-container"><div class="ql-code-block">1</div><div class="ql-code-block">23</div></div><p><br></p>',
+        html: '<p>0</p><div class="ql-code-block-container"><div class="ql-code-block">1</div><div class="ql-code-block">23</div></div><p><br></p>',
       });
-      editor.applyDelta(
-        new Delta()
-          .delete(4)
-          .retain(1)
-          .delete(2),
-      );
+      editor.applyDelta(new Delta().delete(4).retain(1).delete(2));
       expect(editor.scroll.domNode.innerHTML).toEqual('<p>2</p>');
     });
   });
 
-  describe('getFormat()', function() {
-    it('unformatted', function() {
+  describe('getFormat()', function () {
+    it('unformatted', function () {
       const editor = this.initialize(Editor, '<p>0123</p>');
       expect(editor.getFormat(1)).toEqual({});
     });
 
-    it('formatted', function() {
+    it('formatted', function () {
       const editor = this.initialize(Editor, '<h1><em>0123</em></h1>');
       expect(editor.getFormat(1)).toEqual({ header: 1, italic: true });
     });
 
-    it('cursor', function() {
+    it('cursor', function () {
       const editor = this.initialize(
         Editor,
         '<h1><strong><em>0123</em></strong></h1><h2><u>5678</u></h2>',
@@ -727,7 +726,7 @@ describe('Editor', function() {
       });
     });
 
-    it('cursor with preformat', function() {
+    it('cursor with preformat', function () {
       const [editor, selection] = this.initialize(
         [Editor, Selection],
         '<h1><strong><em>0123</em></strong></h1>',
@@ -744,7 +743,7 @@ describe('Editor', function() {
       });
     });
 
-    it('across leaves', function() {
+    it('across leaves', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -762,7 +761,7 @@ describe('Editor', function() {
       });
     });
 
-    it('across leaves repeated', function() {
+    it('across leaves repeated', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -781,7 +780,7 @@ describe('Editor', function() {
       });
     });
 
-    it('across lines repeated', function() {
+    it('across lines repeated', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -797,7 +796,7 @@ describe('Editor', function() {
         align: ['right', 'center'],
       });
     });
-    it('across lines', function() {
+    it('across lines', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -813,13 +812,13 @@ describe('Editor', function() {
     });
   });
 
-  describe('getHTML', function() {
-    it('inline', function() {
+  describe('getHTML', function () {
+    it('inline', function () {
       const editor = this.initialize(Editor, '<blockquote>Test</blockquote>');
       expect(editor.getHTML(1, 2)).toEqual('es');
     });
 
-    it('across lines', function() {
+    it('across lines', function () {
       const editor = this.initialize(
         Editor,
         '<h1 class="ql-align-center">Header</h1><p>Text</p><blockquote>Quote</blockquote>',
@@ -829,7 +828,7 @@ describe('Editor', function() {
       );
     });
 
-    it('mixed list', function() {
+    it('mixed list', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -853,7 +852,7 @@ describe('Editor', function() {
       `);
     });
 
-    it('nested list', function() {
+    it('nested list', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -885,7 +884,7 @@ describe('Editor', function() {
       `);
     });
 
-    it('nested checklist', function() {
+    it('nested checklist', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -917,7 +916,7 @@ describe('Editor', function() {
       `);
     });
 
-    it('partial list', function() {
+    it('partial list', function () {
       const editor = this.initialize(
         Editor,
         `
@@ -947,18 +946,18 @@ describe('Editor', function() {
       `);
     });
 
-    it('text within tag', function() {
+    it('text within tag', function () {
       const editor = this.initialize(Editor, '<p><a>a</a></p>');
       expect(editor.getHTML(0, 1)).toEqual('<a>a</a>');
     });
 
-    it('escape html', function() {
+    it('escape html', function () {
       const editor = this.initialize(Editor, '<p><br></p>');
       editor.insertText(0, '<b>Test</b>');
       expect(editor.getHTML(0, 11)).toEqual('&lt;b&gt;Test&lt;/b&gt;');
     });
 
-    it('multiline code', function() {
+    it('multiline code', function () {
       const editor = this.initialize(
         Editor,
         '<p><br></p><p>0123</p><p><br></p><p><br></p><p>4567</p><p><br></p>',


### PR DESCRIPTION
This PR improves initial load performance by adding `appendContents` to `Editor`. Unlike `applyDelta`, `appendContents` always appends ops to the existing content, so it doesn't go through `insertAt` of the existing blots, which improves the performance dramatically.

TODO:

The code is a bit repetitive to `applyDelta` so should take a look at whether we can improve.