### PR TITLE
Upgrade quill-delta for semantic cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lodash.isequal": "^4.5.0",
         "lodash.merge": "^4.5.0",
         "parchment": "^2.0.1",
-        "quill-delta": "^5.0.0"
+        "quill-delta": "^5.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.19.3",
@@ -10550,9 +10550,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -19330,11 +19330,11 @@
       }
     },
     "node_modules/quill-delta": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.0.0.tgz",
-      "integrity": "sha512-lVORU8dBPJdxPmwtdGhfRcz2cekn8Osuj5kwHoPMQ3MNlDT/IZ0CGUnQ/tLsAaTn31LWcDC1KyL+gkiGbBlBBw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
       "dependencies": {
-        "fast-diff": "1.2.0",
+        "fast-diff": "^1.3.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0"
       },
@@ -32421,9 +32421,9 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
     },
     "fast-glob": {
       "version": "3.2.12",
@@ -38708,11 +38708,11 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "quill-delta": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.0.0.tgz",
-      "integrity": "sha512-lVORU8dBPJdxPmwtdGhfRcz2cekn8Osuj5kwHoPMQ3MNlDT/IZ0CGUnQ/tLsAaTn31LWcDC1KyL+gkiGbBlBBw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
       "requires": {
-        "fast-diff": "1.2.0",
+        "fast-diff": "^1.3.0",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.5.0",
     "parchment": "^2.0.1",
-    "quill-delta": "^5.0.0"
+    "quill-delta": "^5.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.19.3",


### PR DESCRIPTION
quill-delta@5.1.0 adds semantic cleanups to `Delta#diff()`, which means in general it would generate better diff results especially when the two text varies greatly.