### PR TITLE
Fix embed inherits formats unexpectedly

### DIFF
--- a/core/editor.ts
+++ b/core/editor.ts
@@ -62,6 +62,9 @@ class Editor {
             ) {
               isImplicitNewlineAppended = true;
             }
+            const [leaf] = this.scroll.leaf(index);
+            const formats = merge({}, bubbleFormats(leaf));
+            attributes = AttributeMap.diff(formats, attributes) || {};
           } else if (index > 0) {
             // @ts-expect-error
             const [leaf, offset] = this.scroll.descendant(LeafBlot, index - 1);

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -517,6 +517,16 @@ describe('Editor', function () {
       );
     });
 
+    it('insert inline embed to the middle of formatted content', function () {
+      const editor = this.initialize(Editor, '<p><strong>0123</strong></p>');
+      editor.applyDelta(
+        new Delta().retain(2).insert({ image: '/assets/favicon.png' }),
+      );
+      expect(this.container).toEqualHTML(
+        '<p><strong>01</strong><img src="/assets/favicon.png"><strong>23</strong></p>',
+      );
+    });
+
     it('insert block embed with delete before block embed', function () {
       const editor = this.initialize(
         Editor,


### PR DESCRIPTION
Closes #3623

Similar to how we revert the formats for text, we get the current inline formats of the target position and calculate the diff, and apply them to the inserted embed.