### PR TITLE
Enable strictNullChecks

### DIFF
--- a/blots/block.ts
+++ b/blots/block.ts
@@ -53,7 +53,7 @@ class Block extends BlockBlot {
     }
     if (value.length === 0) return;
     const lines = value.split('\n');
-    const text = lines.shift();
+    const text = lines.shift() as string;
     if (text.length > 0) {
       if (index < this.length() - 1 || this.children.tail == null) {
         super.insertAt(Math.min(index, this.length() - 1), text);
@@ -66,6 +66,7 @@ class Block extends BlockBlot {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     let block: Blot | this = this;
     lines.reduce((lineIndex, line) => {
+      // @ts-expect-error Fix me later
       block = block.split(lineIndex, true);
       block.insertAt(0, line);
       return line.length;
@@ -114,6 +115,7 @@ class Block extends BlockBlot {
         this.parent.insertBefore(clone, this);
         return this;
       }
+      // @ts-expect-error Fix me later
       this.parent.insertBefore(clone, this.next);
       return clone;
     }
@@ -169,9 +171,11 @@ class BlockEmbed extends EmbedBlot {
     });
     const ref = this.split(index);
     blocks.forEach(block => {
+      // @ts-expect-error Fix me later
       this.parent.insertBefore(block, ref);
     });
     if (text) {
+      // @ts-expect-error Fix me later
       this.parent.insertBefore(this.scroll.create('text', text), ref);
     }
   }

--- a/blots/cursor.ts
+++ b/blots/cursor.ts
@@ -67,6 +67,7 @@ class Cursor extends EmbedBlot {
 
   remove() {
     super.remove();
+    // @ts-expect-error Fix me later
     this.parent = null;
   }
 
@@ -79,6 +80,7 @@ class Cursor extends EmbedBlot {
       this.domNode.lastChild != null &&
       this.domNode.lastChild !== this.textNode
     ) {
+      // @ts-expect-error Fix me later
       this.domNode.parentNode.insertBefore(
         this.domNode.lastChild,
         this.domNode,
@@ -171,6 +173,7 @@ class Cursor extends EmbedBlot {
   // And then "x" will be inserted after `<a/>`:
   //    <span class="ql-cursor"><a>\uFEFF</a>d{I}</span>
   optimize(context?: unknown) {
+    // @ts-expect-error Fix me later
     super.optimize(context);
 
     let { parent } = this;

--- a/blots/embed.ts
+++ b/blots/embed.ts
@@ -57,6 +57,7 @@ class Embed extends EmbedBlot {
         };
       } else {
         textNode = document.createTextNode(text);
+        // @ts-expect-error Fix me later
         this.parent.insertBefore(this.scroll.create(textNode), this.next);
         range = {
           startNode: textNode,

--- a/blots/scroll.ts
+++ b/blots/scroll.ts
@@ -83,7 +83,9 @@ class Scroll extends ScrollBlot {
       }
       const ref =
         last.children.head instanceof Break ? null : last.children.head;
+      // @ts-expect-error
       first.moveChildren(last, ref);
+      // @ts-expect-error
       first.remove();
     }
     this.optimize();
@@ -162,7 +164,7 @@ class Scroll extends ScrollBlot {
       blotIndex: number,
       blotLength: number,
     ) => {
-      let lines = [];
+      let lines: (Block | BlockEmbed)[] = [];
       let lengthLeft = blotLength;
       blot.children.forEachAt(
         blotIndex,
@@ -181,7 +183,7 @@ class Scroll extends ScrollBlot {
     return getLines(this, index, length);
   }
 
-  optimize(context: { [key: string]: any }): void;
+  optimize(context?: { [key: string]: any }): void;
   optimize(
     mutations?: MutationRecord[],
     context?: { [key: string]: any },

--- a/core/logger.ts
+++ b/core/logger.ts
@@ -1,20 +1,25 @@
-const levels = ['error', 'warn', 'log', 'info'];
-let level = 'warn';
+const levels = ['error', 'warn', 'log', 'info'] as const;
+export type DebugLevel = typeof levels[number];
+let level: DebugLevel | false = 'warn';
 
-function debug(method: string, ...args: unknown[]) {
-  if (levels.indexOf(method) <= levels.indexOf(level)) {
-    console[method](...args); // eslint-disable-line no-console
+function debug(method: DebugLevel, ...args: unknown[]) {
+  if (level) {
+    if (levels.indexOf(method) <= levels.indexOf(level)) {
+      console[method](...args); // eslint-disable-line no-console
+    }
   }
 }
 
-function namespace(ns: string): Record<typeof levels[number], typeof debug> {
+function namespace(
+  ns: string,
+): Record<DebugLevel, (...args: unknown[]) => void> {
   return levels.reduce((logger, method) => {
     logger[method] = debug.bind(console, method, ns);
     return logger;
-  }, {});
+  }, {} as Record<DebugLevel, (...args: unknown[]) => void>);
 }
 
-namespace.level = newLevel => {
+namespace.level = (newLevel: DebugLevel | false) => {
   level = newLevel;
 };
 debug.level = namespace.level;

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -15,7 +15,7 @@ import Uploader from '../modules/uploader';
 import Editor from './editor';
 import Emitter, { EmitterSource } from './emitter';
 import instances from './instances';
-import logger from './logger';
+import logger, { DebugLevel } from './logger';
 import Module from './module';
 import Selection, { Range } from './selection';
 import Theme, { ThemeConstructor } from './theme';
@@ -27,7 +27,7 @@ Parchment.ParentBlot.uiClass = 'ql-ui';
 
 interface Options {
   theme?: string;
-  debug?: string | boolean;
+  debug?: DebugLevel | boolean;
   registry?: Parchment.Registry;
   readOnly?: boolean;
   container?: HTMLElement | string;
@@ -69,7 +69,7 @@ class Quill {
     'core/theme': Theme,
   };
 
-  static debug(limit: string | boolean) {
+  static debug(limit: DebugLevel | boolean) {
     if (limit === true) {
       limit = 'log';
     }
@@ -231,11 +231,11 @@ class Quill {
     this.allowReadOnlyEdits = false;
   }
 
-  addContainer(container: string, refNode?: Node): HTMLDivElement;
-  addContainer(container: HTMLElement, refNode?: Node): HTMLElement;
+  addContainer(container: string, refNode?: Node | null): HTMLDivElement;
+  addContainer(container: HTMLElement, refNode?: Node | null): HTMLElement;
   addContainer(
     container: string | HTMLElement,
-    refNode = null,
+    refNode: Node | null = null,
   ): HTMLDivElement | HTMLElement {
     if (typeof container === 'string') {
       const className = container;
@@ -875,6 +875,7 @@ function overload(
   }
   // Handle format being object, two format name/value strings or excluded
   if (typeof name === 'object') {
+    // @ts-expect-error Fix me later
     formats = name;
     // @ts-expect-error
     source = value;

--- a/core/selection.ts
+++ b/core/selection.ts
@@ -148,6 +148,7 @@ class Selection {
       // TODO Give blot ability to not split
       if (blot instanceof LeafBlot) {
         const after = blot.split(nativeRange.start.offset);
+        // @ts-expect-error Fix me later
         blot.parent.insertBefore(this.cursor, after);
       } else {
         // @ts-expect-error TODO: nativeRange.start.node doesn't seem to match function signature
@@ -253,6 +254,7 @@ class Selection {
     const indexes = positions.map(position => {
       const [node, offset] = position;
       const blot = this.scroll.find(node, true);
+      // @ts-expect-error Fix me later
       const index = blot.offset(this.scroll);
       if (offset === 0) {
         return index;
@@ -260,6 +262,7 @@ class Selection {
       if (blot instanceof LeafBlot) {
         return index + blot.index(node, offset);
       }
+      // @ts-expect-error Fix me later
       return index + blot.length();
     });
     const end = Math.min(Math.max(...indexes), this.scroll.length() - 1);
@@ -289,6 +292,7 @@ class Selection {
           node = node.childNodes[offset];
           offset = 0;
         } else if (node.childNodes.length === offset) {
+          // @ts-expect-error Fix me later
           node = node.lastChild;
           if (node instanceof Text) {
             offset = node.data.length;
@@ -351,6 +355,7 @@ class Selection {
       startNode != null &&
       (this.root.parentNode == null ||
         startNode.parentNode == null ||
+        // @ts-expect-error Fix me later
         endNode.parentNode == null)
     ) {
       return;
@@ -369,19 +374,23 @@ class Selection {
         endOffset !== native.endOffset
       ) {
         if (startNode instanceof Element && startNode.tagName === 'BR') {
+          // @ts-expect-error Fix me later
           startOffset = Array.from(startNode.parentNode.childNodes).indexOf(
             startNode,
           );
           startNode = startNode.parentNode;
         }
         if (endNode instanceof Element && endNode.tagName === 'BR') {
+          // @ts-expect-error Fix me later
           endOffset = Array.from(endNode.parentNode.childNodes).indexOf(
             endNode,
           );
           endNode = endNode.parentNode;
         }
         const range = document.createRange();
+        // @ts-expect-error Fix me later
         range.setStart(startNode, startOffset);
+        // @ts-expect-error Fix me later
         range.setEnd(endNode, endOffset);
         selection.removeAllRanges();
         selection.addRange(range);

--- a/e2e/utils/index.ts
+++ b/e2e/utils/index.ts
@@ -1,8 +1,11 @@
 export const SHORTKEY = process.platform === 'darwin' ? 'Meta' : 'Control';
 
 export function getSelectionInTextNode() {
-  const { anchorNode, anchorOffset, focusNode, focusOffset } =
-    document.getSelection();
+  const selection = document.getSelection();
+  if (!selection) {
+    throw new Error('Selection is null');
+  }
+  const { anchorNode, anchorOffset, focusNode, focusOffset } = selection;
   return JSON.stringify([
     (anchorNode as Text).data,
     anchorOffset,

--- a/formats/table.ts
+++ b/formats/table.ts
@@ -65,10 +65,15 @@ class TableRow extends Container {
   next: this | null;
 
   checkMerge() {
+    // @ts-expect-error
     if (super.checkMerge() && this.next.children.head != null) {
+      // @ts-expect-error
       const thisHead = this.children.head.formats();
+      // @ts-expect-error
       const thisTail = this.children.tail.formats();
+      // @ts-expect-error
       const nextHead = this.next.children.head.formats();
+      // @ts-expect-error
       const nextTail = this.next.children.tail.formats();
       return (
         thisHead.table === thisTail.table &&
@@ -168,6 +173,7 @@ class TableContainer extends Container {
     if (body == null || body.children.head == null) return;
     body.children.forEach(row => {
       const ref = row.children.at(index);
+      // @ts-expect-error
       const value = TableCell.formats(row.children.head.domNode);
       const cell = this.scroll.create(TableCell.blotName, value);
       row.insertBefore(cell, ref);

--- a/modules/keyboard.ts
+++ b/modules/keyboard.ts
@@ -76,8 +76,11 @@ class Keyboard extends Module<KeyboardOptions> {
   constructor(quill: Quill, options: Partial<KeyboardOptions>) {
     super(quill, options);
     this.bindings = {};
+    // @ts-expect-error Fix me later
     Object.keys(this.options.bindings).forEach(name => {
+      // @ts-expect-error Fix me later
       if (this.options.bindings[name]) {
+        // @ts-expect-error Fix me later
         this.addBinding(this.options.bindings[name]);
       }
     });
@@ -194,6 +197,7 @@ class Keyboard extends Module<KeyboardOptions> {
         leafEnd instanceof TextBlot ? leafEnd.value().slice(offsetEnd) : '';
       const curContext = {
         collapsed: range.length === 0,
+        // @ts-expect-error Fix me later
         empty: range.length === 0 && line.length() <= 1,
         format: this.quill.getFormat(range),
         line,
@@ -224,10 +228,13 @@ class Keyboard extends Module<KeyboardOptions> {
           // all formats must match
           if (
             !Object.keys(binding.format).every(name => {
+              // @ts-expect-error Fix me later
               if (binding.format[name] === true)
                 return curContext.format[name] != null;
+              // @ts-expect-error Fix me later
               if (binding.format[name] === false)
                 return curContext.format[name] == null;
+              // @ts-expect-error Fix me later
               return isEqual(binding.format[name], curContext.format[name]);
             })
           ) {
@@ -240,6 +247,7 @@ class Keyboard extends Module<KeyboardOptions> {
         if (binding.suffix != null && !binding.suffix.test(curContext.suffix)) {
           return false;
         }
+        // @ts-expect-error Fix me later
         return binding.handler.call(this, range, curContext, binding) !== true;
       });
       if (prevented) {
@@ -264,12 +272,14 @@ class Keyboard extends Module<KeyboardOptions> {
         const isPrevLineEmpty =
           prev.statics.blotName === 'block' && prev.length() <= 1;
         if (!isPrevLineEmpty) {
+          // @ts-expect-error Fix me later
           const curFormats = line.formats();
           const prevFormats = this.quill.getFormat(range.index - 1, 1);
           formats = AttributeMap.diff(curFormats, prevFormats) || {};
           if (Object.keys(formats).length > 0) {
             // line.length() - 1 targets \n in line, another -1 for newline being deleted
             const formatDelta = new Delta()
+              // @ts-expect-error Fix me later
               .retain(range.index + line.length() - 2)
               .retain(1, formats);
             delta = delta.compose(formatDelta);
@@ -290,9 +300,11 @@ class Keyboard extends Module<KeyboardOptions> {
     let formats = {};
     const [line] = this.quill.getLine(range.index);
     let delta = new Delta().retain(range.index).delete(length);
+    // @ts-expect-error Fix me later
     if (context.offset >= line.length() - 1) {
       const [next] = this.quill.getLine(range.index + 1);
       if (next) {
+        // @ts-expect-error Fix me later
         const curFormats = line.formats();
         const nextFormats = this.quill.getFormat(range.index, 1);
         formats = AttributeMap.diff(curFormats, nextFormats) || {};
@@ -436,12 +448,14 @@ const defaultOptions: KeyboardOptions = {
       handler(range) {
         const [line, offset] = this.quill.getLine(range.index);
         const formats = {
+          // @ts-expect-error Fix me later
           ...line.formats(),
           list: 'checked',
         };
         const delta = new Delta()
           .retain(range.index)
           .insert('\n', formats)
+          // @ts-expect-error Fix me later
           .retain(line.length() - offset - 1)
           .retain(1, { list: 'unchecked' });
         this.quill.updateContents(delta, Quill.sources.USER);
@@ -459,6 +473,7 @@ const defaultOptions: KeyboardOptions = {
         const delta = new Delta()
           .retain(range.index)
           .insert('\n', context.format)
+          // @ts-expect-error Fix me later
           .retain(line.length() - offset - 1)
           .retain(1, { header: null });
         this.quill.updateContents(delta, Quill.sources.USER);
@@ -559,6 +574,7 @@ const defaultOptions: KeyboardOptions = {
         const delta = new Delta()
           .retain(range.index - offset)
           .delete(length + 1)
+          // @ts-expect-error Fix me later
           .retain(line.length() - 2 - offset)
           .retain(1, { list: value });
         this.quill.updateContents(delta, Quill.sources.USER);
@@ -588,6 +604,7 @@ const defaultOptions: KeyboardOptions = {
           // Requisite prev lines are empty
           if (numLines <= 0) {
             const delta = new Delta()
+              // @ts-expect-error Fix me later
               .retain(range.index + line.length() - offset - 2)
               .retain(1, { 'code-block': null })
               .delete(1);
@@ -638,6 +655,7 @@ function makeCodeBlockHandler(indent: boolean): BindingObject {
           } else {
             length += TAB.length;
           }
+          // @ts-expect-error Fix me later
         } else if (line.domNode.textContent.startsWith(TAB)) {
           line.deleteAt(0, TAB.length);
           if (i === 0) {
@@ -756,7 +774,7 @@ function makeTableArrowHandler(up: boolean): BindingObject {
   };
 }
 
-function normalize(binding: Binding): BindingObject {
+function normalize(binding: Binding): BindingObject | null {
   if (typeof binding === 'string' || typeof binding === 'number') {
     binding = { key: binding };
   } else if (typeof binding === 'object') {

--- a/modules/syntax.ts
+++ b/modules/syntax.ts
@@ -166,7 +166,7 @@ class SyntaxCodeBlockContainer extends CodeBlockContainer {
     )}\n</pre>`;
   }
 
-  optimize(context: unknown) {
+  optimize(context: Record<string, any>) {
     super.optimize(context);
     if (
       this.parent != null &&
@@ -212,6 +212,7 @@ class Syntax extends Module<SyntaxOptions> {
         'Syntax module requires highlight.js. Please include the library on the page before Quill.',
       );
     }
+    // @ts-expect-error Fix me later
     this.languages = this.options.languages.reduce((memo, { key }) => {
       memo[key] = true;
       return memo;
@@ -225,6 +226,7 @@ class Syntax extends Module<SyntaxOptions> {
     this.quill.on(Quill.events.SCROLL_BLOT_MOUNT, blot => {
       if (!(blot instanceof SyntaxCodeBlockContainer)) return;
       const select = this.quill.root.ownerDocument.createElement('select');
+      // @ts-expect-error Fix me later
       this.options.languages.forEach(({ key, label }) => {
         const option = select.ownerDocument.createElement('option');
         option.textContent = label;
@@ -246,9 +248,11 @@ class Syntax extends Module<SyntaxOptions> {
   }
 
   initTimer() {
-    let timer = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
     this.quill.on(Quill.events.SCROLL_OPTIMIZE, () => {
-      clearTimeout(timer);
+      if (timer) {
+        clearTimeout(timer);
+      }
       timer = setTimeout(() => {
         this.highlight();
         timer = null;
@@ -256,7 +260,7 @@ class Syntax extends Module<SyntaxOptions> {
     });
   }
 
-  highlight(blot = null, force = false) {
+  highlight(blot: SyntaxCodeBlockContainer | null = null, force = false) {
     if (this.quill.selection.composing) return;
     this.quill.update(Quill.sources.USER);
     const range = this.quill.getSelection();

--- a/modules/table.ts
+++ b/modules/table.ts
@@ -71,8 +71,9 @@ class Table extends Module {
     return [table, row, cell, offset];
   }
 
-  insertColumn(offset) {
+  insertColumn(offset: number) {
     const range = this.quill.getSelection();
+    if (!range) return;
     const [table, row, cell] = this.getTable(range);
     if (cell == null) return;
     const column = cell.cellOffset();
@@ -97,8 +98,9 @@ class Table extends Module {
     this.insertColumn(1);
   }
 
-  insertRow(offset) {
+  insertRow(offset: number) {
     const range = this.quill.getSelection();
+    if (!range) return;
     const [table, row, cell] = this.getTable(range);
     if (cell == null) return;
     const index = row.rowOffset();
@@ -123,7 +125,7 @@ class Table extends Module {
     this.insertRow(1);
   }
 
-  insertTable(rows, columns) {
+  insertTable(rows: number, columns: number) {
     const range = this.quill.getSelection();
     if (range == null) return;
     const delta = new Array(rows).fill(0).reduce(memo => {

--- a/modules/tableEmbed.ts
+++ b/modules/tableEmbed.ts
@@ -85,7 +85,9 @@ const reindexCellIdentities = (cells, { rows, columns }) => {
   Object.keys(cells).forEach(identity => {
     let [row, column] = parseCellIdentity(identity);
 
+    // @ts-expect-error Fix me later
     row = composePosition(rows, row);
+    // @ts-expect-error Fix me later
     column = composePosition(columns, column);
 
     if (row !== null && column !== null) {
@@ -110,6 +112,7 @@ export const tableHandler = {
 
     Object.keys(b.cells || {}).forEach(identity => {
       const aCell = cells[identity] || {};
+      // @ts-expect-error Fix me later
       const bCell = b.cells[identity];
 
       const content = new Delta(aCell.content || []).compose(
@@ -153,12 +156,15 @@ export const tableHandler = {
 
     Object.keys(a.cells || {}).forEach(identity => {
       let [row, column] = parseCellIdentity(identity);
+      // @ts-expect-error Fix me later
       row = composePosition(rows, row);
+      // @ts-expect-error Fix me later
       column = composePosition(columns, column);
 
       if (row !== null && column !== null) {
         const newIdentity = stringifyCellIdentity(row, column);
 
+        // @ts-expect-error Fix me later
         const aCell = a.cells[identity];
         const bCell = cells[newIdentity];
         if (bCell) {
@@ -222,6 +228,7 @@ export const tableHandler = {
         composePosition(new Delta(change.rows || []), row) === null ||
         composePosition(new Delta(change.columns || []), column) === null
       ) {
+        // @ts-expect-error Fix me later
         cells[identity] = base.cells[identity];
       }
     });

--- a/modules/toolbar.ts
+++ b/modules/toolbar.ts
@@ -9,14 +9,14 @@ const debug = logger('quill:toolbar');
 type Handler = (value: any) => void;
 
 interface ToolbarProps {
-  container?: HTMLElement;
+  container?: HTMLElement | null;
   handlers?: Record<string, Handler>;
 }
 
 class Toolbar extends Module<ToolbarProps> {
   static DEFAULTS: ToolbarProps;
 
-  container: HTMLElement;
+  container?: HTMLElement | null;
   controls: [string, HTMLElement][];
   handlers: Record<string, Handler>;
 
@@ -25,7 +25,7 @@ class Toolbar extends Module<ToolbarProps> {
     if (Array.isArray(this.options.container)) {
       const container = document.createElement('div');
       addControls(container, this.options.container);
-      quill.container.parentNode.insertBefore(container, quill.container);
+      quill.container?.parentNode?.insertBefore(container, quill.container);
       this.container = container;
     } else if (typeof this.options.container === 'string') {
       this.container = document.querySelector(this.options.container);
@@ -39,9 +39,14 @@ class Toolbar extends Module<ToolbarProps> {
     this.container.classList.add('ql-toolbar');
     this.controls = [];
     this.handlers = {};
-    Object.keys(this.options.handlers).forEach(format => {
-      this.addHandler(format, this.options.handlers[format]);
-    });
+    if (this.options.handlers) {
+      Object.keys(this.options.handlers).forEach(format => {
+        const handler = this.options.handlers?.[format];
+        if (handler) {
+          this.addHandler(format, handler);
+        }
+      });
+    }
     Array.from(this.container.querySelectorAll('button, select')).forEach(
       input => {
         // @ts-expect-error
@@ -103,7 +108,9 @@ class Toolbar extends Module<ToolbarProps> {
       }
       this.quill.focus();
       const [range] = this.quill.selection.getRange();
+      // @ts-expect-error Fix me later
       if (this.handlers[format] != null) {
+        // @ts-expect-error Fix me later
         this.handlers[format].call(this, value);
       } else if (
         // @ts-expect-error
@@ -113,12 +120,16 @@ class Toolbar extends Module<ToolbarProps> {
         if (!value) return;
         this.quill.updateContents(
           new Delta()
+            // @ts-expect-error Fix me later
             .retain(range.index)
+            // @ts-expect-error Fix me later
             .delete(range.length)
+            // @ts-expect-error Fix me later
             .insert({ [format]: value }),
           Quill.sources.USER,
         );
       } else {
+        // @ts-expect-error Fix me later
         this.quill.format(format, value, Quill.sources.USER);
       }
       this.update(range);

--- a/modules/uploader.ts
+++ b/modules/uploader.ts
@@ -16,7 +16,7 @@ class Uploader extends Module<UploaderOptions> {
     super(quill, options);
     quill.root.addEventListener('drop', e => {
       e.preventDefault();
-      let native: ReturnType<typeof document.createRange>;
+      let native: ReturnType<typeof document.createRange> | null = null;
       if (document.caretRangeFromPoint) {
         native = document.caretRangeFromPoint(e.clientX, e.clientY);
         // @ts-expect-error
@@ -26,23 +26,29 @@ class Uploader extends Module<UploaderOptions> {
         native = document.createRange();
         native.setStart(position.offsetNode, position.offset);
         native.setEnd(position.offsetNode, position.offset);
-      } else {
-        return;
       }
-      const normalized = quill.selection.normalizeNative(native);
-      const range = quill.selection.normalizedToRange(normalized);
-      this.upload(range, e.dataTransfer.files);
+
+      const normalized = native && quill.selection.normalizeNative(native);
+      if (normalized) {
+        const range = quill.selection.normalizedToRange(normalized);
+        if (e.dataTransfer?.files) {
+          this.upload(range, e.dataTransfer.files);
+        }
+      }
     });
   }
 
   upload(range: Range, files: FileList | File[]) {
     const uploads = [];
     Array.from(files).forEach(file => {
+      // @ts-expect-error Fix me later
       if (file && this.options.mimetypes.includes(file.type)) {
+        // @ts-expect-error Fix me later
         uploads.push(file);
       }
     });
     if (uploads.length > 0) {
+      // @ts-expect-error Fix me later
       this.options.handler.call(this, range, uploads);
     }
   }
@@ -55,6 +61,7 @@ Uploader.DEFAULTS = {
       return new Promise(resolve => {
         const reader = new FileReader();
         reader.onload = e => {
+          // @ts-expect-error Fix me later
           resolve(e.target.result);
         };
         reader.readAsDataURL(file);

--- a/themes/base.ts
+++ b/themes/base.ts
@@ -211,6 +211,7 @@ class BaseTooltip extends Tooltip {
   }
 
   listen() {
+    // @ts-expect-error Fix me later
     this.textbox.addEventListener('keydown', event => {
       if (event.key === 'Enter') {
         this.save();
@@ -230,14 +231,19 @@ class BaseTooltip extends Tooltip {
     this.root.classList.remove('ql-hidden');
     this.root.classList.add('ql-editing');
     if (preview != null) {
+      // @ts-expect-error Fix me later
       this.textbox.value = preview;
     } else if (mode !== this.root.getAttribute('data-mode')) {
+      // @ts-expect-error Fix me later
       this.textbox.value = '';
     }
     this.position(this.quill.getBounds(this.quill.selection.savedRange));
+    // @ts-expect-error Fix me later
     this.textbox.select();
+    // @ts-expect-error Fix me later
     this.textbox.setAttribute(
       'placeholder',
+      // @ts-expect-error Fix me later
       this.textbox.getAttribute(`data-${mode}`) || '',
     );
     this.root.setAttribute('data-mode', mode);
@@ -250,6 +256,7 @@ class BaseTooltip extends Tooltip {
   }
 
   save() {
+    // @ts-expect-error Fix me later
     let { value } = this.textbox;
     switch (this.root.getAttribute('data-mode')) {
       case 'link': {
@@ -279,6 +286,7 @@ class BaseTooltip extends Tooltip {
           const index = range.index + range.length;
           this.quill.insertEmbed(
             index,
+            // @ts-expect-error Fix me later
             this.root.getAttribute('data-mode'),
             value,
             Emitter.sources.USER,
@@ -292,6 +300,7 @@ class BaseTooltip extends Tooltip {
       }
       default:
     }
+    // @ts-expect-error Fix me later
     this.textbox.value = '';
     this.hide();
   }

--- a/themes/bubble.ts
+++ b/themes/bubble.ts
@@ -59,6 +59,7 @@ class BubbleTooltip extends BaseTooltip {
 
   listen() {
     super.listen();
+    // @ts-expect-error Fix me later
     this.root.querySelector('.ql-close').addEventListener('click', () => {
       this.root.classList.remove('ql-editing');
     });

--- a/themes/snow.ts
+++ b/themes/snow.ts
@@ -24,14 +24,17 @@ class SnowTooltip extends BaseTooltip {
 
   listen() {
     super.listen();
+    // @ts-expect-error Fix me later
     this.root.querySelector('a.ql-action').addEventListener('click', event => {
       if (this.root.classList.contains('ql-editing')) {
         this.save();
       } else {
+        // @ts-expect-error Fix me later
         this.edit('link', this.preview.textContent);
       }
       event.preventDefault();
     });
+    // @ts-expect-error Fix me later
     this.root.querySelector('a.ql-remove').addEventListener('click', event => {
       if (this.linkRange != null) {
         const range = this.linkRange;
@@ -55,7 +58,9 @@ class SnowTooltip extends BaseTooltip {
           if (link != null) {
             this.linkRange = new Range(range.index - offset, link.length());
             const preview = LinkBlot.formats(link.domNode);
+            // @ts-expect-error Fix me later
             this.preview.textContent = preview;
+            // @ts-expect-error Fix me later
             this.preview.setAttribute('href', preview);
             this.show();
             this.position(this.quill.getBounds(this.linkRange));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "sourceMap": true,
     "declaration": true,
     "module": "es6",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "strictNullChecks": true,
+    "noUnusedLocals": true
   },
   "include": ["./**/*"]
 }

--- a/ui/icon-picker.ts
+++ b/ui/icon-picker.ts
@@ -1,7 +1,7 @@
 import Picker from './picker';
 
 class IconPicker extends Picker {
-  defaultItem: HTMLElement;
+  defaultItem: HTMLElement | null;
 
   constructor(select: HTMLSelectElement, icons: Record<string, string>) {
     super(select);

--- a/ui/picker.ts
+++ b/ui/picker.ts
@@ -19,6 +19,7 @@ class Picker {
     this.container = document.createElement('span');
     this.buildPicker();
     this.select.style.display = 'none';
+    // @ts-expect-error Fix me later
     this.select.parentNode.insertBefore(this.container, this.select);
 
     this.label.addEventListener('mousedown', () => {
@@ -54,6 +55,7 @@ class Picker {
     item.setAttribute('role', 'button');
     item.classList.add('ql-picker-item');
     if (option.hasAttribute('value')) {
+      // @ts-expect-error Fix me later
       item.setAttribute('data-value', option.getAttribute('value'));
     }
     if (option.textContent) {
@@ -142,7 +144,7 @@ class Picker {
     this.options.setAttribute('aria-hidden', 'true');
   }
 
-  selectItem(item: HTMLElement, trigger = false) {
+  selectItem(item: HTMLElement | null, trigger = false) {
     const selected = this.container.querySelector('.ql-selected');
     if (item === selected) return;
     if (selected != null) {
@@ -150,15 +152,18 @@ class Picker {
     }
     if (item == null) return;
     item.classList.add('ql-selected');
+    // @ts-expect-error Fix me later
     this.select.selectedIndex = Array.from(item.parentNode.children).indexOf(
       item,
     );
     if (item.hasAttribute('data-value')) {
+      // @ts-expect-error Fix me later
       this.label.setAttribute('data-value', item.getAttribute('data-value'));
     } else {
       this.label.removeAttribute('data-value');
     }
     if (item.hasAttribute('data-label')) {
+      // @ts-expect-error Fix me later
       this.label.setAttribute('data-label', item.getAttribute('data-label'));
     } else {
       this.label.removeAttribute('data-label');
@@ -173,6 +178,7 @@ class Picker {
     let option;
     if (this.select.selectedIndex > -1) {
       const item =
+        // @ts-expect-error Fix me later
         this.container.querySelector('.ql-picker-options').children[
           this.select.selectedIndex
         ];


### PR DESCRIPTION
We enable `strictNullChecks` to enable type safety and also make method return types include `null` values. Before this PR, methods like `() => document.getElementById('myid')` will have a return type of `Element` instead of `Element | null`.

This PR doesn't try to fix all typing errors for simplicity, instead, it fixed some of them, especially ones related to return types.