### PR TITLE
Fix image display of CodePens on the Playground page

### DIFF
--- a/website/src/pages/playground.jsx
+++ b/website/src/pages/playground.jsx
@@ -7,9 +7,9 @@ import slug from '../utils/slug';
 
 const pens = [
   { title: 'Autosave', hash: 'RRYBEP' },
-  { title: 'Class vs Inline Style', hash: 'jAvpQL' },
-  { title: 'Form Submit', hash: 'kXRjQJ' },
-  { title: 'Snow Toolbar Tooltips', hash: 'ozYEro' },
+  { title: 'Class vs Inline Style', hash: 'jrvpQL' },
+  { title: 'Form Submit', hash: 'ZOMjmo' },
+  { title: 'Snow Toolbar Tooltips', hash: 'ozYEMo' },
   { title: 'Autogrow Height', hash: 'dOqrVm' },
   { title: 'Custom Fonts', hash: 'gLBYam' },
   { title: 'Quill Playground', hash: 'KzZqZx' },


### PR DESCRIPTION
Preview images of some codepens were not displayed on https://quilljs.com/playground

Before:

![image](https://github.com/quilljs/quill/assets/79307894/dc79091f-22ca-4a75-8e51-d730d17c6752)

After:

![image](https://github.com/quilljs/quill/assets/79307894/23a1c351-7a3e-45f0-bf81-566b2bd16a52)

(When attempting to visit codepens whose images were not displayed, such as e.g. https://codepen.io/quill/pen/jAvpQL, the portion `jAvpQL` was modified to `jrvpQL`.)
