### PR TITLE
Upgrade Parchment to fix typings

### DIFF
--- a/blots/block.ts
+++ b/blots/block.ts
@@ -1,11 +1,11 @@
 import {
   AttributorStore,
   BlockBlot,
+  Blot,
   EmbedBlot,
   LeafBlot,
   Scope,
 } from 'parchment';
-import { Blot } from 'parchment/dist/typings/blot/abstract/blot';
 import Delta from 'quill-delta';
 import Break from './break';
 import Inline from './inline';
@@ -184,18 +184,15 @@ BlockEmbed.scope = Scope.BLOCK_BLOT;
 // It is important for cursor behavior BlockEmbeds use tags that are block level elements
 
 function blockDelta(blot: BlockBlot, filter = true) {
-  return (
-    blot
-      // @ts-expect-error
-      .descendants(LeafBlot)
-      .reduce((delta, leaf: LeafBlot) => {
-        if (leaf.length() === 0) {
-          return delta;
-        }
-        return delta.insert(leaf.value(), bubbleFormats(leaf, {}, filter));
-      }, new Delta())
-      .insert('\n', bubbleFormats(blot))
-  );
+  return blot
+    .descendants(LeafBlot)
+    .reduce((delta, leaf) => {
+      if (leaf.length() === 0) {
+        return delta;
+      }
+      return delta.insert(leaf.value(), bubbleFormats(leaf, {}, filter));
+    }, new Delta())
+    .insert('\n', bubbleFormats(blot));
 }
 
 function bubbleFormats(blot, formats = {}, filter = true) {

--- a/blots/cursor.ts
+++ b/blots/cursor.ts
@@ -1,5 +1,4 @@
-import { EmbedBlot, Scope, ScrollBlot } from 'parchment';
-import { Parent } from 'parchment/dist/typings/blot/abstract/blot';
+import { EmbedBlot, Parent, Scope, ScrollBlot } from 'parchment';
 import Selection from '../core/selection';
 import TextBlot from './text';
 

--- a/blots/scroll.ts
+++ b/blots/scroll.ts
@@ -1,12 +1,13 @@
 import {
-  Scope,
-  ScrollBlot,
+  Blot,
   ContainerBlot,
   LeafBlot,
+  Parent,
   ParentBlot,
   Registry,
+  Scope,
+  ScrollBlot,
 } from 'parchment';
-import { Blot, Parent } from 'parchment/dist/typings/blot/abstract/blot';
 import Emitter, { EmitterSource } from '../core/emitter';
 import Block, { BlockEmbed } from './block';
 import Break from './break';

--- a/core/editor.ts
+++ b/core/editor.ts
@@ -45,13 +45,11 @@ class Editor {
           isImplicitNewlineAppended =
             !text.endsWith('\n') &&
             (scrollLength <= index ||
-              // @ts-expect-error
               !!this.scroll.descendant(BlockEmbed, index)[0]);
           this.scroll.insertAt(index, text);
           const [line, offset] = this.scroll.line(index);
           let formats = merge({}, bubbleFormats(line));
           if (line instanceof Block) {
-            // @ts-expect-error
             const [leaf] = line.descendant(LeafBlot, offset);
             formats = merge(formats, bubbleFormats(leaf));
           }
@@ -63,13 +61,11 @@ class Editor {
           if (isInlineEmbed) {
             if (
               scrollLength <= index ||
-              // @ts-expect-error
               !!this.scroll.descendant(BlockEmbed, index)[0]
             ) {
               isImplicitNewlineAppended = true;
             }
           } else if (index > 0) {
-            // @ts-expect-error
             const [leaf, offset] = this.scroll.descendant(LeafBlot, index - 1);
             if (leaf instanceof TextBlot) {
               const text = leaf.value();
@@ -86,7 +82,6 @@ class Editor {
           this.scroll.insertAt(index, key, op.insert[key]);
 
           if (isInlineEmbed) {
-            // @ts-expect-error
             const [leaf] = this.scroll.descendant(LeafBlot, index);
             const formats = merge({}, bubbleFormats(leaf));
             attributes = AttributeMap.diff(formats, attributes) || {};
@@ -181,7 +176,6 @@ class Editor {
       });
     } else {
       lines = this.scroll.lines(index, length);
-      // @ts-expect-error
       leaves = this.scroll.descendants(LeafBlot, index, length);
     }
     const [lineFormats, leafFormats] = [lines, leaves].map(blots => {

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -1,10 +1,6 @@
 import cloneDeep from 'lodash.clonedeep';
 import merge from 'lodash.merge';
 import * as Parchment from 'parchment';
-import {
-  Blot,
-  BlotConstructor,
-} from 'parchment/dist/typings/blot/abstract/blot';
 import Delta, { Op } from 'quill-delta';
 import Block, { BlockEmbed } from '../blots/block';
 import Scroll, { ScrollConstructor } from '../blots/scroll';
@@ -94,10 +90,10 @@ class Quill {
   static register(
     path:
       | string
-      | BlotConstructor
+      | Parchment.BlotConstructor
       | Parchment.Attributor
       | Record<string, unknown>,
-    target?: BlotConstructor | Parchment.Attributor | boolean,
+    target?: Parchment.BlotConstructor | Parchment.Attributor | boolean,
     overwrite = false,
   ) {
     if (typeof path !== 'string') {
@@ -443,7 +439,7 @@ class Quill {
     return this.editor.getFormat(index.index, index.length);
   }
 
-  getIndex(blot: Blot) {
+  getIndex(blot: Parchment.Blot) {
     return blot.offset(this.scroll);
   }
 

--- a/formats/bold.ts
+++ b/formats/bold.ts
@@ -1,6 +1,5 @@
 import Inline from '../blots/inline';
 
-// @ts-expect-error TODO: Inline.tagName should be string[] | string
 class Bold extends Inline {
   static blotName = 'bold';
   static tagName = ['STRONG', 'B'];

--- a/formats/header.ts
+++ b/formats/header.ts
@@ -1,6 +1,5 @@
 import Block from '../blots/block';
 
-// @ts-expect-error TODO: BlockBlot.tagName should be string[] | string
 class Header extends Block {
   static blotName = 'header';
   static tagName = ['H1', 'H2', 'H3', 'H4', 'H5', 'H6'];

--- a/formats/script.ts
+++ b/formats/script.ts
@@ -1,6 +1,5 @@
 import Inline from '../blots/inline';
 
-// @ts-expect-error TODO: Inline.tagName should be string[] | string
 class Script extends Inline {
   static blotName = 'script';
   static tagName = ['SUB', 'SUP'];

--- a/formats/table.ts
+++ b/formats/table.ts
@@ -1,4 +1,4 @@
-import LinkedList from 'parchment/dist/typings/collection/linked-list';
+import { LinkedList } from 'parchment';
 import Block from '../blots/block';
 import Container from '../blots/container';
 
@@ -132,8 +132,7 @@ class TableContainer extends Container {
   children: LinkedList<TableBody>;
 
   balanceCells() {
-    // @ts-expect-error TODO: fix signature of ParentBlot.descendants
-    const rows = this.descendants(TableRow) as TableRow[];
+    const rows = this.descendants(TableRow);
     const maxColumns = rows.reduce((max, row) => {
       return Math.max(row.children.length, max);
     }, 0);

--- a/modules/syntax.ts
+++ b/modules/syntax.ts
@@ -266,8 +266,7 @@ class Syntax extends Module<SyntaxOptions> {
     const range = this.quill.getSelection();
     const blots =
       blot == null
-        ? // @ts-expect-error
-          this.quill.scroll.descendants(SyntaxCodeBlockContainer)
+        ? this.quill.scroll.descendants(SyntaxCodeBlockContainer)
         : [blot];
     blots.forEach(container => {
       container.highlight(this.highlightBlot, force);

--- a/modules/table.ts
+++ b/modules/table.ts
@@ -24,9 +24,7 @@ class Table extends Module {
   }
 
   balanceTables() {
-    // @ts-expect-error
     this.quill.scroll.descendants(TableContainer).forEach(table => {
-      // @ts-expect-error
       table.balanceCells();
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
         "lodash.merge": "^4.5.0",
-        "parchment": "^2.0.1",
+        "parchment": "^3.0.0-alpha.1",
         "quill-delta": "^5.1.0"
       },
       "devDependencies": {
@@ -18428,9 +18428,9 @@
       }
     },
     "node_modules/parchment": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-2.0.1.tgz",
-      "integrity": "sha512-VBKrlEoZCBD+iwoeag0QTtY1Cti+Ma4nLpVYcc/uus/wHhMsPOi5InH3RL1s4aekahPZpabcS2ToKyGf7RMH/g=="
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-CJN5G75j0W3gPHMHDmY82sdtPf5wVO2YRhdXPBypvwj5YA5C9zsTnUdpq92Zxca8Eha331wMOlf6rTN+vi2dlA=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -38471,9 +38471,9 @@
       }
     },
     "parchment": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-2.0.1.tgz",
-      "integrity": "sha512-VBKrlEoZCBD+iwoeag0QTtY1Cti+Ma4nLpVYcc/uus/wHhMsPOi5InH3RL1s4aekahPZpabcS2ToKyGf7RMH/g=="
+      "version": "3.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0-alpha.1.tgz",
+      "integrity": "sha512-CJN5G75j0W3gPHMHDmY82sdtPf5wVO2YRhdXPBypvwj5YA5C9zsTnUdpq92Zxca8Eha331wMOlf6rTN+vi2dlA=="
     },
     "parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.5.0",
-    "parchment": "^2.0.1",
+    "parchment": "^3.0.0-alpha.1",
     "quill-delta": "^5.1.0"
   },
   "devDependencies": {

--- a/themes/snow.ts
+++ b/themes/snow.ts
@@ -51,7 +51,6 @@ class SnowTooltip extends BaseTooltip {
         if (range == null) return;
         if (range.length === 0 && source === Emitter.sources.USER) {
           const [link, offset] = this.quill.scroll.descendant(
-            // @ts-expect-error
             LinkBlot,
             range.index,
           );


### PR DESCRIPTION
Parchment added two changes regarding TypeScript typings:

1. (Breaking) Exposing all types from 'parchment' so consumers don't need to import from 'parchment/dist/*'
2. `Parchment#descendants(Blot)` now works and will narrow down return types.