### PR TITLE
🏷️ Fix `BaseTooltip.edit()` signature

### DIFF
--- a/themes/base.ts
+++ b/themes/base.ts
@@ -227,7 +227,7 @@ class BaseTooltip extends Tooltip {
     this.hide();
   }
 
-  edit(mode = 'link', preview = null) {
+  edit(mode = 'link', preview: string | null = null) {
     this.root.classList.remove('ql-hidden');
     this.root.classList.add('ql-editing');
     if (preview != null) {


### PR DESCRIPTION
At the moment, the `BaseTooltip.edit()` signature has type:

```ts
declare class BaseTooltip extends Tooltip {
  edit(mode?: string, preview?: null): void;
}
```

This change tweaks the signature to be more accurate:

```ts
declare class BaseTooltip extends Tooltip {
  edit(mode?: string, preview?: string | null): void;
}
```