### PR TITLE
♻️ Turn `Composition` into a module

### DIFF
--- a/core.ts
+++ b/core.ts
@@ -15,6 +15,7 @@ import Keyboard from './modules/keyboard';
 import Uploader from './modules/uploader';
 import Delta, { Op, OpIterator, AttributeMap } from 'quill-delta';
 import Input from './modules/input';
+import Composition from './core/composition';
 
 export { Delta, Op, OpIterator, AttributeMap };
 
@@ -30,6 +31,7 @@ Quill.register({
   'blots/text': TextBlot,
 
   'modules/clipboard': Clipboard,
+  'modules/composition': Composition,
   'modules/history': History,
   'modules/keyboard': Keyboard,
   'modules/uploader': Uploader,

--- a/core/composition.ts
+++ b/core/composition.ts
@@ -1,18 +1,26 @@
 import Embed from '../blots/embed';
 import Scroll from '../blots/scroll';
 import Emitter from './emitter';
+import Module from './module';
 
-class Composition {
+class Composition extends Module {
   isComposing = false;
 
-  constructor(private scroll: Scroll, private emitter: Emitter) {
-    scroll.domNode.addEventListener('compositionstart', event => {
+  private scroll: Scroll;
+  private emitter: Emitter;
+
+  constructor(quill, options) {
+    super(quill, options);
+    this.scroll = quill.scroll;
+    this.emitter = quill.emitter;
+
+    this.scroll.domNode.addEventListener('compositionstart', event => {
       if (!this.isComposing) {
         this.handleCompositionStart(event);
       }
     });
 
-    scroll.domNode.addEventListener('compositionend', event => {
+    this.scroll.domNode.addEventListener('compositionend', event => {
       if (this.isComposing) {
         this.handleCompositionEnd(event);
       }

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -174,8 +174,8 @@ class Quill {
     });
     this.editor = new Editor(this.scroll);
     this.selection = new Selection(this.scroll, this.emitter);
-    this.composition = new Composition(this.scroll, this.emitter);
     this.theme = new this.options.theme(this, this.options); // eslint-disable-line new-cap
+    this.composition = this.theme.addModule('composition');
     this.keyboard = this.theme.addModule('keyboard');
     this.clipboard = this.theme.addModule('clipboard');
     this.history = this.theme.addModule('history');

--- a/core/theme.ts
+++ b/core/theme.ts
@@ -3,6 +3,7 @@ import Clipboard from '../modules/clipboard';
 import History from '../modules/history';
 import Keyboard from '../modules/keyboard';
 import Uploader from '../modules/uploader';
+import Composition from './composition';
 
 interface ThemeOptions {
   modules: Record<string, unknown>;
@@ -30,6 +31,7 @@ class Theme {
   }
 
   addModule(name: 'clipboard'): Clipboard;
+  addModule(name: 'composition'): Composition;
   addModule(name: 'keyboard'): Keyboard;
   addModule(name: 'uploader'): Uploader;
   addModule(name: 'history'): History;


### PR DESCRIPTION
This change allows consumers to modify the behaviour of the new `Composition` class by registering an alternative class instead of the default module.