### PR TITLE
Fix block embed attributor errors

### DIFF
--- a/blots/scroll.ts
+++ b/blots/scroll.ts
@@ -200,10 +200,10 @@ class Scroll extends ScrollBlot {
             renderBlock.key,
             renderBlock.value,
           ) as EmbedBlot;
+          this.insertBefore(blockEmbed, refBlot || undefined);
           Object.keys(renderBlock.attributes).forEach(name => {
             blockEmbed.format(name, renderBlock.attributes[name]);
           });
-          this.insertBefore(blockEmbed, refBlot || undefined);
         }
       });
     }

--- a/test/fuzz/editor.test.ts
+++ b/test/fuzz/editor.test.ts
@@ -36,6 +36,7 @@ const attributeDefs: {
     { name: 'height', values: ['100', '200', '300'] },
   ],
   blockEmbed: [
+    { name: 'align', values: ['center', 'right'] },
     { name: 'width', values: ['100', '200', '300'] },
     { name: 'height', values: ['100', '200', '300'] },
   ],

--- a/test/unit/core/editor.js
+++ b/test/unit/core/editor.js
@@ -926,7 +926,7 @@ describe('Editor', function () {
       });
     });
 
-    it('inserts formatted block embeds', function () {
+    it('inserts formatted block embeds (styles)', function () {
       const editor = this.initialize(Editor, `<p></p>`);
       editor.insertContents(
         0,
@@ -940,6 +940,24 @@ describe('Editor', function () {
         { insert: 'a\n' },
         { insert: { video: '#' }, attributes: { width: '300' } },
         { insert: { video: '#' }, attributes: { width: '300' } },
+        { insert: '\nd\n' },
+      ]);
+    });
+
+    it('inserts formatted block embeds (attributor)', function () {
+      const editor = this.initialize(Editor, `<p></p>`);
+      editor.insertContents(
+        0,
+        new Delta()
+          .insert('a\n')
+          .insert({ video: '#' }, { align: 'center' })
+          .insert({ video: '#' }, { align: 'center' })
+          .insert('\nd'),
+      );
+      expect(editor.getDelta().ops).toEqual([
+        { insert: 'a\n' },
+        { insert: { video: '#' }, attributes: { align: 'center' } },
+        { insert: { video: '#' }, attributes: { align: 'center' } },
         { insert: '\nd\n' },
       ]);
     });


### PR DESCRIPTION
`BlockEmbed#format()` requires `attributor`, which is only created when the blot is attached. This PR fixes the issue by attaching the blot before applying formats.