### PR TITLE
fix checkbox event handler from executing twice on mobile

### DIFF
--- a/formats/list.ts
+++ b/formats/list.ts
@@ -26,6 +26,9 @@ class ListItem extends Block {
     super(scroll, domNode);
     const ui = domNode.ownerDocument.createElement('span');
     const listEventHandler = e => {
+      if (e.type === 'touchstart'){
+        e.preventDefault();
+      }
       if (!scroll.isEnabled()) return;
       const format = this.statics.formats(domNode, scroll);
       if (format === 'checked') {


### PR DESCRIPTION
Original Issue Filed: https://github.com/quilljs/quill/issues/3781

**Steps for Reproduction**

1. On a **MOBILE PHONE** Go to quill's playground: https://quilljs.com/playground/. (I have a pixel 6).
2. Paste the following into the editor (it only adds the `check` list option to the toolbar)
```
var quill = new Quill('#editor-container', {
  modules: {
    toolbar: [
      [{ header: [1, 2, false] }],
      ['bold', 'italic', 'underline'],
      ['image', 'code-block'],
      [{'list': 'check'}],
    ]
  },
  placeholder: 'Compose an epic...',
  theme: 'snow'  // or 'bubble'
});
```
3. Create a checkbox list, and try to tap the checkbox.

**Expected behavior**:
One would expect the check to appear or disappear. 

**Actual behavior**:
What happens is you actually have the check appear or disappear briefly then resume the state that it was originally on.
An interesting behavior is if you long press it works correctly...

**What Is going wrong**
In this method (I added the last checked variable and last checked console debug message):
```
var lastChecked = Date.now();
  function List(domNode) {
    _classCallCheck(this, List);

    var _this2 = _possibleConstructorReturn(this, (List.__proto__ || Object.getPrototypeOf(List)).call(this, domNode));

    var listEventHandler = function listEventHandler(e) {
      if (e.target.parentNode !== domNode) return;
      console.log("lastChecked time: " + lastChecked);

      var format = _this2.statics.formats(domNode);
      var blot = _parchment2.default.find(e.target);
      if (format === 'checked') {
        blot.format('list', 'unchecked');
      } else if (format === 'unchecked') {
        blot.format('list', 'checked');
      }
    };

    domNode.addEventListener('touchstart', listEventHandler);
    domNode.addEventListener('mousedown', listEventHandler);
    return _this2;
  }
```

The time holding variable `lastChecked` will be called twice with the same exact time in milliseconds. I believe the reason is because both `EventListeners` registered at the end of this function get called. The fact that behavior is correct when long pressing affirms this. 


**Solution**
After spending a good bit of time working with quill, I found the solution to this from the following articles:
https://developer.mozilla.org/en-US/docs/Web/API/Touch_events#handling_clicks
https://stackoverflow.com/a/31210694

Essentially calling `event.preventDefault();` 

>Since calling preventDefault() on a [touchstart](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchstart_event) or the first [touchmove](https://developer.mozilla.org/en-US/docs/Web/API/Element/touchmove_event) event of a series prevents the corresponding mouse events from firing

**Note**
My main development space is not javascript, so if there is any suggestions to improve upon this I am open/happy to hear them. I will say I tested this solution on my Pixel 6 as well as a Chromebook and both devices worked with toggling the checkbox.