### PR TITLE
Add role to toolbar

### DIFF
--- a/modules/toolbar.ts
+++ b/modules/toolbar.ts
@@ -31,6 +31,7 @@ class Toolbar extends Module<ToolbarProps> {
     super(quill, options);
     if (Array.isArray(this.options.container)) {
       const container = document.createElement('div');
+      container.setAttribute('role', 'toolbar');
       addControls(container, this.options.container);
       quill.container?.parentNode?.insertBefore(container, quill.container);
       this.container = container;


### PR DESCRIPTION
This PR adds `role` to toolbar when the container is created implicitly. It doesn't do anything to existing container given users may want to customize the structure.