### PR TITLE
Update landing page to use const instead of var in the example

### DIFF
--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -48,7 +48,7 @@ const Content = () => (
                 <pre class="ql-syntax" spellcheck="false"><span class="hljs-comment">// &lt;link href="https://cdn.quilljs.com/1.2.6/quill.snow.css" rel="stylesheet"&gt;</span>
 <span class="hljs-comment">// &lt;script src="https://cdn.quilljs.com/1.2.6/quill.min.js"&gt;&lt;/script&gt;</span>
 
-<span class="hljs-keyword">var</span> quill = <span class="hljs-keyword">new</span> Quill(<span class="hljs-string">'#editor'</span>, {
+<span class="hljs-keyword">const</span> quill = <span class="hljs-keyword">new</span> Quill(<span class="hljs-string">'#editor'</span>, {
   modules: {
     toolbar: <span class="hljs-string">'#toolbar'</span>
   },


### PR DESCRIPTION
The usage of `var` is generally considered obsolete and legacy. This makes the library look outdated in comparison with the competitors. As all of the modern browsers now support `const`. It makes Quill to look outdated especially on the front page example.

More context here: https://github.com/quilljs/quill/pull/3876

```npm run website:develop```
The front page example now uses `const`
<img width="965" alt="image" src="https://github.com/quilljs/quill/assets/963490/a46d26b2-4394-47a7-bdb5-88826fd17411">


This diff
- Updates front-page example to use `const` instead of `var`

