### PR TITLE
Fix docs typo

### DIFF
--- a/website/content/guides/upgrading-to-1-0.mdx
+++ b/website/content/guides/upgrading-to-1-0.mdx
@@ -108,7 +108,7 @@ const oldBullettedList = {
 
 - Ability to add new formats and content, or modify existing ones with [Parchment](https://github.com/quilljs/parchment/).
 
-- Added support for nested list, superscript, subscript, inline code, code block, header, blockquote, text direction, video and forumla support.
+- Added support for nested list, superscript, subscript, inline code, code block, header, blockquote, text direction, video and formula support.
 
 - Ability to format with classes instead of inline styles.
 

--- a/website/src/pages/playground.jsx
+++ b/website/src/pages/playground.jsx
@@ -7,9 +7,9 @@ import slug from '../utils/slug';
 
 const pens = [
   { title: 'Autosave', hash: 'RRYBEP' },
-  { title: 'Class vs Inline Style', hash: 'jAvpQL' },
-  { title: 'Form Submit', hash: 'kXRjQJ' },
-  { title: 'Snow Toolbar Tooltips', hash: 'ozYEro' },
+  { title: 'Class vs Inline Style', hash: 'jrvpQL' },
+  { title: 'Form Submit', hash: 'ZOMjmo' },
+  { title: 'Snow Toolbar Tooltips', hash: 'ozYEMo' },
   { title: 'Autogrow Height', hash: 'dOqrVm' },
   { title: 'Custom Fonts', hash: 'gLBYam' },
   { title: 'Quill Playground', hash: 'KzZqZx' },


### PR DESCRIPTION
1. fix typo `forumla` -> `formula`
2. fix broken codepen preview image url in playground
![quill有图挂了](https://github.com/quilljs/quill/assets/4365899/a7a0bfda-6bd8-4f44-a498-129029b2b2bd)
