### PR TITLE
Normalize UI node selection

### DIFF
--- a/assets/core.styl
+++ b/assets/core.styl
@@ -71,6 +71,7 @@ resets(arr)
   li
     list-style-type: none
     padding-left: LIST_STYLE_OUTER_WIDTH
+    position: relative
 
     > .ql-ui:before
       display: inline-block
@@ -79,12 +80,6 @@ resets(arr)
       text-align: right
       white-space: nowrap
       width: LIST_STYLE_WIDTH
-
-  @supports (display: contents)
-    li[data-list=bullet],
-    li[data-list=ordered]
-      > .ql-ui
-        display: contents
 
   li[data-list=checked],
   li[data-list=unchecked]
@@ -209,10 +204,6 @@ resets(arr)
 
   .ql-ui
     position: absolute
-
-  li
-    > .ql-ui
-      position: static;
 
 .ql-editor.ql-blank::before
   color: rgba(0,0,0,0.6)

--- a/core.ts
+++ b/core.ts
@@ -15,6 +15,7 @@ import Keyboard from './modules/keyboard';
 import Uploader from './modules/uploader';
 import Delta, { Op, OpIterator, AttributeMap } from 'quill-delta';
 import Input from './modules/input';
+import UINode from './modules/uiNode';
 
 export { Delta, Op, OpIterator, AttributeMap };
 
@@ -34,6 +35,7 @@ Quill.register({
   'modules/keyboard': Keyboard,
   'modules/uploader': Uploader,
   'modules/input': Input,
+  'modules/uiNode': UINode,
 });
 
 export default Quill;

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -186,6 +186,7 @@ class Quill {
     this.history = this.theme.addModule('history');
     this.uploader = this.theme.addModule('uploader');
     this.theme.addModule('input');
+    this.theme.addModule('uiNode');
     this.theme.init();
     this.emitter.on(Emitter.events.EDITOR_CHANGE, (type) => {
       if (type === Emitter.events.TEXT_CHANGE) {

--- a/e2e/fixtures/Composition.ts
+++ b/e2e/fixtures/Composition.ts
@@ -1,0 +1,108 @@
+import type {
+  CDPSession,
+  Page,
+  PlaywrightWorkerArgs,
+  PlaywrightWorkerOptions,
+} from '@playwright/test';
+
+abstract class CompositionSession {
+  abstract update(key: string): Promise<void>;
+  abstract commit(committedText: string): Promise<void>;
+
+  protected composingData = '';
+
+  constructor(protected page: Page) {}
+
+  protected async withKeyboardEvents(
+    key: string,
+    callback: () => Promise<void>,
+  ) {
+    const activeElement = this.page.locator('*:focus');
+
+    await activeElement.dispatchEvent('keydown', { key });
+    await callback();
+    await activeElement.dispatchEvent('keyup', { key });
+  }
+}
+
+class ChromiumCompositionSession extends CompositionSession {
+  constructor(
+    page: Page,
+    private session: CDPSession,
+  ) {
+    super(page);
+  }
+
+  async update(key: string) {
+    await this.withKeyboardEvents(key, async () => {
+      this.composingData += key;
+
+      await this.session.send('Input.imeSetComposition', {
+        selectionStart: this.composingData.length,
+        selectionEnd: this.composingData.length,
+        text: this.composingData,
+      });
+    });
+  }
+
+  async commit(committedText: string) {
+    await this.withKeyboardEvents('Space', async () => {
+      await this.session.send('Input.insertText', {
+        text: committedText,
+      });
+    });
+  }
+}
+
+class WebkitCompositionSession extends CompositionSession {
+  constructor(
+    page: Page,
+    private session: any,
+  ) {
+    super(page);
+  }
+
+  async update(key: string) {
+    await this.withKeyboardEvents(key, async () => {
+      this.composingData += key;
+
+      await this.session.send('Page.setComposition', {
+        selectionStart: this.composingData.length,
+        selectionLength: 0,
+        text: this.composingData,
+      });
+    });
+  }
+
+  async commit(committedText: string) {
+    await this.withKeyboardEvents('Space', async () => {
+      await this.page.keyboard.insertText(committedText);
+    });
+  }
+}
+
+class Composition {
+  constructor(
+    private page: Page,
+    private browserName: PlaywrightWorkerOptions['browserName'],
+    private playwright: PlaywrightWorkerArgs['playwright'],
+  ) {}
+
+  async start() {
+    switch (this.browserName) {
+      case 'chromium': {
+        const session = await this.page.context().newCDPSession(this.page);
+        return new ChromiumCompositionSession(this.page, session);
+      }
+      case 'webkit': {
+        const session = (await (this.playwright as any)._toImpl(this.page))
+          ._delegate._session;
+        return new WebkitCompositionSession(this.page, session);
+      }
+      default:
+        throw new Error(`Unsupported browser: ${this.browserName}`);
+    }
+  }
+}
+
+export default Composition;

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,12 +1,22 @@
 import { test as base } from '@playwright/test';
 import EditorPage from '../pageobjects/EditorPage';
+import Composition from './Composition';
 
 export const test = base.extend<{
   editorPage: EditorPage;
   clipboard: Clipboard;
+  composition: Composition;
 }>({
   editorPage: ({ page }, use) => {
     use(new EditorPage(page));
+  },
+  composition: ({ page, browserName, playwright }, use) => {
+    test.fail(
+      browserName === 'firefox',
+      'CDPSession is not available in Firefox',
+    );
+
+    use(new Composition(page, browserName, playwright));
   },
 });
 

--- a/e2e/list.spec.ts
+++ b/e2e/list.spec.ts
@@ -10,92 +10,141 @@ test.describe('list', () => {
   });
 
   for (const list of listTypes) {
-    test(`jump to line start (${list})`, async ({ page, editorPage }) => {
-      await editorPage.setContents([
-        { insert: 'item 1' },
-        { insert: '\n', attributes: { list } },
-      ]);
-
-      await editorPage.moveCursorAfterText('item 1');
-      await page.keyboard.press(isMac ? `Meta+ArrowLeft` : 'Home');
-      expect(await editorPage.getSelection()).toEqual({ index: 0, length: 0 });
-
-      await page.keyboard.type('start ');
-      expect(await editorPage.getContents()).toEqual([
-        { insert: 'start item 1' },
-        { insert: '\n', attributes: { list } },
-      ]);
-    });
-
-    test.describe('navigation with left/right arrow keys', () => {
-      test(`move to previous/next line (${list})`, async ({
-        page,
-        editorPage,
-      }) => {
+    test.describe(`navigation with shortcuts ${list}`, () => {
+      test('jump to line start', async ({ page, editorPage }) => {
         await editorPage.setContents([
-          { insert: 'first line' },
-          { insert: '\n', attributes: { list } },
-          { insert: 'second line' },
+          { insert: 'item 1' },
           { insert: '\n', attributes: { list } },
         ]);
 
-        await editorPage.moveCursorTo('s_econd');
-        await page.keyboard.press('ArrowLeft');
-        await page.keyboard.press('ArrowLeft');
+        await editorPage.moveCursorAfterText('item 1');
+        await page.keyboard.press(isMac ? `Meta+ArrowLeft` : 'Home');
         expect(await editorPage.getSelection()).toEqual({
-          index: 'first line'.length,
+          index: 0,
           length: 0,
         });
-        await page.keyboard.press('ArrowRight');
-        await page.keyboard.press('ArrowRight');
-        expect(await editorPage.getSelection()).toEqual({
-          index: 'first line\ns'.length,
-          length: 0,
-        });
-      });
 
-      test(`extend selection to previous/next line (${list})`, async ({
-        page,
-        editorPage,
-      }) => {
-        await editorPage.setContents([
-          { insert: 'first line' },
-          { insert: '\n', attributes: { list } },
-          { insert: 'second line' },
-          { insert: '\n', attributes: { list } },
-        ]);
-
-        await editorPage.moveCursorTo('s_econd');
-        await page.keyboard.press('Shift+ArrowLeft');
-        await page.keyboard.press('Shift+ArrowLeft');
-        await page.keyboard.type('a');
+        await page.keyboard.type('start ');
         expect(await editorPage.getContents()).toEqual([
-          { insert: 'first lineaecond line' },
+          { insert: 'start item 1' },
           { insert: '\n', attributes: { list } },
         ]);
       });
-    });
 
-    // https://github.com/quilljs/quill/issues/3837
-    test(`typing at beginning with IME (${list})`, async ({
-      editorPage,
-      composition,
-    }) => {
-      await editorPage.setContents([
-        { insert: 'item 1' },
-        { insert: '\n', attributes: { list } },
-        { insert: '' },
-        { insert: '\n', attributes: { list } },
-      ]);
+      test.describe('navigation with left/right arrow keys', () => {
+        test('move to previous/next line', async ({ page, editorPage }) => {
+          const firstLine = 'first line';
+          await editorPage.setContents([
+            { insert: firstLine },
+            { insert: '\n', attributes: { list } },
+            { insert: 'second line' },
+            { insert: '\n', attributes: { list } },
+          ]);
 
-      await editorPage.setSelection(7, 0);
-      await editorPage.typeWordWithIME(composition, '我');
-      expect(await editorPage.getContents()).toEqual([
-        { insert: 'item 1' },
-        { insert: '\n', attributes: { list } },
-        { insert: '我' },
-        { insert: '\n', attributes: { list } },
-      ]);
+          await editorPage.setSelection(firstLine.length + 2, 0);
+          await page.keyboard.press('ArrowLeft');
+          await page.keyboard.press('ArrowLeft');
+          expect(await editorPage.getSelection()).toEqual({
+            index: firstLine.length,
+            length: 0,
+          });
+          await page.keyboard.press('ArrowRight');
+          await page.keyboard.press('ArrowRight');
+          expect(await editorPage.getSelection()).toEqual({
+            index: firstLine.length + 2,
+            length: 0,
+          });
+        });
+
+        test('RTL support', async ({ page, editorPage }) => {
+          const firstLine = 'اللغة العربية';
+          await editorPage.setContents([
+            { insert: firstLine },
+            { insert: '\n', attributes: { list, direction: 'rtl' } },
+            { insert: 'توحيد اللهجات العربية' },
+            { insert: '\n', attributes: { list, direction: 'rtl' } },
+          ]);
+
+          await editorPage.setSelection(firstLine.length + 2, 0);
+          await page.keyboard.press('ArrowRight');
+          await page.keyboard.press('ArrowRight');
+          expect(await editorPage.getSelection()).toEqual({
+            index: firstLine.length,
+            length: 0,
+          });
+          await page.keyboard.press('ArrowLeft');
+          await page.keyboard.press('ArrowLeft');
+          expect(await editorPage.getSelection()).toEqual({
+            index: firstLine.length + 2,
+            length: 0,
+          });
+        });
+
+        test('extend selection to previous/next line', async ({
+          page,
+          editorPage,
+        }) => {
+          await editorPage.setContents([
+            { insert: 'first line' },
+            { insert: '\n', attributes: { list } },
+            { insert: 'second line' },
+            { insert: '\n', attributes: { list } },
+          ]);
+
+          await editorPage.moveCursorTo('s_econd');
+          await page.keyboard.press('Shift+ArrowLeft');
+          await page.keyboard.press('Shift+ArrowLeft');
+          await page.keyboard.type('a');
+          expect(await editorPage.getContents()).toEqual([
+            { insert: 'first lineaecond line' },
+            { insert: '\n', attributes: { list } },
+          ]);
+        });
+      });
+
+      // https://github.com/quilljs/quill/issues/3837
+      test('typing at beginning with IME', async ({
+        editorPage,
+        composition,
+      }) => {
+        await editorPage.setContents([
+          { insert: 'item 1' },
+          { insert: '\n', attributes: { list } },
+          { insert: '' },
+          { insert: '\n', attributes: { list } },
+        ]);
+
+        await editorPage.setSelection(7, 0);
+        await editorPage.typeWordWithIME(composition, '我');
+        expect(await editorPage.getContents()).toEqual([
+          { insert: 'item 1' },
+          { insert: '\n', attributes: { list } },
+          { insert: '我' },
+          { insert: '\n', attributes: { list } },
+        ]);
+      });
     });
   }
+
+  test('checklist is checkable', async ({ editorPage, page }) => {
+    await editorPage.setContents([
+      { insert: 'item 1' },
+      { insert: '\n', attributes: { list: 'unchecked' } },
+    ]);
+
+    await editorPage.setSelection(7, 0);
+    const rect = await editorPage.root.locator('li').evaluate((element) => {
+      return element.getBoundingClientRect();
+    });
+    await page.mouse.click(rect.left + 5, rect.top + 5);
+    expect(await editorPage.getContents()).toEqual([
+      { insert: 'item 1' },
+      { insert: '\n', attributes: { list: 'checked' } },
+    ]);
+    await page.mouse.click(rect.left + 5, rect.top + 5);
+    expect(await editorPage.getContents()).toEqual([
+      { insert: 'item 1' },
+      { insert: '\n', attributes: { list: 'unchecked' } },
+    ]);
+  });
 });

--- a/e2e/list.spec.ts
+++ b/e2e/list.spec.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures';
 import { isMac } from './utils';
 
-const listTypes = ['bullet', 'ordered', 'checked'];
+const listTypes = ['bullet', 'checked'];
 
 test.describe('list', () => {
   test.beforeEach(async ({ editorPage }) => {
@@ -74,6 +74,28 @@ test.describe('list', () => {
           { insert: '\n', attributes: { list } },
         ]);
       });
+    });
+
+    // https://github.com/quilljs/quill/issues/3837
+    test(`typing at beginning with IME (${list})`, async ({
+      editorPage,
+      composition,
+    }) => {
+      await editorPage.setContents([
+        { insert: 'item 1' },
+        { insert: '\n', attributes: { list } },
+        { insert: '' },
+        { insert: '\n', attributes: { list } },
+      ]);
+
+      await editorPage.setSelection(7, 0);
+      await editorPage.typeWordWithIME(composition, '我');
+      expect(await editorPage.getContents()).toEqual([
+        { insert: 'item 1' },
+        { insert: '\n', attributes: { list } },
+        { insert: '我' },
+        { insert: '\n', attributes: { list } },
+      ]);
     });
   }
 });

--- a/e2e/list.spec.ts
+++ b/e2e/list.spec.ts
@@ -2,22 +2,78 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures';
 import { isMac } from './utils';
 
+const listTypes = ['bullet', 'ordered', 'checked'];
+
 test.describe('list', () => {
   test.beforeEach(async ({ editorPage }) => {
     await editorPage.open();
   });
 
-  test('navigating with shortcuts', async ({ page, editorPage }) => {
-    await editorPage.setContents([
-      { insert: 'item 1' },
-      { insert: '\n', attributes: { list: 'bullet' } },
-    ]);
+  for (const list of listTypes) {
+    test(`jump to line start (${list})`, async ({ page, editorPage }) => {
+      await editorPage.setContents([
+        { insert: 'item 1' },
+        { insert: '\n', attributes: { list } },
+      ]);
 
-    await editorPage.moveCursorAfterText('item 1');
-    await page.keyboard.press(isMac ? `Meta+ArrowLeft` : 'Home');
-    expect(await editorPage.getSelection()).toEqual({ index: 0, length: 0 });
+      await editorPage.moveCursorAfterText('item 1');
+      await page.keyboard.press(isMac ? `Meta+ArrowLeft` : 'Home');
+      expect(await editorPage.getSelection()).toEqual({ index: 0, length: 0 });
 
-    await page.keyboard.press(isMac ? `Meta+ArrowRight` : 'End');
-    expect(await editorPage.getSelection()).toEqual({ index: 6, length: 0 });
-  });
+      await page.keyboard.type('start ');
+      expect(await editorPage.getContents()).toEqual([
+        { insert: 'start item 1' },
+        { insert: '\n', attributes: { list } },
+      ]);
+    });
+
+    test.describe('navigation with left/right arrow keys', () => {
+      test(`move to previous/next line (${list})`, async ({
+        page,
+        editorPage,
+      }) => {
+        await editorPage.setContents([
+          { insert: 'first line' },
+          { insert: '\n', attributes: { list } },
+          { insert: 'second line' },
+          { insert: '\n', attributes: { list } },
+        ]);
+
+        await editorPage.moveCursorTo('s_econd');
+        await page.keyboard.press('ArrowLeft');
+        await page.keyboard.press('ArrowLeft');
+        expect(await editorPage.getSelection()).toEqual({
+          index: 'first line'.length,
+          length: 0,
+        });
+        await page.keyboard.press('ArrowRight');
+        await page.keyboard.press('ArrowRight');
+        expect(await editorPage.getSelection()).toEqual({
+          index: 'first line\ns'.length,
+          length: 0,
+        });
+      });
+
+      test(`extend selection to previous/next line (${list})`, async ({
+        page,
+        editorPage,
+      }) => {
+        await editorPage.setContents([
+          { insert: 'first line' },
+          { insert: '\n', attributes: { list } },
+          { insert: 'second line' },
+          { insert: '\n', attributes: { list } },
+        ]);
+
+        await editorPage.moveCursorTo('s_econd');
+        await page.keyboard.press('Shift+ArrowLeft');
+        await page.keyboard.press('Shift+ArrowLeft');
+        await page.keyboard.type('a');
+        expect(await editorPage.getContents()).toEqual([
+          { insert: 'first lineaecond line' },
+          { insert: '\n', attributes: { list } },
+        ]);
+      });
+    });
+  }
 });

--- a/e2e/pageobjects/EditorPage.ts
+++ b/e2e/pageobjects/EditorPage.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import type Composition from '../fixtures/Composition';
 
 interface Op {
   insert?: string | Record<string, unknown>;
@@ -79,6 +80,26 @@ export default class EditorPage {
       // @ts-expect-error
       return window.quill.getSelection();
     });
+  }
+
+  async setSelection(index: number, length: number): Promise<void>;
+  async setSelection(range: { index: number; length: number }): Promise<void>;
+  async setSelection(
+    range: { index: number; length: number } | number,
+    length?: number,
+  ) {
+    await this.page.evaluate(
+      // @ts-expect-error
+      (range) => window.quill.setSelection(range),
+      typeof range === 'number' ? { index: range, length: length || 0 } : range,
+    );
+  }
+
+  async typeWordWithIME(composition: Composition, composedWord: string) {
+    const ime = await composition.start();
+    await ime.update('w');
+    await ime.update('o');
+    await ime.commit(composedWord);
   }
 
   async cutoffHistory() {

--- a/e2e/replaceSelection.spec.ts
+++ b/e2e/replaceSelection.spec.ts
@@ -37,6 +37,18 @@ test.describe('replace selection', () => {
       expect(await editorPage.getContents()).toEqual([{ insert: '1\n\n' }]);
     });
 
+    test('with IME', async ({ editorPage, composition }) => {
+      await editorPage.setContents([
+        { insert: '1' },
+        { insert: '2', attributes: { color: 'red' } },
+        { insert: '3\n' },
+      ]);
+      await editorPage.selectText('2', '3');
+      await editorPage.typeWordWithIME(composition, '我');
+      expect(await editorPage.root.innerHTML()).toEqual('<p>1我</p>');
+      expect(await editorPage.getContents()).toEqual([{ insert: '1我\n' }]);
+    });
+
     test('after a bold text', async ({ page, editorPage }) => {
       await editorPage.setContents([
         { insert: '1', attributes: { bold: true } },

--- a/modules/uiNode.ts
+++ b/modules/uiNode.ts
@@ -1,0 +1,98 @@
+import { ParentBlot } from 'parchment';
+import Module from '../core/module';
+import Quill from '../core/quill';
+
+const isMac = /Mac/i.test(navigator.platform);
+
+const canMoveCaretBeforeUINode = (event: KeyboardEvent) => {
+  if (
+    event.key === 'ArrowLeft' ||
+    event.key === 'ArrowRight' ||
+    event.key === 'ArrowUp' ||
+    event.key === 'ArrowDown' ||
+    event.key === 'Home'
+  ) {
+    return true;
+  }
+
+  if (isMac && event.key === 'a' && event.ctrlKey === true) {
+    return true;
+  }
+
+  return false;
+};
+
+class UINode extends Module {
+  isListening = false;
+  selectionChangeDeadline = 0;
+
+  constructor(quill: Quill, options: Record<string, never>) {
+    super(quill, options);
+
+    this.handleArrowKeys();
+    this.handleNavigationShortcuts();
+  }
+
+  private handleArrowKeys() {
+    this.quill.keyboard.addBinding({
+      key: 'ArrowLeft',
+      shiftKey: null,
+      handler(range, { line, offset, event }) {
+        if (offset === 0 && line instanceof ParentBlot && line.uiNode) {
+          this.quill.setSelection(
+            range.index - 1,
+            range.length + (event.shiftKey ? 1 : 0),
+            Quill.sources.USER,
+          );
+          return false;
+        }
+        return true;
+      },
+    });
+  }
+
+  private handleNavigationShortcuts() {
+    this.quill.root.addEventListener('keydown', (event) => {
+      if (!event.defaultPrevented && canMoveCaretBeforeUINode(event)) {
+        this.ensureListeningToSelectionChange();
+      }
+    });
+  }
+
+  private ensureListeningToSelectionChange() {
+    if (this.isListening) return;
+
+    this.isListening = true;
+    this.selectionChangeDeadline = Date.now() + 100;
+
+    const listener = () => {
+      this.isListening = false;
+
+      if (Date.now() <= this.selectionChangeDeadline) {
+        this.handleSelectionChange();
+      }
+    };
+
+    document.addEventListener('selectionchange', listener, {
+      once: true,
+    });
+  }
+
+  private handleSelectionChange() {
+    const selection = document.getSelection();
+    if (!selection) return;
+    const range = selection.getRangeAt(0);
+    if (range.collapsed !== true || range.startOffset !== 0) return;
+
+    const line = this.quill.scroll.find(range.startContainer);
+    if (!(line instanceof ParentBlot) || !line.uiNode) return;
+
+    const newRange = document.createRange();
+    newRange.setStartAfter(line.uiNode);
+    newRange.setEndAfter(line.uiNode);
+    selection.removeAllRanges();
+    selection.addRange(newRange);
+  }
+}
+
+export default UINode;

--- a/modules/uiNode.ts
+++ b/modules/uiNode.ts
@@ -4,10 +4,12 @@ import Quill from '../core/quill';
 
 const isMac = /Mac/i.test(navigator.platform);
 
+// A loose check to see if the shortcut can move the caret before a UI node:
+// <ANY_PARENT>[CARET]<div class="ql-ui"></div>[CONTENT]</ANY_PARENT>
 const canMoveCaretBeforeUINode = (event: KeyboardEvent) => {
   if (
     event.key === 'ArrowLeft' ||
-    event.key === 'ArrowRight' ||
+    event.key === 'ArrowRight' || // RTL language or moving from the end of the previous line
     event.key === 'ArrowUp' ||
     event.key === 'ArrowDown' ||
     event.key === 'Home'

--- a/test/unit/modules/toolbar.spec.ts
+++ b/test/unit/modules/toolbar.spec.ts
@@ -14,6 +14,7 @@ import { SizeClass } from '../../../formats/size';
 import Bold from '../../../formats/bold';
 import Link from '../../../formats/link';
 import { AlignClass } from '../../../formats/align';
+import UINode from '../../../modules/uiNode';
 
 const createContainer = (html = '') => {
   const container = document.body.appendChild(document.createElement('div'));
@@ -152,6 +153,7 @@ describe('Toolbar', () => {
           'modules/history': History,
           'modules/uploader': Uploader,
           'modules/input': Input,
+          'modules/uiNode': UINode,
         },
         true,
       );


### PR DESCRIPTION
This PR added a new module to normalize browser's native behavior. 

Specifically, in Firefox, when the current line blot contains a UI node, pressing CMD+ArrowLeft in macOS would result in the caret being placed right before the UI node. This PR normalizes the behavior by checking such situations and moving the caret after the UI node.

* This PR fixed #3837 and also added an E2E test case.
* This PR fixed CMD+ArrowLeft not working in Firefox for checklists.

### Test Plan

* Make sure no regressions for #3837
* Make sure CMD+ArrowLeft works in Firefox for all list types.