### PR TITLE
Refactor: switch to lodash-es

### DIFF
--- a/core/editor.ts
+++ b/core/editor.ts
@@ -1,6 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
-import merge from 'lodash.merge';
+import { cloneDeep, isEqual, merge } from 'lodash-es';
 import { LeafBlot, EmbedBlot, Scope, ParentBlot } from 'parchment';
 import type { Blot } from 'parchment';
 import Delta, { AttributeMap, Op } from 'quill-delta';

--- a/core/quill.ts
+++ b/core/quill.ts
@@ -1,5 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
-import merge from 'lodash.merge';
+import { cloneDeep, merge } from 'lodash-es';
 import * as Parchment from 'parchment';
 import type { Op } from 'quill-delta';
 import Delta from 'quill-delta';

--- a/core/selection.ts
+++ b/core/selection.ts
@@ -1,6 +1,5 @@
 import { LeafBlot, Scope } from 'parchment';
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import { cloneDeep, isEqual } from 'lodash-es';
 import Emitter from './emitter';
 import type { EmitterSource } from './emitter';
 import logger from './logger';

--- a/modules/keyboard.ts
+++ b/modules/keyboard.ts
@@ -1,5 +1,4 @@
-import cloneDeep from 'lodash.clonedeep';
-import isEqual from 'lodash.isequal';
+import { cloneDeep, isEqual } from 'lodash-es';
 import Delta, { AttributeMap } from 'quill-delta';
 import { EmbedBlot, Scope, TextBlot } from 'parchment';
 import type { Blot, BlockBlot } from 'parchment';

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,6 @@
       ],
       "dependencies": {
         "eventemitter3": "^4.0.7",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.merge": "^4.5.0",
         "parchment": "^3.0.0-alpha.1",
         "quill-delta": "^5.1.0"
       },
@@ -24,9 +21,7 @@
         "@babel/preset-env": "^7.22.5",
         "@babel/preset-typescript": "^7.22.5",
         "@playwright/test": "^1.39.0",
-        "@types/lodash.clonedeep": "^4.5.7",
-        "@types/lodash.isequal": "^4.5.6",
-        "@types/lodash.merge": "^4.6.7",
+        "@types/lodash-es": "^4.17.11",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "@vitest/browser": "^0.34.6",
@@ -44,6 +39,7 @@
         "http-proxy": "^1.18.0",
         "jsdom": "^22.1.0",
         "lodash": "^4.17.15",
+        "lodash-es": "^4.17.21",
         "mini-css-extract-plugin": "^2.7.6",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.0.3",
@@ -4800,28 +4796,10 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
     },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.merge": {
-      "version": "4.6.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
-      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-eCw8FYAWHt2DDl77s+AMLLzPn310LKohruumpucZI4oOFJkIgnlaJcy23OKMJxx4r9PeTF13Gv6w+jqjWQaYUg==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -15236,6 +15214,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -27223,28 +27207,10 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
       "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
     },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
-      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.isequal": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz",
-      "integrity": "sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.merge": {
-      "version": "4.6.7",
-      "resolved": "https://registry.npmjs.org/@types/lodash.merge/-/lodash.merge-4.6.7.tgz",
-      "integrity": "sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==",
+    "@types/lodash-es": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha512-eCw8FYAWHt2DDl77s+AMLLzPn310LKohruumpucZI4oOFJkIgnlaJcy23OKMJxx4r9PeTF13Gv6w+jqjWQaYUg==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"
@@ -34859,6 +34825,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   ],
   "dependencies": {
     "eventemitter3": "^4.0.7",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
-    "lodash.merge": "^4.5.0",
     "parchment": "^3.0.0-alpha.1",
     "quill-delta": "^5.1.0"
   },
@@ -28,9 +25,7 @@
     "@babel/preset-env": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
     "@playwright/test": "^1.39.0",
-    "@types/lodash.clonedeep": "^4.5.7",
-    "@types/lodash.isequal": "^4.5.6",
-    "@types/lodash.merge": "^4.6.7",
+    "@types/lodash-es": "^4.17.11",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
     "@vitest/browser": "^0.34.6",
@@ -48,6 +43,7 @@
     "http-proxy": "^1.18.0",
     "jsdom": "^22.1.0",
     "lodash": "^4.17.15",
+    "lodash-es": "^4.17.21",
     "mini-css-extract-plugin": "^2.7.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.0.3",

--- a/themes/base.ts
+++ b/themes/base.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash.merge';
+import { merge } from 'lodash-es';
 import type Quill from '../core/quill';
 import Emitter from '../core/emitter';
 import Theme from '../core/theme';

--- a/themes/bubble.ts
+++ b/themes/bubble.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash.merge';
+import { merge } from 'lodash-es';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
 import { Range } from '../core/selection';

--- a/themes/snow.ts
+++ b/themes/snow.ts
@@ -1,4 +1,4 @@
-import merge from 'lodash.merge';
+import { merge } from 'lodash-es';
 import Emitter from '../core/emitter';
 import BaseTheme, { BaseTooltip } from './base';
 import LinkBlot from '../formats/link';


### PR DESCRIPTION
By switching to lodash-es, we can save ~10KB minimized size for the 3 packages currently used (`cloneDeep`, `isEqual`, `merge`), because independent packages (`lodash.clonedeep` etc.)  each contain their own lodash sub-modules (`isObject`, `isArray`, etc.)


See [example](https://stackblitz.com/edit/vitejs-vite-dnhgzn?file=lodash-es.js&file=lodash-separate.js&terminal=dev) for build size comparison:


![image](https://github.com/quilljs/quill/assets/5557143/c5ab2ffc-27a2-4d85-a62e-2e64b7807b35)
