### PR TITLE
Avoid generating unsupported formats on paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [Unreleased]
 
 - **Clipboard** Convert newlines between inline elements to a space.
+- **Clipboard** Avoid generating unsupported formats on paste.
 - **Syntax** Support highlight.js v10 and v11.
 
 # 2.0.0-beta.2


### PR DESCRIPTION
Closes https://github.com/quilljs/quill/issues/1434

This PR ensures that only registered formats can be applied.