### PR TITLE
Add link, image, video, formula to the formats array example

### DIFF
--- a/packages/website/content/docs/modules/toolbar.mdx
+++ b/packages/website/content/docs/modules/toolbar.mdx
@@ -126,6 +126,7 @@ Note [Themes](/docs/themes/) may also specify default values for dropdowns. For 
 const toolbarOptions = [
   ['bold', 'italic', 'underline', 'strike'],        // toggled buttons
   ['blockquote', 'code-block'],
+  ['link', 'image', 'video', 'formula'],
 
   [{ 'header': 1 }, { 'header': 2 }],               // custom button values
   [{ 'list': 'ordered'}, { 'list': 'bullet' }],


### PR DESCRIPTION
Users often ask for a list of all available formats as array and HTML.
I suggest to also expand the HTML example with all available formats similar to the [formats page](https://v2.quilljs.com/docs/formats) (not in this PR)

Should we also add inline-code and check list?
```
'code'
{ 'list': 'check' }
```