### PR TITLE
Add missing attributor for `Selection` test

### DIFF
--- a/packages/quill/test/unit/core/selection.spec.ts
+++ b/packages/quill/test/unit/core/selection.spec.ts
@@ -11,7 +11,7 @@ import Italic from '../../../src/formats/italic';
 import Strike from '../../../src/formats/strike';
 import { ColorStyle } from '../../../src/formats/color';
 import { BackgroundStyle } from '../../../src/formats/background';
-import { FontClass } from '../../../src/formats/font';
+import { SizeClass } from '../../../src/formats/size';
 
 const createSelection = (html: string, container = document.body) => {
   const scroll = createScroll(
@@ -25,7 +25,7 @@ const createSelection = (html: string, container = document.body) => {
       Link,
       ColorStyle,
       BackgroundStyle,
-      FontClass,
+      SizeClass,
     ]),
     container,
   );


### PR DESCRIPTION
I'm not sure why the "large text" test passes, but we have derivative tests in our fork that fail because the `SizeClass` attributor is missing, and the `ql-size-large` class is stripped.

You can reproduce in this repo if you change the test setup:

```diff
test('large text', () => {
  const { reference, container } = setup();
  const selection = createSelection(
-  '<p><span class="ql-size-large">0000</span></p>',
+  '<p>0000</p>',
    container,
  );
+ selection.scroll.formatAt(0, 4, 'size', 'large');
  const span = container.querySelector('span') as HTMLSpanElement;
  const bounds = selection.getBounds(2);
  expect(bounds?.left).approximately(
    reference.left + span.offsetWidth / 2,
    3,
  );
  expect(bounds?.height).approximately(span.offsetHeight, 3);
  expect(bounds?.top).approximately(reference.top, 3);
});
```