### PR TITLE
🐛 Run clipboard matchers against plain text pastes

### DIFF
--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -106,7 +106,8 @@ class Clipboard extends Module<ClipboardOptions> {
       });
     }
     if (!html) {
-      return new Delta().insert(text || '', formats);
+      const converted = this.convertText(text || '');
+      return converted.compose(new Delta().retain(converted.length(), formats));
     }
     const delta = this.convertHTML(html);
     // Remove trailing newline
@@ -123,8 +124,19 @@ class Clipboard extends Module<ClipboardOptions> {
     normalizeExternalHTML(doc);
   }
 
+  protected convertText(text: string) {
+    const doc = new DOMParser().parseFromString('', 'text/html');
+    const node = doc.createTextNode(text);
+    doc.body.appendChild(node);
+    return this.convertDoc(doc);
+  }
+
   protected convertHTML(html: string) {
     const doc = new DOMParser().parseFromString(html, 'text/html');
+    return this.convertDoc(doc);
+  }
+
+  private convertDoc(doc: Document) {
     this.normalizeHTML(doc);
     const container = doc.body;
     const nodeMatches = new WeakMap();


### PR DESCRIPTION
This is a reimplementation of https://github.com/quilljs/quill/pull/3530

At the moment, if the clipboard pastes `text/plain` content and no `text/html` content, the `Clipboard.convert()` function will completely skip the matching logic.

This is surprising when registering text node clipboard matchers.

This change updates the `convert()` function to match the plain text against the plain text matchers, just like we do with HTML.

Note that these matchers will run _before_ applying the formats for ["paste and match style"][1], so they won't match an element matchers for the target formatting (which I think should be expected anyway).

[1]: https://github.com/quilljs/quill/pull/3927