### PR TITLE
🐛 Fix Selection.getBounds() when starting range at end of text node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix toolbar button state not updated in some cases
 - Narrower `BubbleTheme.tooltip` type
+- Fix `Selection.getBounds()` when starting range at end of text node
 
 # 2.0.0-rc.1
 

--- a/packages/quill/src/core/selection.ts
+++ b/packages/quill/src/core/selection.ts
@@ -183,6 +183,17 @@ class Selection {
     let node: Node;
     let [leaf, offset] = this.scroll.leaf(index);
     if (leaf == null) return null;
+    if (length > 0 && offset === leaf.length()) {
+      const [next] = this.scroll.leaf(index + 1);
+      if (next) {
+        const [line] = this.scroll.line(index);
+        const [nextLine] = this.scroll.line(index + 1);
+        if (line === nextLine) {
+          leaf = next;
+          offset = 0;
+        }
+      }
+    }
     [node, offset] = leaf.position(offset, true);
     const range = document.createRange();
     if (length > 0) {

--- a/packages/quill/test/unit/core/selection.spec.ts
+++ b/packages/quill/test/unit/core/selection.spec.ts
@@ -598,6 +598,22 @@ describe('Selection', () => {
       );
     });
 
+    test('selection starting at end of text node', () => {
+      const { reference, container } = setup();
+      container.style.width = `${reference.width * 4}px`;
+      const selection = createSelection(
+        `
+        <p>
+          0000
+          <b>0000</b>
+          0000
+        </p>`,
+        container,
+      );
+      const bounds = selection.getBounds(4, 1);
+      expect(bounds?.width).approximately(reference.width, 1);
+    });
+
     test('multiple lines', () => {
       const { reference, container } = setup();
       const selection = createSelection(


### PR DESCRIPTION
Cherry-picked from #3774.
Closes #3774

At the moment there's a bug when trying to get the bounds of a range
which starts at the end of a text node at the end of a line.

In this case, the returned bounds span the entire width of the editor,
which isn't the desired result.

This change fixes the issue by checking if the Quill range starts at the
end of a leaf. If it does, we try to define the range starting at the
beginning of the next leaf instead.