### PR TITLE
Preserve es modules in babel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix toolbar button state not updated in some cases
 - Narrower `BubbleTheme.tooltip` type
 - Fix `Selection.getBounds()` when starting range at end of text node
+- Improve compatibility with esbuild
 
 # 2.0.0-rc.1
 

--- a/packages/quill/babel.config.js
+++ b/packages/quill/babel.config.js
@@ -1,7 +1,10 @@
 const pkg = require('./package.json');
 
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-typescript'],
+  presets: [
+    ['@babel/preset-env', { modules: false }],
+    '@babel/preset-typescript'
+  ],
   plugins: [
     ['transform-define', { QUILL_VERSION: pkg.version }],
     './scripts/babel-svg-inline-import',

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -11,6 +11,7 @@
     "parchment": "^3.0.0-alpha.2",
     "quill-delta": "^5.1.0"
   },
+  "sideEffects": false,
   "devDependencies": {
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.3",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -11,7 +11,6 @@
     "parchment": "^3.0.0-alpha.2",
     "quill-delta": "^5.1.0"
   },
-  "sideEffects": false,
   "devDependencies": {
     "@babel/cli": "^7.23.4",
     "@babel/core": "^7.23.3",


### PR DESCRIPTION
For users installing from npm, they already have a bundler that can handle es modules.
For users that want to run quill in nodejs directly, it's currently not possible due to [side effects calling DOM](https://github.com/quilljs/quill/blob/cd3203f6f092af123b37cea629e76acb842d169f/packages/quill/src/core/emitter.ts#L8-L17)
 
By preserving modules, it allows third party dependencies (e.g. lodash-es) to be tree shaken. Currently lodash-es is fully bundled by users because of es modules transpiled to `require()` https://www.npmjs.com/package/quill/v/2.0.0-rc.1?activeTab=code
![image](https://github.com/quilljs/quill/assets/5557143/38e69dca-ac37-40f5-b9bf-b6821bec5bf5)
