### PR TITLE
Fix example for content and delta in playground

### DIFF
--- a/packages/website/content/docs/delta.mdx
+++ b/packages/website/content/docs/delta.mdx
@@ -146,7 +146,7 @@ function update(delta) {
   const contents = quill.getContents();
   let html = \`<h3>contents</h3>\${formatDelta(contents)}\`
   if (delta) {
-    html = \`\${html}<h3>change</h3>\${formatDelta(contents)}\`;
+    html = \`\${html}<h3>change</h3>\${formatDelta(delta)}\`;
   }
   playground.innerHTML = html;
 }


### PR DESCRIPTION
The example in the playground is using `contents` while displaying the changes in the playground.