### PR TITLE
Export ATTRIBUTES in formats/image

### DIFF
--- a/packages/quill/src/formats/image.ts
+++ b/packages/quill/src/formats/image.ts
@@ -64,4 +64,4 @@ class Image extends EmbedBlot {
   }
 }
 
-export default Image;
+export { Image as default, ATTRIBUTES };


### PR DESCRIPTION
Export `ATTRIBUTES` in `formats/image`, so developers can easily add some attrs.