### PR TITLE
Fix redundant newlines when pasting from external sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix `Quill#getSemanticHTML()` for list items
 - Remove unnecessary Firefox workaround
+- **Clipboard** Fix redundant newlines when pasting from external sources
 
 # 2.0.0-rc.2
 

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -529,7 +529,10 @@ function matchList(node: Node, delta: Delta, scroll: ScrollBlot) {
 
 function matchNewline(node: Node, delta: Delta, scroll: ScrollBlot) {
   if (!deltaEndsWith(delta, '\n')) {
-    if (isLine(node, scroll)) {
+    if (
+      isLine(node, scroll) &&
+      (node.childNodes.length > 0 || node instanceof HTMLParagraphElement)
+    ) {
       return delta.insert('\n');
     }
     if (delta.length() > 0 && node.nextSibling) {

--- a/packages/quill/test/unit/modules/clipboard.spec.ts
+++ b/packages/quill/test/unit/modules/clipboard.spec.ts
@@ -563,5 +563,11 @@ describe('Clipboard', () => {
           .insert('\n'),
       );
     });
+
+    test('ignore empty elements except paragraphs', () => {
+      const html = '<div>hello<div></div>my<p></p>world</div>';
+      const delta = createClipboard().convert({ html });
+      expect(delta).toEqual(new Delta().insert('hello\nmy\n\nworld'));
+    });
   });
 });


### PR DESCRIPTION
This PR brought back some old behaviors that would ignore empty `div`s when pasting from external sources. An example is when pasting from Office online, it contains the empty divs that are UI controls and should be ignored.