### PR TITLE
Add formats option for specifying allowed formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix `Quill#getSemanticHTML()` for list items
 - Remove unnecessary Firefox workaround
 - **Clipboard** Fix redundant newlines when pasting from external sources
+- Add `formats` option for specifying allowed formats
 
 # 2.0.0-rc.2
 

--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -794,13 +794,7 @@ function expandConfig(
     }
   } else {
     registry = options.formats
-      ? createRegistryWithFormats(
-          options.formats,
-          config.registry,
-          (errorMessage) => {
-            debug.error(errorMessage);
-          },
-        )
+      ? createRegistryWithFormats(options.formats, config.registry, debug)
       : config.registry;
   }
 

--- a/packages/quill/src/core/utils/createRegistryWithFormats.ts
+++ b/packages/quill/src/core/utils/createRegistryWithFormats.ts
@@ -6,7 +6,7 @@ const CORE_FORMATS = ['block', 'break', 'cursor', 'inline', 'scroll', 'text'];
 const createRegistryWithFormats = (
   formats: string[],
   sourceRegistry: Registry,
-  logError: (errorMessage: string) => void,
+  debug: { error: (errorMessage: string) => void },
 ) => {
   const registry = new Registry();
   CORE_FORMATS.forEach((name) => {
@@ -17,7 +17,7 @@ const createRegistryWithFormats = (
   formats.forEach((name) => {
     let format = sourceRegistry.query(name);
     if (!format) {
-      logError(
+      debug.error(
         `Cannot register "${name}" specified in "formats" config. Are you sure it was registered?`,
       );
     }
@@ -28,7 +28,9 @@ const createRegistryWithFormats = (
 
       iterations += 1;
       if (iterations > MAX_REGISTER_ITERATIONS) {
-        logError(`Maximum iterations reached when registering "${name}"`);
+        debug.error(
+          `Cycle detected in registering blot requiredContainer: "${name}"`,
+        );
         break;
       }
     }

--- a/packages/quill/src/core/utils/createRegistryWithFormats.ts
+++ b/packages/quill/src/core/utils/createRegistryWithFormats.ts
@@ -1,0 +1,40 @@
+import { Registry } from 'parchment';
+
+const MAX_REGISTER_ITERATIONS = 100;
+const CORE_FORMATS = ['block', 'break', 'cursor', 'inline', 'scroll', 'text'];
+
+const createRegistryWithFormats = (
+  formats: string[],
+  sourceRegistry: Registry,
+  logError: (errorMessage: string) => void,
+) => {
+  const registry = new Registry();
+  CORE_FORMATS.forEach((name) => {
+    const coreBlot = sourceRegistry.query(name);
+    if (coreBlot) registry.register(coreBlot);
+  });
+
+  formats.forEach((name) => {
+    let format = sourceRegistry.query(name);
+    if (!format) {
+      logError(
+        `Cannot register "${name}" specified in "formats" config. Are you sure it was registered?`,
+      );
+    }
+    let iterations = 0;
+    while (format) {
+      registry.register(format);
+      format = 'blotName' in format ? format.requiredContainer ?? null : null;
+
+      iterations += 1;
+      if (iterations > MAX_REGISTER_ITERATIONS) {
+        logError(`Maximum iterations reached when registering "${name}"`);
+        break;
+      }
+    }
+  });
+
+  return registry;
+};
+
+export default createRegistryWithFormats;

--- a/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
+++ b/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
@@ -1,0 +1,82 @@
+import '../../../../src/quill.js';
+import { describe, expect, test, vitest } from 'vitest';
+import createRegistryWithFormats from '../../../../src/core/utils/createRegistryWithFormats.js';
+import { globalRegistry } from '../../../../src/core/quill.js';
+import { Registry } from 'parchment';
+import Inline from '../../../../src/blots/inline.js';
+import Container from '../../../../src/blots/container.js';
+
+describe('createRegistryWithFormats', () => {
+  test('register core formats', () => {
+    const registry = createRegistryWithFormats([], globalRegistry, () => {});
+    expect(registry.query('cursor')).toBeTruthy();
+    expect(registry.query('bold')).toBeFalsy();
+  });
+
+  test('register specified formats', () => {
+    const registry = createRegistryWithFormats(
+      ['bold'],
+      globalRegistry,
+      () => {},
+    );
+    expect(registry.query('cursor')).toBeTruthy();
+    expect(registry.query('bold')).toBeTruthy();
+  });
+
+  test('register required container', () => {
+    const sourceRegistry = new Registry();
+
+    class RequiredContainer extends Container {
+      static blotName = 'my-required-container';
+    }
+    class Child extends Inline {
+      static requiredContainer = RequiredContainer;
+      static blotName = 'my-child';
+    }
+
+    sourceRegistry.register(Child);
+
+    const registry = createRegistryWithFormats(
+      ['my-child'],
+      sourceRegistry,
+      () => {},
+    );
+
+    expect(registry.query('my-child')).toBeTruthy();
+    expect(registry.query('my-required-container')).toBeTruthy();
+  });
+
+  test('infinite loop', () => {
+    const sourceRegistry = new Registry();
+
+    class InfiniteBlot extends Inline {
+      static requiredContainer = InfiniteBlot;
+      static blotName = 'infinite-blot';
+    }
+
+    sourceRegistry.register(InfiniteBlot);
+
+    const logError = vitest.fn();
+    const registry = createRegistryWithFormats(
+      ['infinite-blot'],
+      sourceRegistry,
+      logError,
+    );
+
+    expect(registry.query('infinite-blot')).toBeTruthy();
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringMatching('Maximum iterations reached'),
+    );
+  });
+
+  test('report missing formats', () => {
+    const logError = vitest.fn();
+    const registry = createRegistryWithFormats(
+      ['my-unknown'],
+      globalRegistry,
+      logError,
+    );
+    expect(registry.query('my-unknown')).toBeFalsy();
+    expect(logError).toHaveBeenCalledWith(expect.stringMatching('my-unknown'));
+  });
+});

--- a/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
+++ b/packages/quill/test/unit/core/utils/createRegistryWithFormats.spec.ts
@@ -2,23 +2,22 @@ import '../../../../src/quill.js';
 import { describe, expect, test, vitest } from 'vitest';
 import createRegistryWithFormats from '../../../../src/core/utils/createRegistryWithFormats.js';
 import { globalRegistry } from '../../../../src/core/quill.js';
+import logger from '../../../../src/core/logger.js';
 import { Registry } from 'parchment';
 import Inline from '../../../../src/blots/inline.js';
 import Container from '../../../../src/blots/container.js';
 
+const debug = logger('test');
+
 describe('createRegistryWithFormats', () => {
   test('register core formats', () => {
-    const registry = createRegistryWithFormats([], globalRegistry, () => {});
+    const registry = createRegistryWithFormats([], globalRegistry, debug);
     expect(registry.query('cursor')).toBeTruthy();
     expect(registry.query('bold')).toBeFalsy();
   });
 
   test('register specified formats', () => {
-    const registry = createRegistryWithFormats(
-      ['bold'],
-      globalRegistry,
-      () => {},
-    );
+    const registry = createRegistryWithFormats(['bold'], globalRegistry, debug);
     expect(registry.query('cursor')).toBeTruthy();
     expect(registry.query('bold')).toBeTruthy();
   });
@@ -39,7 +38,7 @@ describe('createRegistryWithFormats', () => {
     const registry = createRegistryWithFormats(
       ['my-child'],
       sourceRegistry,
-      () => {},
+      debug,
     );
 
     expect(registry.query('my-child')).toBeTruthy();
@@ -56,25 +55,25 @@ describe('createRegistryWithFormats', () => {
 
     sourceRegistry.register(InfiniteBlot);
 
-    const logError = vitest.fn();
+    const logError = vitest.spyOn(debug, 'error');
     const registry = createRegistryWithFormats(
       ['infinite-blot'],
       sourceRegistry,
-      logError,
+      debug,
     );
 
     expect(registry.query('infinite-blot')).toBeTruthy();
     expect(logError).toHaveBeenCalledWith(
-      expect.stringMatching('Maximum iterations reached'),
+      expect.stringMatching('Cycle detected'),
     );
   });
 
   test('report missing formats', () => {
-    const logError = vitest.fn();
+    const logError = vitest.spyOn(debug, 'error');
     const registry = createRegistryWithFormats(
       ['my-unknown'],
       globalRegistry,
-      logError,
+      debug,
     );
     expect(registry.query('my-unknown')).toBeFalsy();
     expect(logError).toHaveBeenCalledWith(expect.stringMatching('my-unknown'));

--- a/packages/website/content/docs/configuration.mdx
+++ b/packages/website/content/docs/configuration.mdx
@@ -104,3 +104,41 @@ quill.setContents(
 ### theme
 
 Name of theme to use. The builtin options are `"bubble"` or `"snow"`. An invalid or falsy value will load a default minimal theme. Note the theme's specific stylesheet still needs to be included manually. See [Themes](/docs/themes/) for more information.
+
+### formats
+
+Default: `null`
+
+A list of format names to whitelist. If not given, all formats are allowed.
+For advance usages, see [Registries](/docs/registries/).
+
+<Sandpack
+  defaultShowPreview
+  activeFile="index.js"
+  files={{
+    'index.html': `
+<!-- Include stylesheet -->
+<link href="{{site.cdn}}/quill.snow.css" rel="stylesheet" />
+<div id="editor">
+</div>
+<!-- Include the Quill library -->
+<script src="{{site.cdn}}/quill.js"></script>
+<script src="/index.js"></script>`,
+    "/index.js": `
+const Parchment = Quill.import('parchment');
+
+const quill = new Quill('#editor', {
+  formats: ['italic'],
+});
+
+const Delta = Quill.import('delta');
+quill.setContents(
+  new Delta()
+    .insert('Only ')
+    .insert('italic', { italic: true })
+    .insert(' is allowed. ')
+    .insert('Bold', { bold: true })
+    .insert(' is not.')
+);
+`}}
+/>

--- a/packages/website/content/docs/configuration.mdx
+++ b/packages/website/content/docs/configuration.mdx
@@ -54,6 +54,49 @@ Default: `warn`
 
 Shortcut for [debug](/docs/api/#debug). Note `debug` is a static method and will affect other instances of Quill editors on the page. Only warning and error messages are enabled by default.
 
+### formats
+
+Default: `null`
+
+A list of formats that are recognized and can exist within the editor contents.
+
+By default, all formats that are defined in the Quill library are allowed.
+To restrict formatting to a smaller list, pass in an array of the format names to support.
+
+You can create brand new formats or more fully customize the content using [Registries](/docs/registries/).
+Specifying a `registry` option will ignore this `formats` option.
+
+<Sandpack
+  defaultShowPreview
+  activeFile="index.js"
+  files={{
+    'index.html': `
+<!-- Include stylesheet -->
+<link href="{{site.cdn}}/quill.snow.css" rel="stylesheet" />
+<div id="editor">
+</div>
+<!-- Include the Quill library -->
+<script src="{{site.cdn}}/quill.js"></script>
+<script src="/index.js"></script>`,
+    "/index.js": `
+const Parchment = Quill.import('parchment');
+
+const quill = new Quill('#editor', {
+  formats: ['italic'],
+});
+
+const Delta = Quill.import('delta');
+quill.setContents(
+  new Delta()
+    .insert('Only ')
+    .insert('italic', { italic: true })
+    .insert(' is allowed. ')
+    .insert('Bold', { bold: true })
+    .insert(' is not.')
+);
+`}}
+/>
+
 ### placeholder
 
 Default: None
@@ -100,45 +143,12 @@ quill.setContents(
 `}}
 />
 
+### registry
+
+Default: `null`
+
+By default all formats defined by Quill are supported in the editor contents through a shared registry between editor instances. Use `formats` to restrict formatting for simple use cases and `registry` for greater customization. Specifying this `registry` option will ignore the `formatting` option. Learn more about [Registries](/docs/registries/).
 
 ### theme
 
 Name of theme to use. The builtin options are `"bubble"` or `"snow"`. An invalid or falsy value will load a default minimal theme. Note the theme's specific stylesheet still needs to be included manually. See [Themes](/docs/themes/) for more information.
-
-### formats
-
-Default: `null`
-
-A list of format names to whitelist. If not given, all formats are allowed.
-For advance usages, see [Registries](/docs/registries/).
-
-<Sandpack
-  defaultShowPreview
-  activeFile="index.js"
-  files={{
-    'index.html': `
-<!-- Include stylesheet -->
-<link href="{{site.cdn}}/quill.snow.css" rel="stylesheet" />
-<div id="editor">
-</div>
-<!-- Include the Quill library -->
-<script src="{{site.cdn}}/quill.js"></script>
-<script src="/index.js"></script>`,
-    "/index.js": `
-const Parchment = Quill.import('parchment');
-
-const quill = new Quill('#editor', {
-  formats: ['italic'],
-});
-
-const Delta = Quill.import('delta');
-quill.setContents(
-  new Delta()
-    .insert('Only ')
-    .insert('italic', { italic: true })
-    .insert(' is allowed. ')
-    .insert('Bold', { bold: true })
-    .insert(' is not.')
-);
-`}}
-/>


### PR DESCRIPTION
Achieve a similar purpose as `registry` option but it's easier to use. As in most cases users don't need to overload a format to have different implementations.