### PR TITLE
Include source maps for Parchment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased]
 
+- Include source maps for Parchment
+
 # 2.0.0-rc.3
 
 - Fix `Quill#getSemanticHTML()` for list items

--- a/package-lock.json
+++ b/package-lock.json
@@ -16553,6 +16553,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-5.0.0.tgz",
+      "integrity": "sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.72.1"
+      }
+    },
+    "node_modules/source-map-loader/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -19017,6 +19049,7 @@
         "jsdom": "^22.1.0",
         "mini-css-extract-plugin": "^2.7.6",
         "prettier": "^3.0.3",
+        "source-map-loader": "^5.0.0",
         "style-loader": "^3.3.3",
         "stylus": "^0.62.0",
         "stylus-loader": "^7.1.3",

--- a/packages/quill/package.json
+++ b/packages/quill/package.json
@@ -42,6 +42,7 @@
     "jsdom": "^22.1.0",
     "mini-css-extract-plugin": "^2.7.6",
     "prettier": "^3.0.3",
+    "source-map-loader": "^5.0.0",
     "style-loader": "^3.3.3",
     "stylus": "^0.62.0",
     "stylus-loader": "^7.1.3",

--- a/packages/quill/webpack.common.cjs
+++ b/packages/quill/webpack.common.cjs
@@ -9,6 +9,12 @@ const tsRules = {
   use: ['babel-loader'],
 };
 
+const sourceMapRules = {
+  test: /\.js$/,
+  enforce: 'pre',
+  use: ['source-map-loader'],
+};
+
 const svgRules = {
   test: /\.svg$/,
   include: [resolve(__dirname, 'src/assets/icons')],
@@ -53,7 +59,7 @@ module.exports = {
     },
   },
   module: {
-    rules: [tsRules, stylRules, svgRules],
+    rules: [tsRules, stylRules, svgRules, sourceMapRules],
   },
   plugins: [
     new MiniCssExtractPlugin({


### PR DESCRIPTION
Previously, source maps for libraries are not included in Quill's bundle.