### PR TITLE
Add support for v1 list attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased]
 
+- **Clipboard** Add support for Quill v1 list attributes
+
 # 2.0.0-rc.4
 
 - Include source maps for Parchment

--- a/packages/quill/src/modules/clipboard.ts
+++ b/packages/quill/src/modules/clipboard.ts
@@ -539,8 +539,14 @@ function matchIndent(node: Node, delta: Delta, scroll: ScrollBlot) {
 }
 
 function matchList(node: Node, delta: Delta, scroll: ScrollBlot) {
-  // @ts-expect-error
-  const list = node.tagName === 'OL' ? 'ordered' : 'bullet';
+  const element = node as Element;
+  let list = element.tagName === 'OL' ? 'ordered' : 'bullet';
+
+  const checkedAttr = element.getAttribute('data-checked');
+  if (checkedAttr) {
+    list = checkedAttr === 'true' ? 'checked' : 'unchecked';
+  }
+
   return applyFormat(delta, 'list', list, scroll);
 }
 


### PR DESCRIPTION
Quill v1 used `data-checked` attribute on the `ul` tag, whereas v2 has changed to `data-list` attribute on the `li` tags.

This change allows the matcher for list tags to recognize the v1 structure.  This will help in situations where any consumers have upgraded to Quill v2 and encounter HTML that was generated from Quill v1.