### PR TITLE
image selector fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # [Unreleased]
 
+- Prevent overriding of theme's default toolbar settings mistakenly [#4120](https://github.com/quilljs/quill/pull/4120)
+
 # 2.0.0
 
 We are thrilled to announce the release of Quill 2.0! Please check out the [announcement post](https://slab.com/blog/announcing-quill-2-0/).

--- a/packages/quill/test/unit/core/quill.spec.ts
+++ b/packages/quill/test/unit/core/quill.spec.ts
@@ -764,6 +764,21 @@ describe('Quill', () => {
       });
     });
 
+    test('toolbar container shorthand with theme options', () => {
+      const config = expandConfig(`#${testContainerId}`, {
+        modules: {
+          toolbar: document.querySelector(`#${testContainerId}`),
+        },
+        theme: 'snow',
+      });
+      for (const [format, handler] of Object.entries(
+        Snow.DEFAULTS.modules.toolbar!.handlers ?? {},
+      )) {
+        // @ts-expect-error
+        expect(config.modules.toolbar.handlers[format]).toBe(handler);
+      }
+    });
+
     test('toolbar format array', () => {
       const config = expandConfig(`#${testContainerId}`, {
         modules: {


### PR DESCRIPTION
Hi,

as we see on the v2 web site, theme toolbar's handlers (like image) are overwritten, and quill uses the default handler instead.
The fix :  quill.ts, "special case toolbar shortend" was called too late.
We can also see this difference in the code between v2.0 and v1.3.7


Thanks,

![2024-04-17_19h55_52](https://github.com/quilljs/quill/assets/17026569/c0908cbd-00a1-4246-b1c5-53b626b80ea1)
