### PR TITLE
Improve typings for methods that return a Delta

### DIFF
--- a/packages/quill/src/core/quill.ts
+++ b/packages/quill/src/core/quill.ts
@@ -334,7 +334,7 @@ class Quill {
     name: string,
     value: unknown,
     source: EmitterSource = Emitter.sources.API,
-  ) {
+  ): Delta {
     return modify.call(
       this,
       () => {
@@ -557,7 +557,7 @@ class Quill {
     embed: string,
     value: unknown,
     source: EmitterSource = Quill.sources.API,
-  ) {
+  ): Delta {
     return modify.call(
       this,
       () => {
@@ -647,7 +647,7 @@ class Quill {
     return this.emitter.once(...args);
   }
 
-  removeFormat(index: number, length: number, source?: EmitterSource) {
+  removeFormat(index: number, length: number, source?: EmitterSource): Delta {
     [index, length, , source] = overload(index, length, source);
     return modify.call(
       this,
@@ -688,7 +688,7 @@ class Quill {
   setContents(
     delta: Delta | Op[],
     source: EmitterSource = Emitter.sources.API,
-  ) {
+  ): Delta {
     return modify.call(
       this,
       () => {
@@ -741,7 +741,7 @@ class Quill {
   updateContents(
     delta: Delta | Op[],
     source: EmitterSource = Emitter.sources.API,
-  ) {
+  ): Delta {
     return modify.call(
       this,
       () => {

--- a/packages/quill/test/types/quill.test-d.ts
+++ b/packages/quill/test/types/quill.test-d.ts
@@ -30,8 +30,12 @@ const quill = new Quill('#editor');
 }
 
 {
-  quill.insertEmbed(10, 'image', 'https://example.com/logo.png');
-  quill.insertEmbed(10, 'image', 'https://example.com/logo.png', 'api');
+  assertType<Delta>(
+    quill.insertEmbed(10, 'image', 'https://example.com/logo.png'),
+  );
+  assertType<Delta>(
+    quill.insertEmbed(10, 'image', 'https://example.com/logo.png', 'api'),
+  );
 }
 
 {
@@ -74,22 +78,26 @@ const quill = new Quill('#editor');
 }
 
 {
-  quill.updateContents([{ insert: 'Hello World!' }]);
-  quill.updateContents([{ insert: 'Hello World!' }], 'api');
-  quill.updateContents(new Delta().insert('Hello World!'));
-  quill.updateContents(new Delta().insert('Hello World!'), 'api');
+  assertType<Delta>(quill.updateContents([{ insert: 'Hello World!' }]));
+  assertType<Delta>(quill.updateContents([{ insert: 'Hello World!' }], 'api'));
+  assertType<Delta>(quill.updateContents(new Delta().insert('Hello World!')));
+  assertType<Delta>(
+    quill.updateContents(new Delta().insert('Hello World!'), 'api'),
+  );
 }
 
 {
-  quill.setContents([{ insert: 'Hello World!\n' }]);
-  quill.setContents([{ insert: 'Hello World!\n' }], 'api');
-  quill.setContents(new Delta().insert('Hello World!\n'));
-  quill.setContents(new Delta().insert('Hello World!\n'), 'api');
+  assertType<Delta>(quill.setContents([{ insert: 'Hello World!\n' }]));
+  assertType<Delta>(quill.setContents([{ insert: 'Hello World!\n' }], 'api'));
+  assertType<Delta>(quill.setContents(new Delta().insert('Hello World!\n')));
+  assertType<Delta>(
+    quill.setContents(new Delta().insert('Hello World!\n'), 'api'),
+  );
 }
 
 {
-  quill.format('bold', true);
-  quill.format('bold', true, 'api');
+  assertType<Delta>(quill.format('bold', true));
+  assertType<Delta>(quill.format('bold', true, 'api'));
 }
 
 {
@@ -136,8 +144,8 @@ const quill = new Quill('#editor');
 }
 
 {
-  quill.removeFormat(3, 2);
-  quill.removeFormat(3, 2, 'user');
+  assertType<Delta>(quill.removeFormat(3, 2));
+  assertType<Delta>(quill.removeFormat(3, 2, 'user'));
 }
 
 {


### PR DESCRIPTION
my current quill version: `v2.0.0`.

as in v2, quill provides its own bundled dts file for developers, but some methods under the `Quill` scope are incorrectly typed due to `Function.call()` will returns an `any` type.

e.g., `quill.updateContents()`, its return type should be `Delta`, but in quill.d.ts, the signature is

```typescript
declare class Quill {
  updateContents(delta: Delta | Op[], source?: EmitterSource): any;
}
```

this pr solves the problem by explicitly declaring the return type, and improve dts type tests