### PR TITLE
fix: rgb color doesn't change in toolbar

### DIFF
--- a/packages/quill/src/formats/background.ts
+++ b/packages/quill/src/formats/background.ts
@@ -1,10 +1,9 @@
-import { ClassAttributor, Scope } from 'parchment';
-import { ColorAttributor } from './color.js';
+import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
 
 const BackgroundClass = new ClassAttributor('background', 'ql-bg', {
   scope: Scope.INLINE,
 });
-const BackgroundStyle = new ColorAttributor('background', 'background-color', {
+const BackgroundStyle = new StyleAttributor('background', 'background-color', {
   scope: Scope.INLINE,
 });
 

--- a/packages/quill/src/formats/color.ts
+++ b/packages/quill/src/formats/color.ts
@@ -1,23 +1,10 @@
 import { ClassAttributor, Scope, StyleAttributor } from 'parchment';
 
-class ColorAttributor extends StyleAttributor {
-  value(domNode: HTMLElement) {
-    let value = super.value(domNode) as string;
-    if (!value.startsWith('rgb(')) return value;
-    value = value.replace(/^[^\d]+/, '').replace(/[^\d]+$/, '');
-    const hex = value
-      .split(',')
-      .map((component) => `00${parseInt(component, 10).toString(16)}`.slice(-2))
-      .join('');
-    return `#${hex}`;
-  }
-}
-
 const ColorClass = new ClassAttributor('color', 'ql-color', {
   scope: Scope.INLINE,
 });
-const ColorStyle = new ColorAttributor('color', 'color', {
+const ColorStyle = new StyleAttributor('color', 'color', {
   scope: Scope.INLINE,
 });
 
-export { ColorAttributor, ColorClass, ColorStyle };
+export { ColorClass, ColorStyle };


### PR DESCRIPTION
I found that the color of the corresponding icon in the toolbar does not change with the RGB color, and I did not find any places where the hex color value must be used. I think this is a bug