### PR TITLE
Respond to `/docs` route and do redirection

### DIFF
--- a/packages/website/src/pages/docs.jsx
+++ b/packages/website/src/pages/docs.jsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import docs from '../data/docs';
+
+const Docs = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace(docs[0].url);
+  }, [router]);
+
+  return null;
+};
+
+export default Docs;


### PR DESCRIPTION
closes #4173 

This PR adds a `docs.jsx` component under `packages/website/src/pages` to match the `/docs` route and then redirects to the first URL provided by `packages/website/src/data/docs.tsx` , the same way as `packages/website/src/pages/playgroud.jsx` does